### PR TITLE
feat: isolate sync branches across linked worktrees

### DIFF
--- a/docs/project/specs/active/plan-2026-02-25-multi-worktree-sync-branch-isolation.md
+++ b/docs/project/specs/active/plan-2026-02-25-multi-worktree-sync-branch-isolation.md
@@ -1,0 +1,684 @@
+---
+title: Multi-Worktree Sync Branch Isolation
+description: Preserve current tbd sync workflows while supporting linked worktree AI environments
+author: Codex with Joshua Levy guidance
+---
+# Feature: Multi-Worktree Sync Branch Isolation
+
+**Date:** 2026-02-25 (last updated 2026-02-26)
+
+**Author:** Codex with Joshua Levy guidance
+
+**Status:** Draft
+
+## Overview
+
+tbd sync works well in standard single-checkout repositories, where
+`.tbd/data-sync-worktree/` can safely check out local branch `tbd-sync`.
+
+In AI workflows using many linked checkouts (for example Codex sessions), each checkout
+attempts to create an inner sync worktree on the same local branch.
+Git forbids checking out one local branch in multiple worktrees, causing branch-lock
+conflicts.
+
+This spec proposes a minimal-change design that preserves existing sync architecture and
+workflows:
+
+- Keep one canonical remote sync branch: `origin/tbd-sync`
+- Keep one inner sync worktree per outer checkout
+- Use unique local sync branches per checkout when needed (for example
+  `tbd-sync--wt-<id>`)
+- Push local per-checkout branch to canonical remote branch with explicit refspec
+
+The design goal is seamless behavior in both single-checkout and multi-checkout
+environments without replacing the existing worktree model.
+
+## Goals
+
+- Preserve current tbd sync workflows, data model, and user-facing command behavior
+- Support multiple linked outer checkouts under one shared git common dir without
+  branch-lock conflicts
+- Keep fast file-based issue access via per-checkout hidden sync worktree
+- Maintain canonical remote branch contract (`origin/tbd-sync`) for interoperability
+  across machines
+- Avoid silent fallback writes to `.tbd/data-sync/` on main branch in production paths
+- Provide robust repair and cleanup behavior for stale per-worktree local sync branches
+
+## Non-Goals
+
+- Replacing worktree-based storage with a new storage architecture
+- Introducing symlink-based inner worktree sharing
+- Changing synced issue file format, mappings format, attic format, or CLI issue
+  semantics
+- Renaming canonical remote sync branch away from `tbd-sync`
+- Building full real-time locking or daemon-based coordination
+
+## Background
+
+Current architecture (working well today):
+
+- Main branch tracks `.tbd/config.yml`, `.tbd/.gitignore`, `.tbd/.gitattributes`,
+  `.tbd/workspaces/`
+- `tbd-sync` branch tracks `.tbd/data-sync/` (issues, mappings, attic, meta)
+- Hidden inner worktree at `.tbd/data-sync-worktree/` gives direct file access and
+  search
+- `tbd sync` commits local worktree changes, merges remote, and pushes with
+  retry/recovery
+
+Why conflicts happen in linked worktree environments:
+
+- Linked outer checkouts share one git repository metadata directory (`.git` common dir)
+- Each outer checkout tries to create/attach its own inner worktree on local branch
+  `tbd-sync`
+- Git branch checkout rules prevent one local branch from being simultaneously checked
+  out in multiple worktrees
+- Result: setup/sync errors, non-seamless behavior in AI session workflows
+
+Relevant constraints:
+
+- Need to preserve current outbox, attic, merge, and recovery semantics
+- Need to preserve simple UX and avoid introducing large migration risk
+- Need to support outer checkout churn (creation/deletion/path changes) in AI systems
+
+## Backward Compatibility
+
+**BACKWARD COMPATIBILITY REQUIREMENTS:**
+
+Release policy for this work: prioritize a clean design over preserving legacy internal
+abstractions.
+
+- **Code types, methods, and function signatures**: DO NOT MAINTAIN deprecated internal
+  TypeScript APIs. This is a CLI application and we can refactor internal signatures
+  without preserving deprecated shims.
+
+- **Library APIs**: DO NOT MAINTAIN (no deprecated compatibility layer needed; tbd is
+  CLI-first and does not expose a stable SDK contract for this feature).
+
+- **Server APIs**: N/A.
+
+- **File formats**: SUPPORT BOTH. Existing `.tbd` structures and sync-branch file
+  formats remain unchanged.
+  Repositories currently using local `tbd-sync` should continue working without
+  migration. This compatibility applies only to persisted data formats, not to internal
+  code paths.
+
+- **Database schemas**: N/A.
+
+CLI compatibility note:
+
+- CLI should operate the same way for users.
+  No intentional breaking CLI command or flag changes are included in this design.
+
+## Design
+
+### Approach
+
+Use split branch roles:
+
+- **Remote canonical sync branch**: `tbd-sync` (shared contract across all environments)
+- **Local sync branch** (per outer checkout): one branch per checkout when needed
+
+Key behavior:
+
+1. On sync/worktree init, select local sync branch for this outer checkout
+2. If plain local `tbd-sync` is available and not checked out elsewhere, use it
+3. Otherwise allocate/reuse a per-checkout local branch like `tbd-sync--wt-<id>`
+4. Inner worktree checks out the selected local sync branch
+5. Pull/merge reads from `origin/tbd-sync`
+6. Push uses explicit refspec: `refs/heads/<localSyncBranch>:refs/heads/tbd-sync`
+
+This avoids branch checkout conflicts while preserving canonical remote behavior.
+
+### Option Analysis
+
+| Option | Summary | Pros | Cons | Decision |
+| --- | --- | --- | --- | --- |
+| A | Detached inner worktree (no local branch) | Avoids branch lock conflicts | Higher debug complexity; status semantics less intuitive | Rejected for now |
+| B | One shared inner worktree in git common dir | Simple branch model | Shared unsynced state across outer checkouts; lock complexity | Rejected |
+| C | Ephemeral sync worktree only during sync | No persistent conflicts | Larger behavioral change; weak direct-file UX | Rejected |
+| D | Per-checkout local sync branches | Minimal architecture change; preserves workflow | Extra local branch lifecycle cleanup | **Chosen** |
+
+### Branch Naming and Identity
+
+Local sync branch resolution (deterministic for each outer checkout):
+
+1. If local state already has `local_sync_branch`, validate and reuse it when possible
+2. Else attempt canonical local sync branch (`config.sync.branch`, usually `tbd-sync`)
+   if not checked out elsewhere
+3. Else derive a managed branch from the canonical branch and an outer-checkout
+   fingerprint
+4. Persist selected branch in local state (`.tbd/state.yml`)
+
+Important properties:
+
+- Stable per outer checkout
+- Collision-resistant
+- Human-debuggable naming
+- Does not require config changes for normal users
+
+Managed branch naming:
+
+- Canonical remote branch (unchanged): `config.sync.branch` (default `tbd-sync`)
+- Local managed branch pattern: `<remoteBranch>--wt-<fingerprint>`
+- Example: `tbd-sync--wt-a1b2c3d4`
+- Fingerprint source: normalized absolute outer checkout path
+- Fingerprint length: fixed short hex (8 chars)
+- Collision fallback: append `-2`, `-3`, ... if branch already exists and is checked out
+  by another worktree
+
+Branch naming safety and stability rules:
+
+- Branch names remain valid under existing `GitBranchName` constraints
+  (`[a-zA-Z0-9._/-]+`), so no schema change is required
+- Managed suffix is always appended to the canonical remote branch string, preserving
+  human context when custom sync branches are used
+- If canonical branch name is near Git’s max ref length, truncate prefix before adding
+  `--wt-<fingerprint>` so managed names always stay within branch-name limits
+- Fingerprint input uses normalized real path for stability across `.`/`..` or symlink
+  entry paths to the same checkout
+- Resolver never rewrites existing user-managed branch names; it only picks canonical or
+  managed names for tbd-owned worktrees
+
+### Current Couplings to Resolve
+
+Current code assumes one shared local branch name:
+
+- `packages/tbd/src/cli/commands/sync.ts` uses one `syncBranch` from config for all
+  local and remote operations
+- `packages/tbd/src/file/git.ts` hardcodes `SYNC_BRANCH` in `ensureWorktreeAttached()`
+- `pushWithRetry()` assumes local branch name equals remote branch name in refspec
+- `doctor.ts` health checks compare only one branch name for local and remote
+- `status.ts` only reports one branch field (`sync_branch`)
+
+Those assumptions are the exact conflict source in linked-worktree environments and must
+be separated into:
+
+- `remoteSyncBranch` (canonical, shared) and
+- `localSyncBranch` (per outer checkout).
+
+### Branch Resolver Algorithm (Function-Level)
+
+Resolver behavior must be deterministic and side-effect controlled.
+
+Selection and creation are separated:
+
+- `resolveSyncBranchRefs()` selects branch refs and persists local state only when
+  `forWrite=true`
+- `initWorktree()` / repair paths are responsible for branch creation/checkout
+
+Decision order in `resolveSyncBranchRefs(baseDir, config, { forWrite })`:
+
+1. Read `remoteName` + `remoteSyncBranch` from config
+2. Read `.tbd/state.yml` and current `local_sync_branch` (if present)
+3. Inspect current worktree occupancy via `git worktree list --porcelain`
+4. Reuse state branch if it exists and is not checked out by another worktree
+5. Else use canonical local branch (`remoteSyncBranch`) if not occupied elsewhere
+6. Else choose deterministic managed branch name from checkout path fingerprint
+7. If `forWrite=true`, persist selected branch to `local_sync_branch`
+
+Read-only behavior:
+
+- `forWrite=false` (status/doctor read checks) must not mutate `state.yml`
+- If no usable branch is found in read mode, return canonical as informational value and
+  report source as `canonical`
+
+### Detailed File-Level Change Plan
+
+#### 1) New Branch-Resolver Module
+
+File: `packages/tbd/src/file/sync-branch.ts` (new)
+
+Purpose:
+
+- Centralize branch-ref resolution
+- Keep branch decision logic out of command handlers
+
+Proposed exports:
+
+```ts
+export interface SyncBranchRefs {
+  remoteName: string;        // config.sync.remote
+  remoteSyncBranch: string;  // canonical shared branch (config.sync.branch)
+  localSyncBranch: string;   // per-checkout local branch
+  source: 'state' | 'canonical' | 'managed';
+}
+
+export interface ResolveSyncBranchRefsOptions {
+  forWrite?: boolean;
+}
+
+export async function resolveSyncBranchRefs(
+  baseDir: string,
+  config: Config,
+  options?: ResolveSyncBranchRefsOptions,
+): Promise<SyncBranchRefs>;
+
+export function makeManagedLocalBranchName(
+  remoteSyncBranch: string,
+  checkoutPath: string,
+): string;
+
+export function isManagedLocalBranch(
+  localBranch: string,
+  remoteSyncBranch: string,
+): boolean;
+
+export async function listManagedLocalBranches(
+  baseDir: string,
+  remoteSyncBranch: string,
+): Promise<string[]>;
+```
+
+#### 2) Local State Schema and Persistence
+
+Files:
+
+- `packages/tbd/src/lib/schemas.ts`
+- `packages/tbd/src/file/config.ts`
+- `packages/tbd/src/lib/types.ts` (type inference impact only; no manual interface
+  needed)
+
+Changes:
+
+- Add optional local state field:
+  - `local_sync_branch: GitBranchName.optional()`
+- Update `LOCAL_STATE_FIELD_ORDER` to include `local_sync_branch` before `welcome_seen`
+- Keep `state.yml` backward-compatible (optional field, permissive parse)
+
+#### 3) Git Helpers (Worktree and Branch Plumbing)
+
+File: `packages/tbd/src/file/git.ts`
+
+Function signature updates:
+
+```ts
+initWorktree(
+  baseDir: string,
+  remote = 'origin',
+  remoteSyncBranch = SYNC_BRANCH,
+  localSyncBranch = remoteSyncBranch,
+): Promise<{ success: boolean; path?: string; created?: boolean; error?: string }>;
+
+updateWorktree(
+  baseDir: string,
+  remote = 'origin',
+  remoteSyncBranch = SYNC_BRANCH,
+  localSyncBranch = remoteSyncBranch,
+): Promise<{ success: boolean; error?: string }>;
+
+repairWorktree(
+  baseDir: string,
+  status: 'missing' | 'prunable' | 'corrupted',
+  remote = 'origin',
+  remoteSyncBranch = SYNC_BRANCH,
+  localSyncBranch = remoteSyncBranch,
+): Promise<{ success: boolean; path?: string; backedUp?: string; error?: string }>;
+
+ensureWorktreeAttached(
+  worktreePath: string,
+  expectedLocalBranch: string,
+): Promise<boolean>;
+
+pushWithRetry(
+  localSyncBranch: string,
+  remoteName: string,
+  remoteSyncBranch: string,
+  onMergeNeeded: () => Promise<ConflictEntry[]>,
+  baseDir?: string,
+): Promise<PushResult>;
+
+checkRemoteBranchHealth(
+  remoteName = 'origin',
+  remoteSyncBranch = SYNC_BRANCH,
+  localSyncBranch = remoteSyncBranch,
+): Promise<RemoteBranchHealth>;
+
+checkSyncConsistency(
+  baseDir: string,
+  localSyncBranch = SYNC_BRANCH,
+  remoteName = 'origin',
+  remoteSyncBranch = localSyncBranch,
+): Promise<SyncConsistency>;
+```
+
+New helpers (same file):
+
+- `listWorktreeBranchRefs(baseDir)` from `git worktree list --porcelain`
+- `isBranchCheckedOutInOtherWorktree(baseDir, branch, currentWorktreePath?)`
+
+Behavior requirements:
+
+- `initWorktree()` checks/creates `localSyncBranch` while fetching from
+  `${remote}/${remoteSyncBranch}`
+- First-time creation rules:
+  - remote exists:
+    `worktree add -b <localSyncBranch> <path> <remote>/<remoteSyncBranch>`
+  - remote missing but local exists: `worktree add <path> <localSyncBranch>`
+  - neither exists: orphan-init `localSyncBranch`
+- `pushWithRetry()` uses explicit split refspec:
+  - `refs/heads/<localSyncBranch>:refs/heads/<remoteSyncBranch>`
+- `migrateDataToWorktree()` updates to
+  `ensureWorktreeAttached(worktreePath, expectedLocalBranch)` call path
+
+#### 4) Sync Command Integration
+
+File: `packages/tbd/src/cli/commands/sync.ts`
+
+Structural updates:
+
+- Add cached refs field in handler:
+  - `private syncRefs: SyncBranchRefs | null = null`
+- In `run()`:
+  - load config immediately after `requireInit()`
+  - resolve refs once via `resolveSyncBranchRefs(tbdRoot, config, { forWrite: true })`
+  - pass refs into all health-repair and sync paths
+
+Method-level signature updates:
+
+```ts
+private async showIssueStatus(refs: SyncBranchRefs): Promise<void>;
+private async getSyncStatus(refs: SyncBranchRefs): Promise<SyncStatus>;
+private async pullChanges(refs: SyncBranchRefs): Promise<void>;
+private async pushChanges(refs: SyncBranchRefs): Promise<void>;
+private async doPushWithRetry(refs: SyncBranchRefs): Promise<PushResult>;
+private async fullSync(
+  refs: SyncBranchRefs,
+  options: { force?: boolean; autoSave?: boolean; outbox?: boolean },
+): Promise<void>;
+private async maybeImportOutbox(refs: SyncBranchRefs): Promise<void>;
+```
+
+`SyncStatus` update:
+
+- keep existing fields
+- add `localSyncBranch` and `remoteSyncBranch` for JSON/debug clarity
+
+Command behavior updates:
+
+- `doRepairWorktree()` calls
+  `repairWorktree(..., refs.remoteName, refs.remoteSyncBranch, refs.localSyncBranch)`
+- `commitWorktreeChanges()` calls
+  `ensureWorktreeAttached(worktreePath, refs.localSyncBranch)`
+- All `fetch`, `rev-list`, `log`, and `git show` operations use:
+  - local side: `refs.localSyncBranch`
+  - remote side: `${refs.remoteName}/${refs.remoteSyncBranch}`
+- User-facing text remains canonical-first (show remote sync branch as primary)
+
+#### 5) Doctor Command Integration
+
+File: `packages/tbd/src/cli/commands/doctor.ts`
+
+Structural updates:
+
+- Add cached refs field:
+  - `private syncRefs: SyncBranchRefs | null = null`
+- Resolve refs once after config load:
+  - read checks: `forWrite=false`
+  - fix path (`--fix`): `forWrite=true`
+
+Function-level updates:
+
+- `checkWorktree()` repair call threads split refs into `repairWorktree(...)`
+- `checkDataLocation()` fix path `initWorktree(...)` call threads split refs
+- `checkLocalSyncBranch()` targets `refs.localSyncBranch`
+- `checkRemoteSyncBranch()` calls
+  `checkRemoteBranchHealth(refs.remoteName, refs.remoteSyncBranch, refs.localSyncBranch)`
+- `checkSyncConsistency()` calls
+  `checkSyncConsistency(this.cwd, refs.localSyncBranch, refs.remoteName, refs.remoteSyncBranch)`
+
+New diagnostics/fixes:
+
+- state says branch X but X missing locally
+- state branch occupied by another worktree
+- inner worktree attached to wrong branch
+- optional `--fix`: prune stale managed branches (never current branch, never checked
+  out)
+
+#### 6) Status Command and Shared Section Rendering
+
+Files:
+
+- `packages/tbd/src/cli/commands/status.ts`
+- `packages/tbd/src/cli/lib/sections.ts`
+
+Changes:
+
+- `StatusData` adds `local_sync_branch: string | null`
+- `loadPostInitInfo()` resolves refs in read mode and sets:
+  - `sync_branch = remoteSyncBranch`
+  - `local_sync_branch = localSyncBranch`
+- `ConfigSectionData` extends with optional `localSyncBranch`
+- text render rule:
+  - always show `Sync branch: <remoteSyncBranch>`
+  - show `Local sync branch: <localSyncBranch>` only when different
+- JSON output includes both fields so automation/agents can diagnose conflicts
+
+#### 7) Init and Setup Paths
+
+Files:
+
+- `packages/tbd/src/cli/commands/init.ts`
+- `packages/tbd/src/cli/commands/setup.ts`
+
+`init.ts` updates:
+
+- After config creation, read config and resolve refs with `forWrite=true`
+- Pass resolved refs to `initWorktree(...)`
+- If `--sync-branch` / `--remote` are provided, write those values to config before
+  resolving refs (preserves current CLI intent)
+
+`setup.ts` updates (`initializeTbd()`):
+
+- After `initConfig(...)`, read config and resolve refs with `forWrite=true`
+- Call `initWorktree(cwd, refs.remoteName, refs.remoteSyncBranch, refs.localSyncBranch)`
+
+#### 8) Uninstall Consistency
+
+File: `packages/tbd/src/cli/commands/uninstall.ts`
+
+Changes:
+
+- Resolve refs in read mode for branch discovery
+- Collect removable local branches:
+  - canonical local branch (if present)
+  - managed local branches matching `<remoteSyncBranch>--wt-*`
+- `--keep-branch` preserves all local sync branches
+- deletion safety:
+  - never delete branch currently checked out in any worktree
+  - show warnings for skipped branches
+- remote deletion remains scoped to canonical remote branch and `--remove-remote`
+
+### Scope Clarification: Path Fallback Hardening
+
+This spec keeps focus on branch/worktree conflict resolution.
+
+- `resolveDataSyncDir()` global fallback semantics are **not** changed as part of this
+  rollout.
+- Existing sync/doctor worktree health protections remain in place.
+- Any repo-wide strict-path hardening will be a separate follow-up spec to avoid
+  accidental behavior changes in unrelated commands.
+
+### API Changes
+
+User-facing CLI flags:
+
+- No required new flags for baseline behavior
+- Existing `tbd sync` behavior remains unchanged from user perspective
+
+Internal contract changes:
+
+- Sync internals distinguish `localSyncBranch` from `remoteSyncBranch`
+- Push/pull code paths no longer assume local and remote branch names are identical
+
+Internal data model additions:
+
+- `.tbd/state.yml`
+  - `local_sync_branch?: string`
+
+### Corner Cases and Expected Behavior
+
+| Scenario | Expected Behavior |
+| --- | --- |
+| Standard single checkout | Uses local `tbd-sync`, no visible behavior change |
+| Two linked outer checkouts start fresh | First may use local `tbd-sync`, second auto-uses `tbd-sync--wt-*` |
+| Outer checkout moved/renamed | New branch may be allocated; old branch becomes stale and prunable by doctor |
+| Outer checkout deleted abruptly | Stale local branch remains until doctor cleanup |
+| Existing inner worktree detached HEAD | Auto-repair reattaches to selected local sync branch |
+| Local branch missing but state points to it | Repair recreates branch from remote canonical |
+| Remote `origin/tbd-sync` missing | Initial orphan/first-push workflow remains supported |
+| Concurrent sync from two outer checkouts | Normal git non-fast-forward retries and merge handling apply |
+| Push denied (HTTP 403) | Existing outbox auto-save behavior remains unchanged |
+| Data mistakenly written to direct path | Doctor migration/repair still applies; no silent production fallback |
+| Canonical branch name changed in config | Local branches still per-checkout, remote target follows config |
+| Copied checkout with stale `state.yml` branch | Resolver detects branch in use elsewhere and reallocates managed branch |
+| Managed branch exists but was manually deleted | Resolver recreates from remote canonical branch when possible |
+| Managed branch exists but points to unrelated history | Doctor warns; `--fix` reattaches/recreates managed branch |
+
+### Failure Safety
+
+- No destructive operations on canonical remote branch refs
+- No destructive branch cleanup without explicit safety checks
+- Stale branch cleanup limited to managed prefix (`<remoteSyncBranch>--wt-`) and only
+  when not checked out
+- Preserve current attic/outbox recovery paths
+
+## Implementation Plan
+
+### Phase 1: Branch Ref Infrastructure
+
+- [ ] Add `packages/tbd/src/file/sync-branch.ts`:
+  - [ ] `resolveSyncBranchRefs(baseDir, config, options)`
+  - [ ] `makeManagedLocalBranchName(remoteSyncBranch, checkoutPath)`
+  - [ ] `isManagedLocalBranch(localBranch, remoteSyncBranch)`
+  - [ ] `listManagedLocalBranches(baseDir, remoteSyncBranch)`
+- [ ] Add git worktree inspection helpers in `packages/tbd/src/file/git.ts`:
+  - [ ] `listWorktreeBranchRefs(baseDir)`
+  - [ ] `isBranchCheckedOutInOtherWorktree(baseDir, branch, currentWorktreePath?)`
+- [ ] Extend state schema and serialization:
+  - [ ] `packages/tbd/src/lib/schemas.ts`: `LocalStateSchema.local_sync_branch`
+  - [ ] `packages/tbd/src/lib/schemas.ts`: `LOCAL_STATE_FIELD_ORDER`
+  - [ ] `packages/tbd/src/file/config.ts`: verify read/write/update state flows
+
+Acceptance criteria:
+- Deterministic resolver output for same checkout path + same worktree occupancy
+- Read-only resolution does not write `state.yml`
+- Write-mode resolution persists and reuses `local_sync_branch`
+
+### Phase 2: Git Layer Ref Separation
+
+- [ ] Update signatures and internal logic in `packages/tbd/src/file/git.ts`:
+  - [ ] `initWorktree(...)` split local/remote refs
+  - [ ] `updateWorktree(...)` split local/remote refs
+  - [ ] `repairWorktree(...)` split local/remote refs
+  - [ ] `ensureWorktreeAttached(worktreePath, expectedLocalBranch)`
+  - [ ] `pushWithRetry(localSyncBranch, remoteName, remoteSyncBranch, ...)`
+  - [ ] `checkRemoteBranchHealth(remoteName, remoteSyncBranch, localSyncBranch)`
+  - [ ] `checkSyncConsistency(baseDir, localSyncBranch, remoteName, remoteSyncBranch)`
+  - [ ] `migrateDataToWorktree(...)` call-site update for `ensureWorktreeAttached`
+
+Acceptance criteria:
+- No branch helper assumes local branch name equals remote branch name
+- Push/pull/rev-list operations use explicit split refs
+- Single-checkout behavior remains unchanged (`localSyncBranch === remoteSyncBranch`)
+
+### Phase 3: Command Integration
+
+- [ ] `packages/tbd/src/cli/commands/sync.ts`:
+  - [ ] resolve refs once in `run()`
+  - [ ] thread refs through `showIssueStatus`, `getSyncStatus`, `pullChanges`,
+    `pushChanges`, `doPushWithRetry`, `fullSync`, and `maybeImportOutbox`
+  - [ ] pass refs into worktree repair path and `ensureWorktreeAttached`
+- [ ] `packages/tbd/src/cli/commands/doctor.ts`:
+  - [ ] resolve refs once (read-only vs `--fix`)
+  - [ ] update local/remote/consistency checks to split refs
+  - [ ] add branch-binding drift diagnostics
+  - [ ] add safe stale managed-branch cleanup in fix mode
+- [ ] `packages/tbd/src/cli/commands/status.ts` and
+  `packages/tbd/src/cli/lib/sections.ts`:
+  - [ ] add `local_sync_branch` to JSON payload
+  - [ ] add optional local-branch line in text output
+- [ ] `packages/tbd/src/cli/commands/init.ts`:
+  - [ ] persist `--sync-branch` / `--remote` overrides to config
+  - [ ] resolve refs and call split-ref `initWorktree(...)`
+- [ ] `packages/tbd/src/cli/commands/setup.ts`:
+  - [ ] resolve refs and call split-ref `initWorktree(...)` in `initializeTbd()`
+- [ ] `packages/tbd/src/cli/commands/uninstall.ts`:
+  - [ ] discover managed branches for same canonical remote branch
+  - [ ] safe-delete non-checked-out managed branches when not `--keep-branch`
+
+Acceptance criteria:
+- Multiple linked outer checkouts can all run `tbd sync` without branch checkout errors
+- Canonical remote branch remains `config.sync.branch`
+- User-facing command semantics remain stable
+
+## Testing Strategy
+
+Unit tests:
+
+- Add new test file: `packages/tbd/tests/sync-branch.test.ts`
+  - deterministic managed-name generation
+  - read-only vs write-mode resolver behavior
+  - state reuse/reallocation when branch is occupied elsewhere
+  - collision suffix behavior (`-2`, `-3`, ...)
+- Update `packages/tbd/tests/worktree-health.test.ts`
+  - split-ref checks for `checkRemoteBranchHealth` and `checkSyncConsistency`
+  - `ensureWorktreeAttached(worktreePath, expectedLocalBranch)` branch reattach cases
+- Update `packages/tbd/tests/config.test.ts` or `packages/tbd/tests/schemas.test.ts`
+  - `local_sync_branch` parse/write ordering behavior
+
+Integration/e2e tests:
+
+- Update `packages/tbd/tests/git-remote.test.ts`
+  - two local branches push to one canonical remote branch
+- Update `packages/tbd/tests/cli-sync-worktree-scenarios.tryscript.md`
+  - linked-worktree scenario: two outer checkouts, one canonical remote branch
+- Update `packages/tbd/tests/cli-sync-remote.tryscript.md`
+  - JSON/status assertions include split refs (if exposed)
+- Update `packages/tbd/tests/cli-status.tryscript.md`
+  - text output local branch line shown only when different
+- Update `packages/tbd/tests/cli-uninstall.tryscript.md`
+  - managed-branch cleanup behavior and `--keep-branch` behavior
+- Regression for outbox flow in `packages/tbd/tests/cli-sync.tryscript.md` and/or
+  `packages/tbd/tests/doctor-sync.test.ts`
+  - verify HTTP 403 save/import behavior unchanged
+
+Regression tests:
+
+- Single-checkout flow remains unchanged
+- Existing repositories with local `tbd-sync` continue syncing correctly
+- Existing worktree corruption/missing-worktree repair tests remain passing
+- `tbd setup --auto` and `tbd init` still succeed in a standard single checkout
+
+Validation matrix:
+
+- Git 2.42+ (required for orphan worktree behavior)
+- macOS/Linux (baseline)
+- AI multi-checkout environment simulation using linked worktrees
+
+## Rollout Plan
+
+1. Implement under existing sync flow with no opt-in required
+2. First sync in each checkout auto-selects/persists local sync branch
+3. Existing single-checkout repositories continue on local `tbd-sync`
+4. Linked-worktree environments transparently transition to per-checkout local branches
+5. Doctor provides cleanup guidance for stale local branch artifacts
+6. Update troubleshooting docs with multi-checkout behavior notes
+
+## Locked Decisions
+
+- Fingerprint input uses normalized real checkout path only (no extra repository ID
+  salt)
+- Status text shows `Local sync branch` only when it differs from canonical sync branch
+- Managed-branch pruning is fix-only (`tbd doctor --fix` / uninstall paths), not normal
+  sync
+- No new CLI flags are added for this release; existing debug mode can include split
+  refs
+
+## References
+
+- [tbd design doc](/Users/levy/wrk/github/tbd/packages/tbd/docs/tbd-design.md)
+- [sync command implementation](/Users/levy/wrk/github/tbd/packages/tbd/src/cli/commands/sync.ts)
+- [git worktree helpers](/Users/levy/wrk/github/tbd/packages/tbd/src/file/git.ts)
+- [path resolution](/Users/levy/wrk/github/tbd/packages/tbd/src/lib/paths.ts)
+- [sync troubleshooting guideline](/Users/levy/wrk/github/tbd/packages/tbd/docs/guidelines/tbd-sync-troubleshooting.md)
+- [worktree recovery/hardening spec](/Users/levy/wrk/github/tbd/docs/project/specs/done/plan-2026-01-28-sync-worktree-recovery-and-hardening.md)

