### PR TITLE
chore: release v0.1.7

### DIFF
--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -1,5 +1,12 @@
 # tbd-git
 
+## 0.1.7
+
+### Patch Changes
+
+- Inherit spec_path from parent beads, automatic gh CLI setup via SessionStart hook, and
+  various bug fixes
+
 ## 0.1.6
 
 ### Patch Changes

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tbd-git",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Git-native issue tracking for AI agents and humans",
   "license": "MIT",
   "author": "Joshua Levy <joshua@cal.berkeley.edu> (https://github.com/jlevy)",


### PR DESCRIPTION
## Summary
- Bump tbd-git from v0.1.6 to v0.1.7 (patch release)
- Includes: spec_path inheritance from parent beads, automatic gh CLI setup via SessionStart hook, and various bug fixes

## Test plan
- [x] All 667 tests pass
- [x] Build succeeds

https://claude.ai/code/session_012gm2WqiMQye9YcfE1DixE7