### PR TITLE
chore: release get-tbd v0.1.10

### DIFF
--- a/.changeset/fix-detached-head-worktree.md
+++ b/.changeset/fix-detached-head-worktree.md
@@ -1,7 +1,0 @@
----
-"get-tbd": patch
----
-
-Fix detached HEAD worktree handling for users upgrading from older tbd versions.
-Auto-repairs worktrees that were created before the detached HEAD improvement,
-ensuring sync operations preserve the working directory correctly.

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -1,5 +1,13 @@
 # get-tbd
 
+## 0.1.10
+
+### Patch Changes
+
+- c2cff07: Fix detached HEAD worktree handling for users upgrading from older tbd
+  versions. Auto-repairs worktrees that were created before the detached HEAD
+  improvement, ensuring sync operations preserve the working directory correctly.
+
 ## 0.1.9
 
 ### Patch Changes

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-tbd",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Git-native issue tracking for AI agents and humans",
   "license": "MIT",
   "author": "Joshua Levy <joshua@cal.berkeley.edu> (https://github.com/jlevy)",


### PR DESCRIPTION
## Summary

- Fix detached HEAD worktree handling for users upgrading from older tbd versions
- Auto-repairs worktrees created before the detached HEAD improvement
- Ensures sync operations preserve the working directory correctly

## Test plan

- [x] Run `pnpm test` to ensure all tests pass
- [x] Verify worktree repair on upgrade from older versions
- [ ] Validate release build with `pnpm build`

https://claude.ai/code/session_01DC4xxR1iyZ8M96dd1bPAF7
