### PR TITLE
chore: release tbd-git v0.1.6

### DIFF
--- a/.changeset/release-0.1.5.md
+++ b/.changeset/release-0.1.5.md
@@ -1,5 +1,0 @@
----
-"tbd-git": patch
----
-
-Agent orientation system, DocCache with shortcuts, and documentation improvements.

--- a/.changeset/release-0.1.6.md
+++ b/.changeset/release-0.1.6.md
@@ -1,5 +1,0 @@
----
-"tbd-git": patch
----
-
-Spec linking feature with `--spec` options for create/list commands, configurable doc cache with auto-sync, and various bug fixes.

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -1,5 +1,14 @@
 # tbd-git
 
+## 0.1.6
+
+### Patch Changes
+
+- afc01dd: Agent orientation system, DocCache with shortcuts, and documentation
+  improvements.
+- cc830b5: Spec linking feature with `--spec` options for create/list commands,
+  configurable doc cache with auto-sync, and various bug fixes.
+
 ## 0.1.5
 
 ### Patch Changes

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tbd-git",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Git-native issue tracking for AI agents and humans",
   "license": "MIT",
   "author": "Joshua Levy <joshua@cal.berkeley.edu> (https://github.com/jlevy)",

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,37 +2,38 @@
 
 ### Features
 
-- **Agent orientation system**: Complete implementation of `tbd prime` for agent
-  self-orientation with dynamic status output
-- **Update command options**: Added `--title` and `--from-file` options for `tbd update`
-- **DocCache and shortcuts**: New shortcut system for quick access to guidelines and
-  templates via `tbd shortcut`
-- **Separate doc commands**: Guidelines and templates exposed as top-level
-  `tbd guideline` and `tbd template` commands
-- **Agent instruction headers**: Doc output now includes agent instruction headers
-- **gitignore-utils library**: Idempotent .gitignore editing for setup commands
+- **Spec linking**: New `spec_path` field to associate beads with specification
+  documents
+- **Create with spec**: `tbd create --spec path/to/spec.md` links beads to specs at
+  creation
+- **List by spec**: `tbd list --spec path/to/spec.md` filters beads by associated spec
+- **Configurable doc cache**: New `docs_cache` config for controlling doc sync behavior
+- **Auto-sync verbosity**: Doc auto-sync now respects CLI verbosity settings
+- **Incremental build**: Pre-push hook uses incremental build for faster development
+- **Global install script**: New `ensure-tbd-cli.sh` script for reliable tbd
+  installation
 
 ### Fixes
 
-- Fixed generated SKILL.md and AGENTS.md to be flowmark-compatible
-- Fixed DO NOT EDIT marker placement after YAML frontmatter
-- Fixed `--status closed` filter to properly return closed issues
-- Fixed prefix auto-detection removed, now requires explicit `--prefix` flag
-- Fixed tryscript tests for new command options and version patterns
-- Fixed CLI tests for Windows compatibility and environment-independent matching
+- Fixed shortcut name from `new-research-doc` to `new-research-brief`
+- Fixed project-paths test for Windows cross-platform CI
+- Fixed race condition in legacy cleanup on macOS
+- Fixed macOS symlink path resolution using realpath in tests
+- Fixed legacy cleanup moved to SetupAutoHandler for CI reliability
+- Fixed SKILL.md generation for flowmark-compatible formatting
+- Fixed format version from 0.2.0 to 0.1.5 in f02 spec
 
 ### Refactoring
 
-- Removed Cursor rules in favor of AGENTS.md
-- Consolidated shortcut naming to use “beads” consistently
-- Removed legacy commands for clean upgrade path
-- Streamlined init/setup design with unified entry point
+- Simplified markdown-utils with single `parseMarkdown` function
+- Consolidated doc_cache and docs config into unified `docs_cache`
+- Streamlined global scripts and removed legacy redirect
+- Consolidated tbd session script to ensure PATH persists
 
 ### Documentation
 
-- Added research on skills vs meta-skill architecture
-- Enhanced README with agent orientation and self-documenting CLI guidance
-- Added comprehensive relationship types documentation (§2.7)
-- Added typescript-cli-tool-rules guideline
+- Comprehensive revision of CLI as Agent Skill research
+- Reorganized and improved Quick Reference tables
+- Added dependency and status update examples
 
-**Full commit history**: https://github.com/jlevy/tbd/compare/v0.1.4...v0.1.5
+**Full commit history**: https://github.com/jlevy/tbd/compare/v0.1.5...v0.1.6


### PR DESCRIPTION
## What’s Changed

### Features

- **Spec linking**: New `spec_path` field to associate beads with specification
  documents
- **Create with spec**: `tbd create --spec path/to/spec.md` links beads to specs at
  creation
- **List by spec**: `tbd list --spec path/to/spec.md` filters beads by associated spec
- **Configurable doc cache**: New `docs_cache` config for controlling doc sync behavior
- **Auto-sync verbosity**: Doc auto-sync now respects CLI verbosity settings
- **Incremental build**: Pre-push hook uses incremental build for faster development
- **Global install script**: New `ensure-tbd-cli.sh` script for reliable tbd
  installation

### Fixes

- Fixed shortcut name from `new-research-doc` to `new-research-brief`
- Fixed project-paths test for Windows cross-platform CI
- Fixed race condition in legacy cleanup on macOS
- Fixed macOS symlink path resolution using realpath in tests
- Fixed legacy cleanup moved to SetupAutoHandler for CI reliability
- Fixed SKILL.md generation for flowmark-compatible formatting
- Fixed format version from 0.2.0 to 0.1.5 in f02 spec

### Refactoring

- Simplified markdown-utils with single `parseMarkdown` function
- Consolidated doc_cache and docs config into unified `docs_cache`
- Streamlined global scripts and removed legacy redirect
- Consolidated tbd session script to ensure PATH persists

### Documentation

- Comprehensive revision of CLI as Agent Skill research
- Reorganized and improved Quick Reference tables
- Added dependency and status update examples

**Full commit history**: https://github.com/jlevy/tbd/compare/v0.1.5...v0.1.6
