### PR TITLE
chore: release get-tbd v0.1.12

### DIFF
--- a/.changeset/release-v0112.md
+++ b/.changeset/release-v0112.md
@@ -1,5 +1,0 @@
----
-"get-tbd": patch
----
-
-Bug fixes for sync reliability, stats output redesign, and documentation improvements.

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -1,5 +1,12 @@
 # get-tbd
 
+## 0.1.12
+
+### Patch Changes
+
+- 1509909: Bug fixes for sync reliability, stats output redesign, and documentation
+  improvements.
+
 ## 0.1.11
 
 ### Patch Changes

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-tbd",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Git-native issue tracking for AI agents and humans",
   "license": "MIT",
   "author": "Joshua Levy <joshua@cal.berkeley.edu> (https://github.com/jlevy)",


### PR DESCRIPTION
## Summary

- Improved sync reliability with proper push failure reporting
- Redesigned stats output with status icons and better organization
- Added human-readable doc sizes and token counts to list commands
- Extensive documentation improvements

## Bug Fixes

- **Sync reliability**: Fixed silent failures - sync now properly reports push failures instead of incorrectly showing "Already in sync"
- **Fresh clone support**: Auto-create worktree on fresh clones without requiring `--fix` flag

## Features

- **Stats redesign**: New stats output with status icons, active/closed breakdown, and aligned columns
- **Doc metrics**: Human-readable document sizes and token counts in list commands

## Documentation

- Expanded sync outbox spec with write-through design
- Consolidated multi-agent research documentation
- Added Python modern guidelines combining python-rules with opinionated best practices
- Standardized beads terminology across all shortcuts
- Added error-handling-rules guideline
- Updated install instructions

https://claude.ai/code/session_01CRej17x1gbUH8ycekUyuNC