--- a/packages/tbd/src/cli/commands/doctor.ts
+++ b/packages/tbd/src/cli/commands/doctor.ts
@@ -13,7 +13,12 @@ import { join } from 'node:path';
 import { BaseCommand } from '../lib/base-command.js';
 import { requireInit } from '../lib/errors.js';
 import { listIssues } from '../../file/storage.js';
-import { readConfig } from '../../file/config.js';
+import { readConfig, readLocalState } from '../../file/config.js';
+import {
+  resolveSyncBranchRefs,
+  listManagedLocalBranches,
+  type SyncBranchRefs,
+} from '../../file/sync-branch.js';
 import type { Config, Issue, IssueStatusType } from '../../lib/types.js';
 import { resolveDataSyncDir, TBD_DIR, WORKTREE_DIR, DATA_SYNC_DIR } from '../../lib/paths.js';
 import { detectDuplicateYamlKeys } from '../../utils/yaml-utils.js';
@@ -33,6 +38,8 @@ import {
   checkLocalBranchHealth,
   checkRemoteBranchHealth,
   checkSyncConsistency,
+  isBranchCheckedOutInOtherWorktree,
+  ensureWorktreeAttached,
   repairWorktree,
   migrateDataToWorktree,
   initWorktree,
@@ -57,6 +64,7 @@ class DoctorHandler extends BaseCommand {
   private dataSyncDir = '';
   private cwd = '';
   private config: Config | null = null;
+  private syncRefs: SyncBranchRefs | null = null;
   private issues: Issue[] = [];
 
   async run(options: DoctorOptions): Promise<void> {
@@ -68,6 +76,9 @@ class DoctorHandler extends BaseCommand {
     // Load config
     try {
       this.config = await readConfig(this.cwd);
+      this.syncRefs = await resolveSyncBranchRefs(this.cwd, this.config, {
+        forWrite: Boolean(options.fix),
+      });
     } catch {
       // Config may be invalid - will be caught by health checks
     }
@@ -136,6 +147,12 @@ class DoctorHandler extends BaseCommand {
     // Check 15: Sync consistency (worktree matches local, ahead/behind counts)
     healthChecks.push(await this.checkSyncConsistency());
 
+    // Check 16: Local sync branch binding in state/worktree
+    healthChecks.push(await this.checkLocalSyncBinding(options.fix));
+
+    // Check 17: Stale managed local sync branches
+    healthChecks.push(await this.checkManagedLocalBranches(options.fix));
+
     // Run integration checks (optional IDE/agent integrations)
     const integrationChecks: DiagnosticResult[] = [];
 
@@ -172,10 +189,12 @@ class DoctorHandler extends BaseCommand {
 
         // CONFIG section (shared with status command)
         if (this.config) {
+          const refs = this.getSyncRefs();
           renderConfigSection(
             {
-              syncBranch: this.config.sync.branch,
-              remote: this.config.sync.remote,
+              syncBranch: refs.remoteSyncBranch,
+              localSyncBranch: refs.localSyncBranch,
+              remote: refs.remoteName,
               displayPrefix: this.config.display.id_prefix,
             },
             colors,
@@ -224,6 +243,24 @@ class DoctorHandler extends BaseCommand {
     return {
       gitBranch,
       worktreeHealthy: worktreeHealth.valid,
+    };
+  }
+
+  /**
+   * Get resolved sync refs, falling back to config defaults when resolution is unavailable.
+   */
+  private getSyncRefs(): SyncBranchRefs {
+    if (this.syncRefs) {
+      return this.syncRefs;
+    }
+
+    const remoteSyncBranch = this.config?.sync.branch ?? 'tbd-sync';
+    const remoteName = this.config?.sync.remote ?? 'origin';
+    return {
+      remoteName,
+      remoteSyncBranch,
+      localSyncBranch: remoteSyncBranch,
+      source: 'canonical',
     };
   }
 
@@ -714,7 +751,14 @@ class DoctorHandler extends BaseCommand {
       case 'corrupted': {
         // Attempt repair if --fix is provided and not in dry-run mode
         if (fix && !this.checkDryRun('Repair worktree')) {
-          const result = await repairWorktree(this.cwd, worktreeHealth.status);
+          const refs = this.getSyncRefs();
+          const result = await repairWorktree(
+            this.cwd,
+            worktreeHealth.status,
+            refs.remoteName,
+            refs.remoteSyncBranch,
+            refs.localSyncBranch,
+          );
 
           if (result.success) {
             const message = result.backedUp
@@ -796,11 +840,17 @@ class DoctorHandler extends BaseCommand {
 
     // Issues found in wrong location - attempt migration if --fix and not dry-run
     if (fix && !this.checkDryRun('Migrate data to worktree')) {
+      const refs = this.getSyncRefs();
       // First ensure worktree exists - create it if missing
       let worktreeHealth = await checkWorktreeHealth(this.cwd);
       if (worktreeHealth.status === 'missing') {
         // Worktree doesn't exist yet - create it for migration
-        const initResult = await initWorktree(this.cwd);
+        const initResult = await initWorktree(
+          this.cwd,
+          refs.remoteName,
+          refs.remoteSyncBranch,
+          refs.localSyncBranch,
+        );
         if (!initResult.success) {
           return {
             name: 'Data location',
@@ -826,7 +876,7 @@ class DoctorHandler extends BaseCommand {
       }
 
       // Migrate data to worktree
-      const result = await migrateDataToWorktree(this.cwd);
+      const result = await migrateDataToWorktree(this.cwd, false, refs.localSyncBranch);
 
       if (result.success) {
         const message = result.backupPath
@@ -864,24 +914,27 @@ class DoctorHandler extends BaseCommand {
    * See: plan-2026-01-28-sync-worktree-recovery-and-hardening.md §4b
    */
   private async checkLocalSyncBranch(): Promise<DiagnosticResult> {
-    const syncBranch = this.config?.sync.branch ?? 'tbd-sync';
-    const localHealth = await checkLocalBranchHealth(syncBranch);
+    const refs = this.getSyncRefs();
+    const localHealth = await checkLocalBranchHealth(refs.localSyncBranch);
 
     if (localHealth.exists && !localHealth.orphaned) {
-      return { name: 'Local sync branch', status: 'ok', message: syncBranch };
+      return { name: 'Local sync branch', status: 'ok', message: refs.localSyncBranch };
     }
 
     if (!localHealth.exists) {
       // Local branch doesn't exist - check if remote exists
-      const remote = this.config?.sync.remote ?? 'origin';
-      const remoteHealth = await checkRemoteBranchHealth(remote, syncBranch);
+      const remoteHealth = await checkRemoteBranchHealth(
+        refs.remoteName,
+        refs.remoteSyncBranch,
+        refs.localSyncBranch,
+      );
 
       if (remoteHealth.exists) {
         // Remote exists but local doesn't - can be created from remote
         return {
           name: 'Local sync branch',
           status: 'warn',
-          message: `${syncBranch} not found (remote exists)`,
+          message: `${refs.localSyncBranch} not found (remote exists)`,
           suggestion: 'Run: tbd sync to create from remote',
         };
       }
@@ -898,7 +951,7 @@ class DoctorHandler extends BaseCommand {
     return {
       name: 'Local sync branch',
       status: 'warn',
-      message: `${syncBranch} exists but has no commits`,
+      message: `${refs.localSyncBranch} exists but has no commits`,
       suggestion: 'Run: tbd sync to push data',
     };
   }
@@ -908,30 +961,37 @@ class DoctorHandler extends BaseCommand {
    * See: plan-2026-01-28-sync-worktree-recovery-and-hardening.md §4b
    */
   private async checkRemoteSyncBranch(): Promise<DiagnosticResult> {
-    const syncBranch = this.config?.sync.branch ?? 'tbd-sync';
-    const remote = this.config?.sync.remote ?? 'origin';
-    const remoteHealth = await checkRemoteBranchHealth(remote, syncBranch);
+    const refs = this.getSyncRefs();
+    const remoteHealth = await checkRemoteBranchHealth(
+      refs.remoteName,
+      refs.remoteSyncBranch,
+      refs.localSyncBranch,
+    );
 
     if (remoteHealth.exists) {
       if (remoteHealth.diverged) {
         return {
           name: 'Remote sync branch',
           status: 'warn',
-          message: `${remote}/${syncBranch} has diverged`,
+          message: `${refs.remoteName}/${refs.remoteSyncBranch} has diverged`,
           suggestion: 'Run: tbd sync to reconcile changes',
         };
       }
-      return { name: 'Remote sync branch', status: 'ok', message: `${remote}/${syncBranch}` };
+      return {
+        name: 'Remote sync branch',
+        status: 'ok',
+        message: `${refs.remoteName}/${refs.remoteSyncBranch}`,
+      };
     }
 
     // Remote branch doesn't exist
-    const localHealth = await checkLocalBranchHealth(syncBranch);
+    const localHealth = await checkLocalBranchHealth(refs.localSyncBranch);
     if (localHealth.exists) {
       // Local exists but remote doesn't - needs push
       return {
         name: 'Remote sync branch',
         status: 'warn',
-        message: `${remote}/${syncBranch} not found`,
+        message: `${refs.remoteName}/${refs.remoteSyncBranch} not found`,
         suggestion: 'Run: tbd sync to push local branch',
       };
     }
@@ -964,9 +1024,12 @@ class DoctorHandler extends BaseCommand {
     }
 
     // Check if remote branch exists and has commits
-    const syncBranch = this.config?.sync.branch ?? 'tbd-sync';
-    const remote = this.config?.sync.remote ?? 'origin';
-    const remoteHealth = await checkRemoteBranchHealth(remote, syncBranch);
+    const refs = this.getSyncRefs();
+    const remoteHealth = await checkRemoteBranchHealth(
+      refs.remoteName,
+      refs.remoteSyncBranch,
+      refs.localSyncBranch,
+    );
 
     if (!remoteHealth.exists) {
       // Remote doesn't exist - issues haven't been pushed
@@ -1072,8 +1135,7 @@ class DoctorHandler extends BaseCommand {
    * See: plan-2026-01-28-sync-worktree-recovery-and-hardening.md §4
    */
   private async checkSyncConsistency(): Promise<DiagnosticResult> {
-    const syncBranch = this.config?.sync.branch ?? 'tbd-sync';
-    const remote = this.config?.sync.remote ?? 'origin';
+    const refs = this.getSyncRefs();
 
     // Only check if worktree is valid
     const worktreeHealth = await checkWorktreeHealth(this.cwd);
@@ -1082,7 +1144,12 @@ class DoctorHandler extends BaseCommand {
     }
 
     try {
-      const consistency = await checkSyncConsistency(this.cwd, syncBranch, remote);
+      const consistency = await checkSyncConsistency(
+        this.cwd,
+        refs.localSyncBranch,
+        refs.remoteName,
+        refs.remoteSyncBranch,
+      );
 
       // Check if worktree matches local
       if (!consistency.worktreeMatchesLocal) {
@@ -1092,7 +1159,7 @@ class DoctorHandler extends BaseCommand {
           message: 'worktree HEAD does not match local branch',
           details: [
             `Worktree HEAD: ${consistency.worktreeHead.slice(0, 7)}`,
-            `Local ${syncBranch}: ${consistency.localHead.slice(0, 7)}`,
+            `Local ${refs.localSyncBranch}: ${consistency.localHead.slice(0, 7)}`,
           ],
           fixable: true,
           suggestion: 'Run: tbd doctor --fix to synchronize',
@@ -1140,6 +1207,140 @@ class DoctorHandler extends BaseCommand {
         message: `Unable to check: ${msg}`,
       };
     }
+  }
+
+  /**
+   * Check that local sync branch state and worktree attachment are coherent.
+   */
+  private async checkLocalSyncBinding(fix?: boolean): Promise<DiagnosticResult> {
+    const refs = this.getSyncRefs();
+    const state = await readLocalState(this.cwd);
+    const stateBranch = state.local_sync_branch;
+    const worktreePath = join(this.cwd, WORKTREE_DIR);
+
+    if (stateBranch && stateBranch !== refs.localSyncBranch) {
+      if (fix && this.config && !this.checkDryRun('Re-resolve local sync branch binding')) {
+        this.syncRefs = await resolveSyncBranchRefs(this.cwd, this.config, { forWrite: true });
+        return {
+          name: 'Local sync binding',
+          status: 'ok',
+          message: `updated to ${this.syncRefs.localSyncBranch}`,
+        };
+      }
+
+      return {
+        name: 'Local sync binding',
+        status: 'warn',
+        message: `state points to ${stateBranch}, resolved ${refs.localSyncBranch}`,
+        fixable: true,
+        suggestion: 'Run: tbd doctor --fix to update local binding',
+      };
+    }
+
+    if (stateBranch) {
+      const occupiedElsewhere = await isBranchCheckedOutInOtherWorktree(
+        this.cwd,
+        stateBranch,
+        worktreePath,
+      );
+      if (occupiedElsewhere) {
+        return {
+          name: 'Local sync binding',
+          status: 'warn',
+          message: `${stateBranch} is checked out by another worktree`,
+          fixable: true,
+          suggestion: 'Run: tbd doctor --fix to rebind this checkout',
+        };
+      }
+    }
+
+    const worktreeHealth = await checkWorktreeHealth(this.cwd);
+    if (worktreeHealth.status !== 'valid') {
+      return { name: 'Local sync binding', status: 'ok', message: 'worktree not active' };
+    }
+
+    if (worktreeHealth.branch === refs.localSyncBranch) {
+      return { name: 'Local sync binding', status: 'ok', message: refs.localSyncBranch };
+    }
+
+    if (fix && !this.checkDryRun('Attach worktree to resolved local sync branch')) {
+      await ensureWorktreeAttached(worktreePath, refs.localSyncBranch);
+      return {
+        name: 'Local sync binding',
+        status: 'ok',
+        message: `attached to ${refs.localSyncBranch}`,
+      };
+    }
+
+    const branchMsg = worktreeHealth.branch ?? 'detached HEAD';
+    return {
+      name: 'Local sync binding',
+      status: 'warn',
+      message: `worktree on ${branchMsg}, expected ${refs.localSyncBranch}`,
+      fixable: true,
+      suggestion: 'Run: tbd doctor --fix to reattach worktree',
+    };
+  }
+
+  /**
+   * Identify and optionally prune stale managed local sync branches.
+   */
+  private async checkManagedLocalBranches(fix?: boolean): Promise<DiagnosticResult> {
+    const refs = this.getSyncRefs();
+    const managed = await listManagedLocalBranches(this.cwd, refs.remoteSyncBranch);
+    const candidates = managed.filter((branch) => branch !== refs.localSyncBranch);
+
+    if (candidates.length === 0) {
+      return { name: 'Managed branches', status: 'ok' };
+    }
+
+    const stale: string[] = [];
+    for (const branch of candidates) {
+      const inUse = await isBranchCheckedOutInOtherWorktree(this.cwd, branch);
+      if (!inUse) {
+        stale.push(branch);
+      }
+    }
+
+    if (stale.length === 0) {
+      return { name: 'Managed branches', status: 'ok', message: `${candidates.length} active` };
+    }
+
+    if (fix && !this.checkDryRun('Prune stale managed local sync branches')) {
+      let removed = 0;
+      const failed: string[] = [];
+      for (const branch of stale) {
+        try {
+          await git('-C', this.cwd, 'branch', '-D', branch);
+          removed += 1;
+        } catch {
+          failed.push(branch);
+        }
+      }
+
+      if (failed.length > 0) {
+        return {
+          name: 'Managed branches',
+          status: 'warn',
+          message: `removed ${removed}, failed ${failed.length}`,
+          details: failed.map((branch) => `Could not remove: ${branch}`),
+        };
+      }
+
+      return {
+        name: 'Managed branches',
+        status: 'ok',
+        message: `removed ${removed} stale branch(es)`,
+      };
+    }
+
+    return {
+      name: 'Managed branches',
+      status: 'warn',
+      message: `${stale.length} stale managed branch(es)`,
+      fixable: true,
+      suggestion: 'Run: tbd doctor --fix to prune stale managed branches',
+    };
   }
 }
 

--- a/packages/tbd/src/cli/commands/init.ts
+++ b/packages/tbd/src/cli/commands/init.ts
@@ -13,12 +13,12 @@ import { ensureGitignorePatterns } from '../../utils/gitignore-utils.js';
 import { CLIError, ValidationError } from '../lib/errors.js';
 import { isValidPrefix, isRecommendedPrefix } from '../lib/prefix-detection.js';
 import { VERSION } from '../lib/version.js';
-import { initConfig } from '../../file/config.js';
+import { initConfig, writeConfig } from '../../file/config.js';
+import { resolveSyncBranchRefs } from '../../file/sync-branch.js';
 import {
   TBD_DIR,
   WORKTREE_DIR_NAME,
   DATA_SYNC_DIR_NAME,
-  SYNC_BRANCH,
   TBD_SHORTCUTS_SYSTEM,
   TBD_SHORTCUTS_STANDARD,
   TBD_GUIDELINES_DIR,
@@ -111,7 +111,7 @@ class InitHandler extends BaseCommand {
     await this.execute(async () => {
       // 1. Create .tbd/ directory with config.yml
       // Note: options.prefix is validated to be non-null above
-      await initConfig(cwd, VERSION, options.prefix!);
+      const createdConfig = await initConfig(cwd, VERSION, options.prefix!);
       this.output.debug(`Created ${TBD_DIR}/config.yml with prefix '${options.prefix}'`);
 
       // 2. Create .tbd/.gitignore (idempotent)
@@ -148,10 +148,23 @@ class InitHandler extends BaseCommand {
       await mkdir(join(cwd, TBD_TEMPLATES_DIR), { recursive: true });
       this.output.debug(`Created ${TBD_DOCS_DIR}/ directories`);
 
-      // 4. Initialize the hidden worktree for tbd-sync branch
-      // This creates .tbd/data-sync-worktree/ with the sync branch checkout
-      const remote = options.remote ?? 'origin';
-      const syncBranch = options.syncBranch ?? SYNC_BRANCH;
+      // 4. Initialize the hidden worktree for sync branch.
+      // If branch/remote overrides were provided, persist them in config first.
+      const config =
+        options.remote || options.syncBranch
+          ? {
+              ...createdConfig,
+              sync: {
+                branch: options.syncBranch ?? createdConfig.sync.branch,
+                remote: options.remote ?? createdConfig.sync.remote,
+              },
+            }
+          : createdConfig;
+      if (config !== createdConfig) {
+        await writeConfig(cwd, config);
+        this.output.debug(`Updated ${TBD_DIR}/config.yml with sync overrides`);
+      }
+      const refs = await resolveSyncBranchRefs(cwd, config, { forWrite: true });
 
       // Check Git version before attempting worktree creation
       // Git 2.42+ is required for --orphan worktree support
@@ -172,7 +185,12 @@ class InitHandler extends BaseCommand {
         this.output.debug(`Git version check skipped: ${(error as Error).message}`);
       }
 
-      const worktreeResult = await initWorktree(cwd, remote, syncBranch);
+      const worktreeResult = await initWorktree(
+        cwd,
+        refs.remoteName,
+        refs.remoteSyncBranch,
+        refs.localSyncBranch,
+      );
 
       if (worktreeResult.success) {
         if (worktreeResult.created) {

--- a/packages/tbd/src/cli/commands/setup.ts
+++ b/packages/tbd/src/cli/commands/setup.ts
@@ -37,6 +37,7 @@ import {
   writeConfig,
   markWelcomeSeen,
 } from '../../file/config.js';
+import { resolveSyncBranchRefs } from '../../file/sync-branch.js';
 import { syncDocsWithDefaults } from '../../file/doc-sync.js';
 import { VERSION } from '../lib/version.js';
 import {
@@ -1468,7 +1469,9 @@ class SetupDefaultHandler extends BaseCommand {
 
     // 3. Initialize worktree for sync branch
     try {
-      await initWorktree(cwd);
+      const config = await readConfig(cwd);
+      const refs = await resolveSyncBranchRefs(cwd, config, { forWrite: true });
+      await initWorktree(cwd, refs.remoteName, refs.remoteSyncBranch, refs.localSyncBranch);
 
       // Verify worktree health after creation (prevents silent failures)
       const health = await checkWorktreeHealth(cwd);

--- a/packages/tbd/src/cli/commands/status.ts
+++ b/packages/tbd/src/cli/commands/status.ts
@@ -27,6 +27,7 @@ import {
   type IntegrationCheck,
 } from '../lib/sections.js';
 import { readConfig, findTbdRoot } from '../../file/config.js';
+import { resolveSyncBranchRefs } from '../../file/sync-branch.js';
 import { WORKTREE_DIR } from '../../lib/paths.js';
 import {
   getClaudePaths,
@@ -61,6 +62,7 @@ interface StatusData {
 
   // Post-init only
   sync_branch: string | null;
+  local_sync_branch: string | null;
   remote: string | null;
   display_prefix: string | null;
   worktree_path: string | null;
@@ -101,6 +103,7 @@ class StatusHandler extends BaseCommand {
       beads_detected: false,
       beads_issue_count: null,
       sync_branch: null,
+      local_sync_branch: null,
       remote: null,
       display_prefix: null,
       worktree_path: null,
@@ -232,8 +235,10 @@ class StatusHandler extends BaseCommand {
     // Load config
     try {
       const config = await readConfig(cwd);
-      data.sync_branch = config.sync.branch;
-      data.remote = config.sync.remote;
+      const refs = await resolveSyncBranchRefs(cwd, config, { forWrite: false });
+      data.sync_branch = refs.remoteSyncBranch;
+      data.local_sync_branch = refs.localSyncBranch;
+      data.remote = refs.remoteName;
       data.display_prefix = config.display.id_prefix;
     } catch {
       // Config read failed
@@ -286,6 +291,7 @@ class StatusHandler extends BaseCommand {
     renderConfigSection(
       {
         syncBranch: data.sync_branch,
+        localSyncBranch: data.local_sync_branch,
         remote: data.remote,
         displayPrefix: data.display_prefix,
       },

--- a/packages/tbd/src/cli/commands/sync.ts
+++ b/packages/tbd/src/cli/commands/sync.ts
@@ -17,6 +17,7 @@ import {
 } from '../lib/errors.js';
 import { readConfig } from '../../file/config.js';
 import { listIssues, readIssue, writeIssue } from '../../file/storage.js';
+import { resolveSyncBranchRefs, type SyncBranchRefs } from '../../file/sync-branch.js';
 import {
   git,
   withIsolatedIndex,
@@ -73,6 +74,8 @@ interface SyncStatus {
   localChanges: string[];
   remoteChanges: string[];
   syncBranch: string;
+  localSyncBranch: string;
+  remoteSyncBranch: string;
   remote: string;
   ahead: number;
   behind: number;
@@ -85,6 +88,15 @@ class SyncHandler extends BaseCommand {
   async run(options: SyncOptions): Promise<void> {
     const tbdRoot = await requireInit();
     this.tbdRoot = tbdRoot;
+
+    // Load config early so branch refs are available for worktree repair paths.
+    let config;
+    try {
+      config = await readConfig(tbdRoot);
+    } catch {
+      throw new NotInitializedError('Not a tbd repository. Run `tbd init` first.');
+    }
+    const refs = await resolveSyncBranchRefs(tbdRoot, config, { forWrite: true });
 
     // Validate mutually exclusive options
     // --push/--pull only apply to issues (network operations)
@@ -123,7 +135,7 @@ class SyncHandler extends BaseCommand {
       // Only require --fix for corrupted/prunable states that need repair
       if (worktreeHealth.status === 'missing') {
         // Auto-create worktree - this is the expected state on fresh clones
-        await this.doRepairWorktree(tbdRoot, 'missing');
+        await this.doRepairWorktree(tbdRoot, 'missing', refs);
         worktreeHealth = await checkWorktreeHealth(tbdRoot);
         if (!worktreeHealth.valid) {
           throw new WorktreeCorruptedError(
@@ -132,7 +144,11 @@ class SyncHandler extends BaseCommand {
         }
       } else if (options.fix) {
         // Attempt repair when --fix is provided for corrupted/prunable states
-        await this.doRepairWorktree(tbdRoot, worktreeHealth.status as 'prunable' | 'corrupted');
+        await this.doRepairWorktree(
+          tbdRoot,
+          worktreeHealth.status as 'prunable' | 'corrupted',
+          refs,
+        );
         // Re-check health after repair
         worktreeHealth = await checkWorktreeHealth(tbdRoot);
         if (!worktreeHealth.valid) {
@@ -157,33 +173,28 @@ class SyncHandler extends BaseCommand {
 
     this.dataSyncDir = await resolveDataSyncDir(tbdRoot);
 
-    // Load config to get sync branch
-    let config;
-    try {
-      config = await readConfig(tbdRoot);
-    } catch {
-      throw new NotInitializedError('Not a tbd repository. Run `tbd init` first.');
-    }
-
-    const syncBranch = config.sync.branch;
-    const remote = config.sync.remote;
-
     if (options.status) {
-      await this.showIssueStatus(syncBranch, remote);
+      await this.showIssueStatus(refs);
       return;
     }
 
-    if (this.checkDryRun('Would sync repository', { syncBranch, remote })) {
+    if (
+      this.checkDryRun('Would sync repository', {
+        localSyncBranch: refs.localSyncBranch,
+        remoteSyncBranch: refs.remoteSyncBranch,
+        remote: refs.remoteName,
+      })
+    ) {
       return;
     }
 
     if (options.pull) {
-      await this.pullChanges(syncBranch, remote);
+      await this.pullChanges(refs);
     } else if (options.push) {
-      await this.pushChanges(syncBranch, remote);
+      await this.pushChanges(refs);
     } else {
       // Full sync: pull then push
-      await this.fullSync(syncBranch, remote, {
+      await this.fullSync(refs, {
         force: options.force,
         autoSave: options.autoSave,
         outbox: options.outbox,
@@ -292,12 +303,19 @@ class SyncHandler extends BaseCommand {
   private async doRepairWorktree(
     tbdRoot: string,
     status: 'missing' | 'prunable' | 'corrupted',
+    refs: SyncBranchRefs,
   ): Promise<void> {
     const spinner = this.output.spinner(`Repairing worktree (${status})...`);
 
     try {
       // Use shared repairWorktree from git.ts
-      const result = await repairWorktree(tbdRoot, status);
+      const result = await repairWorktree(
+        tbdRoot,
+        status,
+        refs.remoteName,
+        refs.remoteSyncBranch,
+        refs.localSyncBranch,
+      );
 
       spinner.stop();
 
@@ -316,8 +334,8 @@ class SyncHandler extends BaseCommand {
     }
   }
 
-  private async showIssueStatus(syncBranch: string, remote: string): Promise<void> {
-    const status = await this.getSyncStatus(syncBranch, remote);
+  private async showIssueStatus(refs: SyncBranchRefs): Promise<void> {
+    const status = await this.getSyncStatus(refs);
 
     this.output.data(status, () => {
       const colors = this.output.getColors();
@@ -327,7 +345,14 @@ class SyncHandler extends BaseCommand {
         return;
       }
 
-      console.log(colors.bold(`Sync status: ${syncBranch} ↔ ${remote}/${syncBranch}`));
+      console.log(
+        colors.bold(
+          `Sync status: ${status.localSyncBranch} ↔ ${status.remote}/${status.remoteSyncBranch}`,
+        ),
+      );
+      if (status.localSyncBranch !== status.remoteSyncBranch) {
+        console.log(colors.dim(`  canonical: ${status.remoteSyncBranch}`));
+      }
       console.log('');
 
       if (status.ahead > 0) {
@@ -355,7 +380,7 @@ class SyncHandler extends BaseCommand {
     });
   }
 
-  private async getSyncStatus(syncBranch: string, remote: string): Promise<SyncStatus> {
+  private async getSyncStatus(refs: SyncBranchRefs): Promise<SyncStatus> {
     const localChanges: string[] = [];
     const remoteChanges: string[] = [];
     let ahead = 0;
@@ -388,14 +413,14 @@ class SyncHandler extends BaseCommand {
 
     // Check for remote changes
     try {
-      await git('fetch', remote, syncBranch);
+      await git('fetch', refs.remoteName, refs.remoteSyncBranch);
 
       // Count commits ahead/behind
       try {
         const aheadOutput = await git(
           'rev-list',
           '--count',
-          `${remote}/${syncBranch}..${syncBranch}`,
+          `${refs.remoteName}/${refs.remoteSyncBranch}..${refs.localSyncBranch}`,
         );
         ahead = parseInt(aheadOutput, 10) || 0;
       } catch {
@@ -406,7 +431,7 @@ class SyncHandler extends BaseCommand {
         const behindOutput = await git(
           'rev-list',
           '--count',
-          `${syncBranch}..${remote}/${syncBranch}`,
+          `${refs.localSyncBranch}..${refs.remoteName}/${refs.remoteSyncBranch}`,
         );
         behind = parseInt(behindOutput, 10) || 0;
       } catch {
@@ -418,7 +443,7 @@ class SyncHandler extends BaseCommand {
         const logOutput = await git(
           'log',
           '--oneline',
-          `${syncBranch}..${remote}/${syncBranch}`,
+          `${refs.localSyncBranch}..${refs.remoteName}/${refs.remoteSyncBranch}`,
           '--limit=10',
         );
         for (const line of logOutput.split('\n')) {
@@ -436,17 +461,19 @@ class SyncHandler extends BaseCommand {
         localChanges.length === 0 && remoteChanges.length === 0 && ahead === 0 && behind === 0,
       localChanges,
       remoteChanges,
-      syncBranch,
-      remote,
+      syncBranch: refs.remoteSyncBranch,
+      localSyncBranch: refs.localSyncBranch,
+      remoteSyncBranch: refs.remoteSyncBranch,
+      remote: refs.remoteName,
       ahead,
       behind,
     };
   }
 
-  private async pullChanges(syncBranch: string, remote: string): Promise<void> {
+  private async pullChanges(refs: SyncBranchRefs): Promise<void> {
     const spinner = this.output.spinner('Pulling from remote...');
     try {
-      await git('fetch', remote, syncBranch);
+      await git('fetch', refs.remoteName, refs.remoteSyncBranch);
 
       // Get list of changed files
       let behind = 0;
@@ -454,7 +481,7 @@ class SyncHandler extends BaseCommand {
         const behindOutput = await git(
           'rev-list',
           '--count',
-          `${syncBranch}..${remote}/${syncBranch}`,
+          `${refs.localSyncBranch}..${refs.remoteName}/${refs.remoteSyncBranch}`,
         );
         behind = parseInt(behindOutput, 10) || 0;
       } catch {
@@ -470,19 +497,23 @@ class SyncHandler extends BaseCommand {
       // Merge changes using isolated index
       await withIsolatedIndex(async () => {
         // Read the remote tree
-        await git('read-tree', `${remote}/${syncBranch}`);
+        await git('read-tree', `${refs.remoteName}/${refs.remoteSyncBranch}`);
 
         // Update local branch to remote
-        const remoteCommit = await git('rev-parse', `${remote}/${syncBranch}`);
-        await git('update-ref', `refs/heads/${syncBranch}`, remoteCommit);
+        const remoteCommit = await git('rev-parse', `${refs.remoteName}/${refs.remoteSyncBranch}`);
+        await git('update-ref', `refs/heads/${refs.localSyncBranch}`, remoteCommit);
       });
 
-      this.output.success(`Pulled ${behind} change(s) from ${remote}/${syncBranch}`);
+      this.output.success(
+        `Pulled ${behind} change(s) from ${refs.remoteName}/${refs.remoteSyncBranch}`,
+      );
     } catch (error) {
       spinner.stop();
       const msg = (error as Error).message;
       if (msg.includes('not found') || msg.includes('does not exist')) {
-        this.output.info(`Remote branch ${remote}/${syncBranch} does not exist yet`);
+        this.output.info(
+          `Remote branch ${refs.remoteName}/${refs.remoteSyncBranch} does not exist yet`,
+        );
       } else {
         throw new SyncError(`Failed to pull: ${msg}`);
       }
@@ -495,7 +526,7 @@ class SyncHandler extends BaseCommand {
    *
    * @returns Tallies of new/updated/deleted files committed
    */
-  private async commitWorktreeChanges(): Promise<SyncTallies> {
+  private async commitWorktreeChanges(localSyncBranch: string): Promise<SyncTallies> {
     // Use tbdRoot to derive worktree path consistently
     // FIX Bug 1: Previously used process.cwd() which fails if not in repo root
     // See: plan-2026-01-28-sync-worktree-recovery-and-hardening.md
@@ -503,7 +534,7 @@ class SyncHandler extends BaseCommand {
 
     try {
       // Ensure worktree is attached to sync branch (repair old tbd repos)
-      await ensureWorktreeAttached(worktreePath);
+      await ensureWorktreeAttached(worktreePath, localSyncBranch);
 
       // Check for uncommitted changes (untracked, modified, or deleted)
       const status = await git('-C', worktreePath, 'status', '--porcelain');
@@ -539,11 +570,11 @@ class SyncHandler extends BaseCommand {
     }
   }
 
-  private async pushChanges(syncBranch: string, remote: string): Promise<void> {
+  private async pushChanges(refs: SyncBranchRefs): Promise<void> {
     const spinner = this.output.spinner('Pushing to remote...');
     try {
       // Commit any uncommitted changes in the worktree before pushing
-      const committedTallies = await this.commitWorktreeChanges();
+      const committedTallies = await this.commitWorktreeChanges(refs.localSyncBranch);
       const committedCount =
         committedTallies.new + committedTallies.updated + committedTallies.deleted;
       if (committedCount > 0) {
@@ -553,18 +584,18 @@ class SyncHandler extends BaseCommand {
       // Check how many commits we're ahead of remote
       let ahead = 0;
       try {
-        await git('fetch', remote, syncBranch);
+        await git('fetch', refs.remoteName, refs.remoteSyncBranch);
         const aheadOutput = await git(
           'rev-list',
           '--count',
-          `${remote}/${syncBranch}..${syncBranch}`,
+          `${refs.remoteName}/${refs.remoteSyncBranch}..${refs.localSyncBranch}`,
         );
         ahead = parseInt(aheadOutput, 10) || 0;
         this.output.debug(`Ahead of remote by ${ahead} commit(s)`);
       } catch {
         // Remote branch doesn't exist - count all local commits
         try {
-          const countOutput = await git('rev-list', '--count', syncBranch);
+          const countOutput = await git('rev-list', '--count', refs.localSyncBranch);
           ahead = parseInt(countOutput, 10) || 0;
           this.output.debug(`Remote branch not found, ${ahead} local commit(s) to push`);
         } catch {
@@ -580,11 +611,13 @@ class SyncHandler extends BaseCommand {
       }
 
       // Use push with retry
-      const result = await this.doPushWithRetry(syncBranch, remote);
+      const result = await this.doPushWithRetry(refs);
       spinner.stop();
 
       if (result.success) {
-        this.output.success(`Pushed ${ahead} commit(s) to ${remote}/${syncBranch}`);
+        this.output.success(
+          `Pushed ${ahead} commit(s) to ${refs.remoteName}/${refs.remoteSyncBranch}`,
+        );
       } else if (result.conflicts && result.conflicts.length > 0) {
         this.output.warn(
           `Push completed with ${result.conflicts.length} conflict(s) (see attic for details)`,
@@ -599,10 +632,11 @@ class SyncHandler extends BaseCommand {
     }
   }
 
-  private async doPushWithRetry(syncBranch: string, remote: string): Promise<PushResult> {
+  private async doPushWithRetry(refs: SyncBranchRefs): Promise<PushResult> {
     return pushWithRetry(
-      syncBranch,
-      remote,
+      refs.localSyncBranch,
+      refs.remoteName,
+      refs.remoteSyncBranch,
       async () => {
         // Merge callback - called when we need to merge remote changes
         const conflicts: ConflictEntry[] = [];
@@ -615,7 +649,7 @@ class SyncHandler extends BaseCommand {
             // Try to get the remote version (use relative path for git show)
             const remoteContent = await git(
               'show',
-              `${remote}/${syncBranch}:${DATA_SYNC_DIR}/issues/${localIssue.id}.md`,
+              `${refs.remoteName}/${refs.remoteSyncBranch}:${DATA_SYNC_DIR}/issues/${localIssue.id}.md`,
             );
 
             if (remoteContent) {
@@ -662,8 +696,7 @@ class SyncHandler extends BaseCommand {
   }
 
   private async fullSync(
-    syncBranch: string,
-    remote: string,
+    refs: SyncBranchRefs,
     options: { force?: boolean; autoSave?: boolean; outbox?: boolean } = {},
   ): Promise<void> {
     const spinner = this.output.spinner('Syncing with remote...');
@@ -675,7 +708,7 @@ class SyncHandler extends BaseCommand {
     try {
       // STEP 1: Commit local changes FIRST (before pulling)
       // This ensures local work is preserved before we incorporate remote changes.
-      const committedTallies = await this.commitWorktreeChanges();
+      const committedTallies = await this.commitWorktreeChanges(refs.localSyncBranch);
       // Add committed changes to sent tallies
       summary.sent.new += committedTallies.new;
       summary.sent.updated += committedTallies.updated;
@@ -686,7 +719,7 @@ class SyncHandler extends BaseCommand {
       }
 
       // STEP 2: Fetch remote
-      await git('fetch', remote, syncBranch);
+      await git('fetch', refs.remoteName, refs.remoteSyncBranch);
 
       // Get file-level changes from remote using git diff
       let behindCommits = 0;
@@ -694,7 +727,7 @@ class SyncHandler extends BaseCommand {
         const behindOutput = await git(
           'rev-list',
           '--count',
-          `${syncBranch}..${remote}/${syncBranch}`,
+          `${refs.localSyncBranch}..${refs.remoteName}/${refs.remoteSyncBranch}`,
         );
         behindCommits = parseInt(behindOutput, 10) || 0;
         this.output.debug(`Behind remote by ${behindCommits} commit(s)`);
@@ -705,7 +738,7 @@ class SyncHandler extends BaseCommand {
             const diffOutput = await git(
               'diff',
               '--name-status',
-              `${syncBranch}..${remote}/${syncBranch}`,
+              `${refs.localSyncBranch}..${refs.remoteName}/${refs.remoteSyncBranch}`,
             );
             const receivedTallies = parseGitDiff(diffOutput);
             summary.received.new += receivedTallies.new;
@@ -738,7 +771,7 @@ class SyncHandler extends BaseCommand {
             '-C',
             worktreePath,
             'merge',
-            `${remote}/${syncBranch}`,
+            `${refs.remoteName}/${refs.remoteSyncBranch}`,
             '-m',
             'tbd sync: merge remote changes',
           );
@@ -748,7 +781,10 @@ class SyncHandler extends BaseCommand {
           // Use syncBranch explicitly — bare `HEAD` would resolve to the user's
           // current working branch, not the tbd-sync branch in the worktree.
           if (headBeforeMerge) {
-            await this.showGitLogDebug('Commits received', `${headBeforeMerge}..${syncBranch}`);
+            await this.showGitLogDebug(
+              'Commits received',
+              `${headBeforeMerge}..${refs.localSyncBranch}`,
+            );
           }
 
           // Reconcile ID mappings after clean merge.
@@ -764,7 +800,7 @@ class SyncHandler extends BaseCommand {
           try {
             const remoteIdsContent = await git(
               'show',
-              `${remote}/${syncBranch}:${DATA_SYNC_DIR}/mappings/ids.yml`,
+              `${refs.remoteName}/${refs.remoteSyncBranch}:${DATA_SYNC_DIR}/mappings/ids.yml`,
             );
             if (remoteIdsContent) {
               historicalMapping = parseIdMappingFromYaml(remoteIdsContent);
@@ -816,7 +852,7 @@ class SyncHandler extends BaseCommand {
             try {
               const remoteContent = await git(
                 'show',
-                `${remote}/${syncBranch}:${DATA_SYNC_DIR}/issues/${localIssue.id}.md`,
+                `${refs.remoteName}/${refs.remoteSyncBranch}:${DATA_SYNC_DIR}/issues/${localIssue.id}.md`,
               );
               if (remoteContent) {
                 const remoteIssue = await readIssue(this.dataSyncDir, localIssue.id);
@@ -836,7 +872,7 @@ class SyncHandler extends BaseCommand {
           try {
             const remoteIdsContent = await git(
               'show',
-              `${remote}/${syncBranch}:${DATA_SYNC_DIR}/mappings/ids.yml`,
+              `${refs.remoteName}/${refs.remoteSyncBranch}:${DATA_SYNC_DIR}/mappings/ids.yml`,
             );
             if (remoteIdsContent) {
               conflictRemoteMapping = parseIdMappingFromYaml(remoteIdsContent);
@@ -930,14 +966,14 @@ class SyncHandler extends BaseCommand {
       const aheadOutput = await git(
         'rev-list',
         '--count',
-        `${remote}/${syncBranch}..${syncBranch}`,
+        `${refs.remoteName}/${refs.remoteSyncBranch}..${refs.localSyncBranch}`,
       );
       aheadCommits = parseInt(aheadOutput, 10) || 0;
       this.output.debug(`Ahead of remote by ${aheadCommits} commit(s)`);
     } catch {
       // Remote branch doesn't exist - count all local commits on sync branch
       try {
-        const countOutput = await git('rev-list', '--count', syncBranch);
+        const countOutput = await git('rev-list', '--count', refs.localSyncBranch);
         aheadCommits = parseInt(countOutput, 10) || 0;
         this.output.debug(`Remote branch not found, ${aheadCommits} local commit(s) to push`);
       } catch {
@@ -951,7 +987,7 @@ class SyncHandler extends BaseCommand {
     let pushError = '';
     if (aheadCommits > 0) {
       this.output.debug(`Pushing ${aheadCommits} commit(s) to remote`);
-      const result = await this.doPushWithRetry(syncBranch, remote);
+      const result = await this.doPushWithRetry(refs);
       if (result.conflicts) {
         conflicts.push(...result.conflicts);
       }
@@ -963,7 +999,7 @@ class SyncHandler extends BaseCommand {
         // Show pushed commits in debug mode
         // Use syncBranch explicitly — bare `-N` would resolve against the user's
         // current working branch (HEAD), not the tbd-sync branch.
-        await this.showGitLogDebug('Commits sent', syncBranch, `-${aheadCommits}`);
+        await this.showGitLogDebug('Commits sent', refs.localSyncBranch, `-${aheadCommits}`);
       }
     } else {
       this.output.debug('No commits to push');
@@ -1030,7 +1066,7 @@ class SyncHandler extends BaseCommand {
 
     // After successful push, import from outbox if it has data
     if (options.outbox !== false) {
-      await this.maybeImportOutbox(syncBranch, remote);
+      await this.maybeImportOutbox(refs);
     }
 
     this.output.data({ summary, conflicts: conflicts.length }, () => {
@@ -1123,10 +1159,9 @@ class SyncHandler extends BaseCommand {
    * Uses two-phase sync: import → commit → push → clear.
    * Only clears the outbox if all steps succeed.
    *
-   * @param syncBranch - The sync branch name
-   * @param remote - The remote name
+   * @param refs - Resolved local and remote sync branch refs
    */
-  private async maybeImportOutbox(syncBranch: string, remote: string): Promise<void> {
+  private async maybeImportOutbox(refs: SyncBranchRefs): Promise<void> {
     // Check if outbox exists and has issues
     if (!(await workspaceExists(this.tbdRoot, 'outbox'))) {
       return; // No outbox - nothing to import
@@ -1156,7 +1191,7 @@ class SyncHandler extends BaseCommand {
       }
 
       // Step 2: Commit the imported issues
-      const committedTallies = await this.commitWorktreeChanges();
+      const committedTallies = await this.commitWorktreeChanges(refs.localSyncBranch);
       if (committedTallies.new + committedTallies.updated + committedTallies.deleted === 0) {
         // Nothing to commit - issues were already in worktree
         // This can happen if outbox data was identical to worktree
@@ -1166,7 +1201,7 @@ class SyncHandler extends BaseCommand {
       }
 
       // Step 3: Push the imported issues
-      const pushResult = await this.doPushWithRetry(syncBranch, remote);
+      const pushResult = await this.doPushWithRetry(refs);
       if (!pushResult.success) {
         // Secondary push failed - DON'T clear outbox
         // The issues are now in the worktree, so they'll be synced next time

--- a/packages/tbd/src/cli/commands/uninstall.ts
+++ b/packages/tbd/src/cli/commands/uninstall.ts
@@ -12,6 +12,12 @@ import { join, relative } from 'node:path';
 import { BaseCommand } from '../lib/base-command.js';
 import { NotInitializedError, CLIError } from '../lib/errors.js';
 import { findTbdRoot, readConfig } from '../../file/config.js';
+import {
+  branchExists,
+  remoteBranchExists,
+  isBranchCheckedOutInOtherWorktree,
+} from '../../file/git.js';
+import { resolveSyncBranchRefs, listManagedLocalBranches } from '../../file/sync-branch.js';
 import { SYNC_BRANCH } from '../../lib/paths.js';
 
 interface UninstallOptions {
@@ -38,8 +44,27 @@ class UninstallHandler extends BaseCommand {
       config = null;
     }
 
-    const syncBranch = config?.sync.branch ?? SYNC_BRANCH;
-    const remote = config?.sync.remote ?? 'origin';
+    let syncBranch = config?.sync.branch ?? SYNC_BRANCH;
+    let remote = config?.sync.remote ?? 'origin';
+    if (config) {
+      try {
+        const refs = await resolveSyncBranchRefs(tbdRoot, config, { forWrite: false });
+        syncBranch = refs.remoteSyncBranch;
+        remote = refs.remoteName;
+      } catch {
+        // Keep config-derived defaults
+      }
+    }
+
+    const managedLocalBranches = await listManagedLocalBranches(tbdRoot, syncBranch);
+    const candidateLocalBranches = Array.from(new Set([syncBranch, ...managedLocalBranches]));
+    const removableLocalBranches: string[] = [];
+    for (const candidate of candidateLocalBranches) {
+      if (await branchExists(candidate)) {
+        removableLocalBranches.push(candidate);
+      }
+    }
+
     const tbdDir = join(tbdRoot, '.tbd');
     const worktreePath = join(tbdDir, 'data-sync-worktree');
 
@@ -60,33 +85,20 @@ class UninstallHandler extends BaseCommand {
       // Worktree doesn't exist
     }
 
-    // Check local sync branch
-    let localBranchExists = false;
-    try {
-      execSync(`git rev-parse --verify ${syncBranch}`, {
-        encoding: 'utf-8',
-        stdio: ['ignore', 'pipe', 'ignore'],
-      });
-      localBranchExists = true;
-      if (!options.keepBranch) {
-        items.push(`  - Local branch: ${syncBranch}`);
+    // Check local sync branches
+    const localBranchExists = removableLocalBranches.length > 0;
+    if (localBranchExists && !options.keepBranch) {
+      for (const branch of removableLocalBranches) {
+        items.push(`  - Local branch: ${branch}`);
       }
-    } catch {
-      // Branch doesn't exist
     }
 
     // Check remote sync branch
-    let remoteBranchExists = false;
+    let remoteBranchPresent = false;
     if (options.removeRemote) {
-      try {
-        execSync(`git rev-parse --verify ${remote}/${syncBranch}`, {
-          encoding: 'utf-8',
-          stdio: ['ignore', 'pipe', 'ignore'],
-        });
-        remoteBranchExists = true;
+      if (await remoteBranchExists(remote, syncBranch)) {
+        remoteBranchPresent = true;
         items.push(`  - Remote branch: ${remote}/${syncBranch}`);
-      } catch {
-        // Remote branch doesn't exist
       }
     }
 
@@ -147,21 +159,31 @@ class UninstallHandler extends BaseCommand {
       }
     }
 
-    // 2. Remove local sync branch
+    // 2. Remove local sync branches
     if (localBranchExists && !options.keepBranch) {
-      try {
-        execSync(`git branch -D ${syncBranch}`, {
-          encoding: 'utf-8',
-          stdio: ['ignore', 'pipe', 'ignore'],
-        });
-        console.log(`  ${colors.success('✓')} Removed local branch: ${syncBranch}`);
-      } catch {
-        console.log(`  ${colors.warn('⚠')} Could not remove local branch: ${syncBranch}`);
+      for (const branch of removableLocalBranches) {
+        const inUse = await isBranchCheckedOutInOtherWorktree(tbdRoot, branch);
+        if (inUse) {
+          console.log(
+            `  ${colors.warn('⚠')} Skipped local branch in use by another worktree: ${branch}`,
+          );
+          continue;
+        }
+
+        try {
+          execSync(`git branch -D -- "${branch}"`, {
+            encoding: 'utf-8',
+            stdio: ['ignore', 'pipe', 'ignore'],
+          });
+          console.log(`  ${colors.success('✓')} Removed local branch: ${branch}`);
+        } catch {
+          console.log(`  ${colors.warn('⚠')} Could not remove local branch: ${branch}`);
+        }
       }
     }
 
     // 3. Remove remote sync branch
-    if (remoteBranchExists && options.removeRemote) {
+    if (remoteBranchPresent && options.removeRemote) {
       try {
         execSync(`git push ${remote} --delete ${syncBranch}`, {
           encoding: 'utf-8',
@@ -199,11 +221,22 @@ class UninstallHandler extends BaseCommand {
 
     if (options.keepBranch && localBranchExists) {
       console.log('');
-      console.log(colors.dim(`Note: The ${syncBranch} branch was preserved. Delete it with:`));
-      console.log(colors.dim(`  git branch -D ${syncBranch}`));
+      if (removableLocalBranches.length === 1) {
+        console.log(
+          colors.dim(
+            `Note: The ${removableLocalBranches[0]} branch was preserved. Delete it with:`,
+          ),
+        );
+        console.log(colors.dim(`  git branch -D ${removableLocalBranches[0]}`));
+      } else {
+        console.log(colors.dim('Note: Local sync branches were preserved:'));
+        for (const branch of removableLocalBranches) {
+          console.log(colors.dim(`  - ${branch}`));
+        }
+      }
     }
 
-    if (!options.removeRemote && remoteBranchExists) {
+    if (!options.removeRemote && remoteBranchPresent) {
       console.log('');
       console.log(
         colors.dim(

--- a/packages/tbd/src/cli/lib/sections.ts
+++ b/packages/tbd/src/cli/lib/sections.ts
@@ -30,6 +30,7 @@ export interface RepositorySectionData {
  */
 export interface ConfigSectionData {
   syncBranch: string | null;
+  localSyncBranch?: string | null;
   remote: string | null;
   displayPrefix: string | null;
 }
@@ -137,6 +138,9 @@ export function renderConfigSection(
 
   if (data.syncBranch) {
     console.log(`${colors.dim('Sync branch:')} ${data.syncBranch}`);
+  }
+  if (data.localSyncBranch && data.localSyncBranch !== data.syncBranch) {
+    console.log(`${colors.dim('Local sync branch:')} ${data.localSyncBranch}`);
   }
   if (data.remote) {
     console.log(`${colors.dim('Remote:')} ${data.remote}`);

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -10,9 +10,9 @@
  */
 
 import { execFile } from 'node:child_process';
-import { mkdir } from 'node:fs/promises';
+import { mkdir, access, rm, cp, readdir, realpath } from 'node:fs/promises';
 import { promisify } from 'node:util';
-import { join } from 'node:path';
+import { join, normalize as normalizePath, resolve as resolvePath } from 'node:path';
 
 import { writeFile } from 'atomically';
 
@@ -613,26 +613,28 @@ export interface PushResult {
  * Push with retry and merge on conflict.
  * See: tbd-design.md §3.3.3 Sync Algorithm
  *
- * @param syncBranch - The sync branch name
- * @param remote - The remote name
+ * @param localSyncBranch - Local sync branch name (source ref)
+ * @param remoteName - Remote name
+ * @param remoteSyncBranch - Canonical remote sync branch (destination ref)
  * @param onMergeNeeded - Callback to merge remote changes
  * @param baseDir - Repository root directory (uses process.cwd() if not provided)
  */
 export async function pushWithRetry(
-  syncBranch: string,
-  remote: string,
+  localSyncBranch: string,
+  remoteName: string,
+  remoteSyncBranch: string,
   onMergeNeeded: () => Promise<ConflictEntry[]>,
   baseDir?: string,
 ): Promise<PushResult> {
   // Use explicit refspec to avoid ambiguity with tags or other refs
-  const refspec = `refs/heads/${syncBranch}:refs/heads/${syncBranch}`;
+  const refspec = `refs/heads/${localSyncBranch}:refs/heads/${remoteSyncBranch}`;
   // Build -C prefix args when baseDir is provided
   const dirArgs = baseDir ? ['-C', baseDir] : [];
 
   for (let attempt = 1; attempt <= MAX_PUSH_RETRIES; attempt++) {
     try {
       // Try to push
-      await git(...dirArgs, 'push', remote, refspec);
+      await git(...dirArgs, 'push', remoteName, refspec);
       return { success: true, attempt };
     } catch (error) {
       if (!isNonFastForward(error)) {
@@ -653,7 +655,7 @@ export async function pushWithRetry(
       }
 
       // Fetch and merge remote changes
-      await git(...dirArgs, 'fetch', remote, syncBranch);
+      await git(...dirArgs, 'fetch', remoteName, remoteSyncBranch);
       const conflicts = await onMergeNeeded();
 
       if (conflicts.length > 0) {
@@ -710,12 +712,125 @@ export async function getRemoteUrl(remote: string): Promise<string | null> {
   }
 }
 
+/**
+ * Worktree entry parsed from `git worktree list --porcelain`.
+ */
+export interface WorktreeBranchRef {
+  path: string;
+  branch: string | null;
+  prunable: boolean;
+}
+
+/**
+ * List worktree paths and checked-out local branches.
+ */
+export async function listWorktreeBranchRefs(baseDir: string): Promise<WorktreeBranchRef[]> {
+  try {
+    const output = await git('-C', baseDir, 'worktree', 'list', '--porcelain');
+    const lines = output.split('\n');
+    const refs: WorktreeBranchRef[] = [];
+
+    let current: WorktreeBranchRef | null = null;
+    for (const line of lines) {
+      if (!line.trim()) {
+        if (current) {
+          refs.push(current);
+        }
+        current = null;
+        continue;
+      }
+
+      if (line.startsWith('worktree ')) {
+        if (current) {
+          refs.push(current);
+        }
+        current = {
+          path: line.slice('worktree '.length).trim(),
+          branch: null,
+          prunable: false,
+        };
+        continue;
+      }
+
+      if (!current) {
+        continue;
+      }
+
+      if (line.startsWith('branch ')) {
+        const ref = line.slice('branch '.length).trim();
+        current.branch = ref.startsWith('refs/heads/') ? ref.replace('refs/heads/', '') : null;
+        continue;
+      }
+
+      if (line.startsWith('prunable')) {
+        current.prunable = true;
+      }
+    }
+
+    if (current) {
+      refs.push(current);
+    }
+    return refs;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Check whether a local branch is checked out by any worktree other than the current one.
+ */
+export async function isBranchCheckedOutInOtherWorktree(
+  baseDir: string,
+  branch: string,
+  currentWorktreePath?: string,
+): Promise<boolean> {
+  const refs = await listWorktreeBranchRefs(baseDir);
+  const currentPath = currentWorktreePath
+    ? await normalizeExistingOrFallbackPath(currentWorktreePath)
+    : null;
+
+  for (const ref of refs) {
+    if (ref.prunable || ref.branch !== branch) {
+      continue;
+    }
+
+    if (currentPath) {
+      const refPath = await normalizeExistingOrFallbackPath(ref.path);
+      if (refPath === currentPath) {
+        continue;
+      }
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Normalize path values for reliable worktree-path comparisons.
+ */
+async function normalizeExistingOrFallbackPath(pathValue: string): Promise<string> {
+  try {
+    return normalizePathForComparison(await realpath(pathValue));
+  } catch {
+    return normalizePathForComparison(pathValue);
+  }
+}
+
+/**
+ * Convert paths to a canonical comparison key.
+ */
+function normalizePathForComparison(pathValue: string): string {
+  const resolved = normalizePath(resolvePath(pathValue));
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
 // =============================================================================
 // Worktree Management
 // See: tbd-design.md §2.3 Hidden Worktree Model
 // =============================================================================
 
-import { access, rm, cp } from 'node:fs/promises';
 import {
   WORKTREE_DIR,
   WORKTREE_DIR_NAME,
@@ -897,13 +1012,15 @@ export async function checkWorktreeHealth(baseDir: string): Promise<WorktreeHeal
  *
  * @param baseDir - The base directory of the repository
  * @param remote - The remote name (default: 'origin')
- * @param syncBranch - The sync branch name (default: 'tbd-sync')
+ * @param remoteSyncBranch - Canonical remote sync branch name (default: 'tbd-sync')
+ * @param localSyncBranch - Local sync branch name for this checkout
  * @returns Path to the worktree or error message
  */
 export async function initWorktree(
   baseDir: string,
   remote = 'origin',
-  syncBranch: string = SYNC_BRANCH,
+  remoteSyncBranch: string = SYNC_BRANCH,
+  localSyncBranch: string = remoteSyncBranch,
 ): Promise<{ success: boolean; path?: string; created?: boolean; error?: string }> {
   const worktreePath = join(baseDir, WORKTREE_DIR);
 
@@ -921,19 +1038,19 @@ export async function initWorktree(
 
   try {
     // Check if local branch exists
-    const localExists = await branchExists(syncBranch);
+    const localExists = await branchExists(localSyncBranch);
     if (localExists) {
       // Create worktree on local branch (no --detach, so commits update the branch)
       // Note: Don't use --detach here - we want commits to update tbd-sync branch
-      await git('-C', baseDir, 'worktree', 'add', worktreePath, syncBranch);
+      await git('-C', baseDir, 'worktree', 'add', worktreePath, localSyncBranch);
       return { success: true, path: worktreePath, created: true };
     }
 
     // Check if remote branch exists
-    const remoteExists = await remoteBranchExists(remote, syncBranch);
+    const remoteExists = await remoteBranchExists(remote, remoteSyncBranch);
     if (remoteExists) {
       // Fetch and create worktree from remote branch with local tracking branch
-      await git('-C', baseDir, 'fetch', remote, syncBranch);
+      await git('-C', baseDir, 'fetch', remote, remoteSyncBranch);
       // Use -b to create local branch tracking remote, not --detach
       // This ensures commits update the local branch which can then be pushed
       await git(
@@ -942,9 +1059,9 @@ export async function initWorktree(
         'worktree',
         'add',
         '-b',
-        syncBranch,
+        localSyncBranch,
         worktreePath,
-        `${remote}/${syncBranch}`,
+        `${remote}/${remoteSyncBranch}`,
       );
       return { success: true, path: worktreePath, created: true };
     }
@@ -952,7 +1069,7 @@ export async function initWorktree(
     // No branch exists - create orphan worktree (requires Git 2.42+)
     // Syntax: git worktree add --orphan -b <branch> <path>
     await requireGitVersion();
-    await git('-C', baseDir, 'worktree', 'add', '--orphan', '-b', syncBranch, worktreePath);
+    await git('-C', baseDir, 'worktree', 'add', '--orphan', '-b', localSyncBranch, worktreePath);
 
     // Initialize the data-sync directory structure in the worktree
     const dataSyncPath = join(worktreePath, TBD_DIR, DATA_SYNC_DIR_NAME);
@@ -985,18 +1102,20 @@ export async function initWorktree(
  *
  * @param baseDir - The base directory of the repository
  * @param remote - The remote name (default: 'origin')
- * @param syncBranch - The sync branch name (default: 'tbd-sync')
+ * @param remoteSyncBranch - Canonical remote sync branch name (default: 'tbd-sync')
+ * @param localSyncBranch - Local sync branch name for this checkout
  */
 export async function updateWorktree(
   baseDir: string,
   remote = 'origin',
-  syncBranch: string = SYNC_BRANCH,
+  remoteSyncBranch: string = SYNC_BRANCH,
+  localSyncBranch: string = remoteSyncBranch,
 ): Promise<{ success: boolean; error?: string }> {
   const worktreePath = join(baseDir, WORKTREE_DIR);
 
   // Ensure worktree exists
   if (!(await worktreeExists(baseDir))) {
-    const initResult = await initWorktree(baseDir, remote, syncBranch);
+    const initResult = await initWorktree(baseDir, remote, remoteSyncBranch, localSyncBranch);
     if (!initResult.success) {
       return { success: false, error: initResult.error };
     }
@@ -1005,7 +1124,7 @@ export async function updateWorktree(
   try {
     // Fetch latest from remote
     try {
-      await git('-C', baseDir, 'fetch', remote, syncBranch);
+      await git('-C', baseDir, 'fetch', remote, remoteSyncBranch);
     } catch {
       // Remote fetch may fail if offline - that's ok
     }
@@ -1014,7 +1133,7 @@ export async function updateWorktree(
     let targetCommit: string;
     try {
       // Try local branch first
-      targetCommit = await git('-C', baseDir, 'rev-parse', `refs/heads/${syncBranch}`);
+      targetCommit = await git('-C', baseDir, 'rev-parse', `refs/heads/${localSyncBranch}`);
     } catch {
       try {
         // Fall back to remote tracking branch
@@ -1022,7 +1141,7 @@ export async function updateWorktree(
           '-C',
           baseDir,
           'rev-parse',
-          `refs/remotes/${remote}/${syncBranch}`,
+          `refs/remotes/${remote}/${remoteSyncBranch}`,
         );
       } catch {
         // No remote either - worktree is already at latest
@@ -1093,24 +1212,30 @@ export interface RemoteBranchHealth {
  * Check remote sync branch health.
  * See: plan-2026-01-28-sync-worktree-recovery-and-hardening.md §4b
  *
- * @param remote - The remote name (default: 'origin')
- * @param syncBranch - The sync branch name (default: 'tbd-sync')
+ * @param remoteName - The remote name (default: 'origin')
+ * @param remoteSyncBranch - The remote sync branch name (default: 'tbd-sync')
+ * @param localSyncBranch - The local sync branch used for divergence checks
  * @returns Health status indicating if remote branch exists and divergence state
  */
 export async function checkRemoteBranchHealth(
-  remote = 'origin',
-  syncBranch: string = SYNC_BRANCH,
+  remoteName = 'origin',
+  remoteSyncBranch: string = SYNC_BRANCH,
+  localSyncBranch: string = remoteSyncBranch,
 ): Promise<RemoteBranchHealth> {
   try {
-    await git('fetch', remote, syncBranch);
-    const head = await git('rev-parse', `refs/remotes/${remote}/${syncBranch}`);
+    await git('fetch', remoteName, remoteSyncBranch);
+    const head = await git('rev-parse', `refs/remotes/${remoteName}/${remoteSyncBranch}`);
     const remoteHead = head.trim();
 
     // Check for divergence (only if local branch exists)
     let diverged = false;
     try {
-      const mergeBase = await git('merge-base', syncBranch, `${remote}/${syncBranch}`);
-      const localHead = await git('rev-parse', syncBranch);
+      const mergeBase = await git(
+        'merge-base',
+        localSyncBranch,
+        `${remoteName}/${remoteSyncBranch}`,
+      );
+      const localHead = await git('rev-parse', localSyncBranch);
 
       // Diverged if merge-base is neither local nor remote HEAD
       diverged = mergeBase.trim() !== localHead.trim() && mergeBase.trim() !== remoteHead;
@@ -1148,14 +1273,16 @@ export interface SyncConsistency {
  * See: plan-2026-01-28-sync-worktree-recovery-and-hardening.md §4b
  *
  * @param baseDir - The base directory of the repository
- * @param syncBranch - The sync branch name (default: 'tbd-sync')
- * @param remote - The remote name (default: 'origin')
+ * @param localSyncBranch - The local sync branch name (default: 'tbd-sync')
+ * @param remoteName - The remote name (default: 'origin')
+ * @param remoteSyncBranch - The remote sync branch name (defaults to localSyncBranch)
  * @returns Consistency status with HEAD comparisons and ahead/behind counts
  */
 export async function checkSyncConsistency(
   baseDir: string,
-  syncBranch: string = SYNC_BRANCH,
-  remote = 'origin',
+  localSyncBranch: string = SYNC_BRANCH,
+  remoteName = 'origin',
+  remoteSyncBranch: string = localSyncBranch,
 ): Promise<SyncConsistency> {
   const worktreePath = join(baseDir, WORKTREE_DIR);
 
@@ -1163,12 +1290,15 @@ export async function checkSyncConsistency(
   const worktreeHead = await git('-C', worktreePath, 'rev-parse', 'HEAD').catch(() => '');
 
   // Get local branch HEAD
-  const localHead = await git('-C', baseDir, 'rev-parse', syncBranch).catch(() => '');
+  const localHead = await git('-C', baseDir, 'rev-parse', localSyncBranch).catch(() => '');
 
   // Get remote branch HEAD
-  const remoteHead = await git('-C', baseDir, 'rev-parse', `${remote}/${syncBranch}`).catch(
-    () => '',
-  );
+  const remoteHead = await git(
+    '-C',
+    baseDir,
+    'rev-parse',
+    `${remoteName}/${remoteSyncBranch}`,
+  ).catch(() => '');
 
   // Calculate ahead/behind counts
   let localAhead = 0;
@@ -1181,7 +1311,7 @@ export async function checkSyncConsistency(
         baseDir,
         'rev-list',
         '--count',
-        `${remote}/${syncBranch}..${syncBranch}`,
+        `${remoteName}/${remoteSyncBranch}..${localSyncBranch}`,
       );
       localAhead = parseInt(aheadOutput.trim(), 10) || 0;
     } catch {
@@ -1194,7 +1324,7 @@ export async function checkSyncConsistency(
         baseDir,
         'rev-list',
         '--count',
-        `${syncBranch}..${remote}/${syncBranch}`,
+        `${localSyncBranch}..${remoteName}/${remoteSyncBranch}`,
       );
       localBehind = parseInt(behindOutput.trim(), 10) || 0;
     } catch {
@@ -1290,13 +1420,15 @@ export async function removeWorktree(
  * @param baseDir - The base directory of the repository
  * @param status - Current worktree health status
  * @param remote - The remote name (default: 'origin')
- * @param syncBranch - The sync branch name (default: 'tbd-sync')
+ * @param remoteSyncBranch - Canonical remote sync branch (default: 'tbd-sync')
+ * @param localSyncBranch - Local sync branch for this checkout
  */
 export async function repairWorktree(
   baseDir: string,
   status: 'missing' | 'prunable' | 'corrupted',
   remote = 'origin',
-  syncBranch: string = SYNC_BRANCH,
+  remoteSyncBranch: string = SYNC_BRANCH,
+  localSyncBranch: string = remoteSyncBranch,
 ): Promise<{ success: boolean; path?: string; backedUp?: string; error?: string }> {
   const worktreePath = join(baseDir, WORKTREE_DIR);
 
@@ -1328,12 +1460,12 @@ export async function repairWorktree(
       await git('-C', baseDir, 'worktree', 'prune');
 
       // Initialize fresh worktree
-      const result = await initWorktree(baseDir, remote, syncBranch);
+      const result = await initWorktree(baseDir, remote, remoteSyncBranch, localSyncBranch);
       return { ...result, backedUp: backupPath };
     }
 
     // For missing or prunable (after prune), just initialize
-    const result = await initWorktree(baseDir, remote, syncBranch);
+    const result = await initWorktree(baseDir, remote, remoteSyncBranch, localSyncBranch);
     return result;
   } catch (error) {
     return {
@@ -1349,20 +1481,29 @@ export async function repairWorktree(
  * This repairs them automatically.
  *
  * @param worktreePath - Path to the worktree directory
+ * @param expectedLocalBranch - Expected local sync branch for this checkout
  * @returns true if worktree was detached and repaired, false if already attached
  */
-export async function ensureWorktreeAttached(worktreePath: string): Promise<boolean> {
+export async function ensureWorktreeAttached(
+  worktreePath: string,
+  expectedLocalBranch: string,
+): Promise<boolean> {
   try {
     const currentBranch = await git('-C', worktreePath, 'branch', '--show-current').catch(() => '');
 
     if (!currentBranch) {
       // Detached HEAD - re-attach to sync branch
       // This is a one-time repair for repos created with old tbd versions
-      await git('-C', worktreePath, 'checkout', SYNC_BRANCH);
+      await git('-C', worktreePath, 'checkout', expectedLocalBranch);
       return true; // Was detached, now repaired
     }
 
-    return false; // Already attached
+    if (currentBranch !== expectedLocalBranch) {
+      await git('-C', worktreePath, 'checkout', expectedLocalBranch);
+      return true; // Attached to wrong branch, now repaired
+    }
+
+    return false; // Already attached to expected branch
   } catch (error) {
     // If we can't check/fix, that's a problem but don't fail the operation
     console.warn('Warning: Could not check worktree HEAD status:', error);
@@ -1384,10 +1525,12 @@ export async function ensureWorktreeAttached(worktreePath: string): Promise<bool
  *
  * @param baseDir - The base directory of the repository
  * @param removeSource - Whether to remove data from wrong location after migration
+ * @param expectedLocalBranch - Local sync branch to ensure before writing
  */
 export async function migrateDataToWorktree(
   baseDir: string,
   removeSource = false,
+  expectedLocalBranch: string = SYNC_BRANCH,
 ): Promise<{
   success: boolean;
   migratedCount: number;
@@ -1400,7 +1543,7 @@ export async function migrateDataToWorktree(
 
   try {
     // Ensure worktree is attached to sync branch (repair old tbd repos)
-    await ensureWorktreeAttached(worktreePath);
+    await ensureWorktreeAttached(worktreePath, expectedLocalBranch);
     // Check if there's data in the wrong location
     const wrongIssuesPath = join(wrongPath, 'issues');
     const wrongMappingsPath = join(wrongPath, 'mappings');
@@ -1408,13 +1551,8 @@ export async function migrateDataToWorktree(
     let issueFiles: string[] = [];
     let mappingFiles: string[] = [];
 
-    try {
-      const { readdir } = await import('node:fs/promises');
-      issueFiles = await readdir(wrongIssuesPath).catch(() => []);
-      mappingFiles = await readdir(wrongMappingsPath).catch(() => []);
-    } catch {
-      // Directory doesn't exist
-    }
+    issueFiles = await readdir(wrongIssuesPath).catch(() => []);
+    mappingFiles = await readdir(wrongMappingsPath).catch(() => []);
 
     // Filter out .gitkeep files
     issueFiles = issueFiles.filter((f) => f !== '.gitkeep');

--- a/packages/tbd/src/file/sync-branch.ts
+++ b/packages/tbd/src/file/sync-branch.ts
@@ -1,0 +1,189 @@
+/**
+ * Sync-branch resolver utilities.
+ *
+ * This module separates canonical remote sync-branch identity from the
+ * checkout-local sync branch that owns the hidden worktree.
+ */
+
+import { createHash } from 'node:crypto';
+import { realpath } from 'node:fs/promises';
+import { normalize, resolve } from 'node:path';
+
+import type { Config } from '../lib/types.js';
+import { WORKTREE_DIR } from '../lib/paths.js';
+import { readLocalState, updateLocalState } from './config.js';
+import { git, isBranchCheckedOutInOtherWorktree } from './git.js';
+
+const MANAGED_BRANCH_MARKER = '--wt-';
+const MAX_BRANCH_NAME_LENGTH = 255;
+
+/**
+ * Resolved sync branch refs for one checkout.
+ */
+export interface SyncBranchRefs {
+  /** Git remote name that hosts the canonical sync branch. */
+  remoteName: string;
+  /** Canonical shared remote sync branch from config (e.g., tbd-sync). */
+  remoteSyncBranch: string;
+  /** Local branch used by this checkout's hidden worktree. */
+  localSyncBranch: string;
+  /** Source used to resolve localSyncBranch. */
+  source: 'state' | 'canonical' | 'managed';
+}
+
+/**
+ * Resolver behavior options.
+ */
+export interface ResolveSyncBranchRefsOptions {
+  /** Persist resolved local branch to state.yml when true. */
+  forWrite?: boolean;
+}
+
+/**
+ * Build a deterministic per-checkout managed local branch name.
+ */
+export function makeManagedLocalBranchName(remoteSyncBranch: string, checkoutPath: string): string {
+  const normalizedPath = normalize(resolve(checkoutPath));
+  const fingerprint = createHash('sha1').update(normalizedPath).digest('hex').slice(0, 8);
+  const suffix = `${MANAGED_BRANCH_MARKER}${fingerprint}`;
+  const maxPrefixLength = MAX_BRANCH_NAME_LENGTH - suffix.length;
+  const prefix =
+    maxPrefixLength > 0 ? remoteSyncBranch.slice(0, maxPrefixLength) : remoteSyncBranch;
+  return `${prefix}${suffix}`;
+}
+
+/**
+ * Check if a local branch is a managed per-worktree branch for a canonical sync branch.
+ */
+export function isManagedLocalBranch(localBranch: string, remoteSyncBranch: string): boolean {
+  return localBranch.startsWith(`${remoteSyncBranch}${MANAGED_BRANCH_MARKER}`);
+}
+
+/**
+ * List all managed local branches for the canonical sync branch.
+ */
+export async function listManagedLocalBranches(
+  baseDir: string,
+  remoteSyncBranch: string,
+): Promise<string[]> {
+  try {
+    const output = await git(
+      '-C',
+      baseDir,
+      'for-each-ref',
+      '--format=%(refname:short)',
+      `refs/heads/${remoteSyncBranch}${MANAGED_BRANCH_MARKER}*`,
+    );
+    return output
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Resolve local + remote sync refs for this checkout/worktree.
+ */
+export async function resolveSyncBranchRefs(
+  baseDir: string,
+  config: Config,
+  options?: ResolveSyncBranchRefsOptions,
+): Promise<SyncBranchRefs> {
+  const forWrite = options?.forWrite === true;
+  const remoteName = config.sync.remote;
+  const remoteSyncBranch = config.sync.branch;
+  const worktreePath = joinWorktreePath(baseDir);
+
+  const state = await readLocalState(baseDir);
+  const stateBranch = state.local_sync_branch;
+
+  if (stateBranch) {
+    const stateBranchOccupiedElsewhere = await isBranchCheckedOutInOtherWorktree(
+      baseDir,
+      stateBranch,
+      worktreePath,
+    );
+    if (!stateBranchOccupiedElsewhere) {
+      return {
+        remoteName,
+        remoteSyncBranch,
+        localSyncBranch: stateBranch,
+        source: 'state',
+      };
+    }
+  }
+
+  const canonicalOccupiedElsewhere = await isBranchCheckedOutInOtherWorktree(
+    baseDir,
+    remoteSyncBranch,
+    worktreePath,
+  );
+  if (!canonicalOccupiedElsewhere) {
+    if (forWrite && stateBranch !== remoteSyncBranch) {
+      await updateLocalState(baseDir, { local_sync_branch: remoteSyncBranch });
+    }
+    return {
+      remoteName,
+      remoteSyncBranch,
+      localSyncBranch: remoteSyncBranch,
+      source: 'canonical',
+    };
+  }
+
+  const checkoutRealPath = await resolveCheckoutPath(baseDir);
+  const baseManagedName = makeManagedLocalBranchName(remoteSyncBranch, checkoutRealPath);
+  let selectedManaged = baseManagedName;
+  for (let suffixIndex = 2; ; suffixIndex += 1) {
+    const occupiedElsewhere = await isBranchCheckedOutInOtherWorktree(
+      baseDir,
+      selectedManaged,
+      worktreePath,
+    );
+    if (!occupiedElsewhere) {
+      break;
+    }
+    selectedManaged = appendManagedCollisionSuffix(baseManagedName, suffixIndex);
+  }
+
+  if (forWrite && stateBranch !== selectedManaged) {
+    await updateLocalState(baseDir, { local_sync_branch: selectedManaged });
+  }
+
+  return {
+    remoteName,
+    remoteSyncBranch,
+    localSyncBranch: selectedManaged,
+    source: 'managed',
+  };
+}
+
+/**
+ * Resolve checkout path for stable fingerprinting.
+ */
+async function resolveCheckoutPath(baseDir: string): Promise<string> {
+  try {
+    return await realpath(baseDir);
+  } catch {
+    return normalize(resolve(baseDir));
+  }
+}
+
+/**
+ * Build hidden worktree path for this checkout.
+ */
+function joinWorktreePath(baseDir: string): string {
+  return resolve(baseDir, WORKTREE_DIR);
+}
+
+/**
+ * Append deterministic collision suffix while honoring branch length limits.
+ */
+function appendManagedCollisionSuffix(baseName: string, index: number): string {
+  const suffix = `-${index}`;
+  if (baseName.length + suffix.length <= MAX_BRANCH_NAME_LENGTH) {
+    return `${baseName}${suffix}`;
+  }
+  return `${baseName.slice(0, MAX_BRANCH_NAME_LENGTH - suffix.length)}${suffix}`;
+}

--- a/packages/tbd/src/lib/schemas.ts
+++ b/packages/tbd/src/lib/schemas.ts
@@ -328,6 +328,8 @@ export const LocalStateSchema = z.object({
   last_sync_at: Timestamp.optional(),
   /** When this node last synced the doc cache successfully */
   last_doc_sync_at: Timestamp.optional(),
+  /** The local sync branch selected for this checkout/worktree */
+  local_sync_branch: GitBranchName.optional(),
   /** Whether the user has seen the welcome message */
   welcome_seen: z.boolean().optional(),
 });
@@ -457,5 +459,6 @@ export const META_FIELD_ORDER = ['schema_version', 'created_at'] as const;
 export const LOCAL_STATE_FIELD_ORDER = [
   'last_sync_at',
   'last_doc_sync_at',
+  'local_sync_branch',
   'welcome_seen',
 ] as const;

--- a/packages/tbd/tests/cli-status.tryscript.md
+++ b/packages/tbd/tests/cli-status.tryscript.md
@@ -161,6 +161,7 @@ $ tbd status --json
   "beads_detected": true,
   "beads_issue_count": 1,
   "sync_branch": "tbd-sync",
+  "local_sync_branch": "tbd-sync",
   "remote": "origin",
   "display_prefix": "bd",
 ...

--- a/packages/tbd/tests/cli-sync-remote.tryscript.md
+++ b/packages/tbd/tests/cli-sync-remote.tryscript.md
@@ -152,6 +152,8 @@ $ tbd sync --status --json
   "localChanges": [],
   "remoteChanges": [],
   "syncBranch": "tbd-sync",
+  "localSyncBranch": "tbd-sync",
+  "remoteSyncBranch": "tbd-sync",
   "remote": "origin",
   "ahead": 0,
   "behind": 0

--- a/packages/tbd/tests/cli-sync-worktree-scenarios.tryscript.md
+++ b/packages/tbd/tests/cli-sync-worktree-scenarios.tryscript.md
@@ -292,3 +292,62 @@ All worktree scenarios tested:
 2. Worktree deleted - sync --fix repairs it
 3. Data in wrong location - doctor --fix migrates it
 4. Migration commits are properly synced to remote (bug reproduction)
+5. Linked outer worktrees can sync without local branch checkout conflicts
+
+* * *
+
+## Scenario 5: Linked outer worktrees get isolated local sync branches
+
+This verifies the new split-branch model:
+- canonical remote sync branch remains `tbd-sync`
+- linked outer checkouts can each sync by using their own local sync branch
+
+# Test: Commit .tbd metadata to main so linked worktree has project setup
+
+```console
+$ git add .tbd && git commit -m "Add tbd metadata" 2>&1 | head -1
+[main [..]] Add tbd metadata
+? 0
+```
+
+# Test: Clean stale linked checkout path from prior runs
+
+```console
+$ rm -rf ../linked-checkout
+? 0
+```
+
+# Test: Create linked outer worktree on main
+
+```console
+$ git worktree add -b linked-main ../linked-checkout HEAD
+Preparing worktree [..]
+HEAD is now at [..]
+? 0
+```
+
+# Test: Linked checkout can sync successfully
+
+```console
+$ (cd ../linked-checkout && tbd sync 2>&1)
+✓ [..]
+✓ [..]
+✓ [..]
+? 0
+```
+
+# Test: Linked checkout stores a managed local sync branch in state.yml
+
+```console
+$ (cd ../linked-checkout && grep -E 'local_sync_branch: tbd-sync--wt-' .tbd/state.yml)
+local_sync_branch: tbd-sync--wt-[..]
+? 0
+```
+
+# Test: Canonical remote branch remains tbd-sync
+
+```console
+$ git ls-remote origin tbd-sync | wc -l | tr -d ' '
+1
+? 0
+```

--- a/packages/tbd/tests/config.test.ts
+++ b/packages/tbd/tests/config.test.ts
@@ -106,6 +106,14 @@ describe('config operations', () => {
       expect(state.welcome_seen).toBe(true);
     });
 
+    it('stores and reads local_sync_branch', async () => {
+      await initConfig(tempDir, '3.0.0', 'test');
+      await updateLocalState(tempDir, { local_sync_branch: 'tbd-sync--wt-a1b2c3d4' });
+
+      const state = await readLocalState(tempDir);
+      expect(state.local_sync_branch).toBe('tbd-sync--wt-a1b2c3d4');
+    });
+
     it('preserves other state fields when updating welcome_seen', async () => {
       await initConfig(tempDir, '3.0.0', 'test');
       await updateLocalState(tempDir, { last_sync_at: '2026-01-01T00:00:00Z' });

--- a/packages/tbd/tests/git-remote.test.ts
+++ b/packages/tbd/tests/git-remote.test.ts
@@ -243,6 +243,51 @@ describeUnlessWindows('git remote integration', () => {
       const issues = await listIssues(dataSyncPath);
       expect(issues.length).toBe(2);
     });
+
+    it('pushes multiple local sync branches into one canonical remote branch', async () => {
+      const localBranchA = 'tbd-sync--wt-a1b2c3d4';
+      const localBranchB = 'tbd-sync--wt-b1c2d3e4';
+
+      await initWorktree(workRepoPath, 'origin', SYNC_BRANCH, localBranchA);
+      const worktreePath = join(workRepoPath, WORKTREE_DIR);
+      const dataSyncPath = join(worktreePath, TBD_DIR, DATA_SYNC_DIR_NAME);
+
+      const issueA = createTestIssue({
+        id: testId(TEST_ULIDS.REMOTE_5),
+        title: 'Issue from local branch A',
+      });
+      await writeIssue(dataSyncPath, issueA);
+      await gitInDir(worktreePath, 'add', '.');
+      await gitInDir(worktreePath, 'commit', '-m', 'Add issue from local branch A');
+      await gitInDir(worktreePath, 'push', 'origin', `HEAD:refs/heads/${SYNC_BRANCH}`);
+
+      await gitInDir(workRepoPath, 'branch', localBranchB, localBranchA);
+      await gitInDir(worktreePath, 'checkout', localBranchB);
+
+      const issueB = createTestIssue({
+        id: testId(TEST_ULIDS.CONCURRENT_1),
+        title: 'Issue from local branch B',
+      });
+      await writeIssue(dataSyncPath, issueB);
+      await gitInDir(worktreePath, 'add', '.');
+      await gitInDir(worktreePath, 'commit', '-m', 'Add issue from local branch B');
+      await gitInDir(worktreePath, 'push', 'origin', `HEAD:refs/heads/${SYNC_BRANCH}`);
+
+      await gitInDir(workRepoPath, 'fetch', 'origin', SYNC_BRANCH);
+
+      const remoteIssueA = await gitInDir(
+        workRepoPath,
+        'show',
+        `origin/${SYNC_BRANCH}:.tbd/data-sync/issues/${issueA.id}.md`,
+      );
+      const remoteIssueB = await gitInDir(
+        workRepoPath,
+        'show',
+        `origin/${SYNC_BRANCH}:.tbd/data-sync/issues/${issueB.id}.md`,
+      );
+      expect(remoteIssueA).toContain('Issue from local branch A');
+      expect(remoteIssueB).toContain('Issue from local branch B');
+    });
   });
 
   describe('merge algorithm', () => {

--- a/packages/tbd/tests/sync-branch.test.ts
+++ b/packages/tbd/tests/sync-branch.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for local/remote sync branch resolution.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir, platform } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { initConfig, readConfig, readLocalState } from '../src/file/config.js';
+import {
+  resolveSyncBranchRefs,
+  makeManagedLocalBranchName,
+  isManagedLocalBranch,
+} from '../src/file/sync-branch.js';
+
+const execFileAsync = promisify(execFile);
+const isWindows = platform() === 'win32';
+const describeUnlessWindows = isWindows ? describe.skip : describe;
+
+async function gitInDir(dir: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, { cwd: dir });
+  return stdout.trim();
+}
+
+describeUnlessWindows('sync branch resolution', () => {
+  let testDir: string;
+  let repoPath: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    testDir = join(tmpdir(), `tbd-sync-branch-test-${randomBytes(4).toString('hex')}`);
+    repoPath = join(testDir, 'repo');
+    await mkdir(repoPath, { recursive: true });
+
+    await gitInDir(repoPath, 'init', '-b', 'main');
+    await gitInDir(repoPath, 'config', 'user.email', 'test@example.com');
+    await gitInDir(repoPath, 'config', 'user.name', 'Test User');
+    await writeFile(join(repoPath, 'README.md'), '# Test Repo\n');
+    await gitInDir(repoPath, 'add', 'README.md');
+    await gitInDir(repoPath, 'commit', '-m', 'Initial commit');
+
+    await initConfig(repoPath, '0.1.0', 'test');
+    process.chdir(repoPath);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(testDir, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  it('makeManagedLocalBranchName is deterministic', () => {
+    const a = makeManagedLocalBranchName('tbd-sync', '/tmp/my-repo');
+    const b = makeManagedLocalBranchName('tbd-sync', '/tmp/my-repo');
+    expect(a).toBe(b);
+    expect(a.startsWith('tbd-sync--wt-')).toBe(true);
+  });
+
+  it('makeManagedLocalBranchName stays within branch length limits', () => {
+    const longBranch = `sync-${'x'.repeat(300)}`;
+    const result = makeManagedLocalBranchName(longBranch, '/tmp/long-path-repo');
+    expect(result.length).toBeLessThanOrEqual(255);
+    expect(result.includes('--wt-')).toBe(true);
+  });
+
+  it('resolves canonical local branch when not occupied', async () => {
+    const config = await readConfig(repoPath);
+    const refs = await resolveSyncBranchRefs(repoPath, config, { forWrite: true });
+    expect(refs.remoteSyncBranch).toBe('tbd-sync');
+    expect(refs.localSyncBranch).toBe('tbd-sync');
+    expect(refs.source).toBe('canonical');
+
+    const state = await readLocalState(repoPath);
+    expect(state.local_sync_branch).toBe('tbd-sync');
+  });
+
+  it('uses managed local branch when canonical is checked out elsewhere', async () => {
+    const config = await readConfig(repoPath);
+
+    // Create canonical local branch and check it out in another worktree.
+    await gitInDir(repoPath, 'branch', 'tbd-sync');
+    const occupiedPath = join(testDir, 'occupied-worktree');
+    await gitInDir(repoPath, 'worktree', 'add', occupiedPath, 'tbd-sync');
+
+    const refs = await resolveSyncBranchRefs(repoPath, config, { forWrite: true });
+    expect(isManagedLocalBranch(refs.localSyncBranch, 'tbd-sync')).toBe(true);
+    expect(refs.source).toBe('managed');
+
+    const state = await readLocalState(repoPath);
+    expect(state.local_sync_branch).toBe(refs.localSyncBranch);
+  });
+
+  it('does not mutate state in read-only mode', async () => {
+    const config = await readConfig(repoPath);
+    const refs = await resolveSyncBranchRefs(repoPath, config, { forWrite: false });
+
+    expect(refs.localSyncBranch).toBe('tbd-sync');
+    const state = await readLocalState(repoPath);
+    expect(state.local_sync_branch).toBeUndefined();
+  });
+});

--- a/packages/tbd/tests/worktree-health.test.ts
+++ b/packages/tbd/tests/worktree-health.test.ts
@@ -21,6 +21,7 @@ import {
   checkGitVersion,
   repairWorktree,
   migrateDataToWorktree,
+  ensureWorktreeAttached,
 } from '../src/file/git.js';
 import { resolveDataSyncDir, WorktreeMissingError, clearPathCache } from '../src/lib/paths.js';
 import {
@@ -229,6 +230,44 @@ describeUnlessWindows('worktree health checks', () => {
 
       expect(consistency.localAhead).toBe(1);
       expect(consistency.localBehind).toBe(0);
+    });
+
+    it('supports split local and remote branch names', async () => {
+      await initWorktree(workRepoPath);
+
+      const worktreePath = join(workRepoPath, WORKTREE_DIR);
+      await gitInDir(worktreePath, 'push', '-u', 'origin', SYNC_BRANCH);
+
+      const localManaged = 'tbd-sync--wt-test';
+      await gitInDir(workRepoPath, 'branch', localManaged, SYNC_BRANCH);
+      await gitInDir(worktreePath, 'checkout', localManaged);
+
+      const consistency = await checkSyncConsistency(
+        workRepoPath,
+        localManaged,
+        'origin',
+        SYNC_BRANCH,
+      );
+      expect(consistency.worktreeMatchesLocal).toBe(true);
+      expect(consistency.localAhead).toBe(0);
+      expect(consistency.localBehind).toBe(0);
+    });
+  });
+
+  describe('ensureWorktreeAttached', () => {
+    it('reattaches detached worktree to expected local branch', async () => {
+      await initWorktree(workRepoPath);
+
+      const worktreePath = join(workRepoPath, WORKTREE_DIR);
+      const localManaged = 'tbd-sync--wt-attach';
+      await gitInDir(workRepoPath, 'branch', localManaged, SYNC_BRANCH);
+      await gitInDir(worktreePath, 'checkout', '--detach');
+
+      const repaired = await ensureWorktreeAttached(worktreePath, localManaged);
+      expect(repaired).toBe(true);
+
+      const currentBranch = await gitInDir(worktreePath, 'branch', '--show-current');
+      expect(currentBranch).toBe(localManaged);
     });
   });
 });


### PR DESCRIPTION
Moves commit 1901a43 off main after restoring main to 1ad0234.

This keeps the change reviewable in a PR instead of directly on main.