### PR TITLE
chore: release get-tbd v0.1.9

### DIFF
--- a/.changeset/worktree-robustness.md
+++ b/.changeset/worktree-robustness.md
@@ -1,5 +1,0 @@
----
-"get-tbd": patch
----
-
-Worktree robustness improvements, setup bug fixes, and documentation updates. Key changes include automatic worktree detection and repair, graceful handling of already-migrated data, bypassing parent repo hooks in worktree commits, improved .gitignore management on upgrade, and simplified agent integration documentation.

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -1,5 +1,14 @@
 # get-tbd
 
+## 0.1.9
+
+### Patch Changes
+
+- 2809883: Worktree robustness improvements, setup bug fixes, and documentation updates.
+  Key changes include automatic worktree detection and repair, graceful handling of
+  already-migrated data, bypassing parent repo hooks in worktree commits, improved
+  .gitignore management on upgrade, and simplified agent integration documentation.
+
 ## 0.1.8
 
 ### Patch Changes

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-tbd",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Git-native issue tracking for AI agents and humans",
   "license": "MIT",
   "author": "Joshua Levy <joshua@cal.berkeley.edu> (https://github.com/jlevy)",


### PR DESCRIPTION
## Summary

- Worktree robustness improvements with automatic detection and repair for various failure modes
- Setup improvements: better `.gitignore` management and upgrade handling
- Build fix for tsdown 0.20+ compatibility
- Documentation updates: simplified agent integration docs (SKILL.md + AGENTS.md)

## Test plan

- [x] Existing tests pass
- [x] CHANGELOG.md and package.json version updated correctly
- [ ] Automated release workflow will run on tag push

https://claude.ai/code/session_014uVEC82gC9cACPzijH5G51
