### PR TITLE
fix: reuse sync worktree across linked checkouts

### DIFF
--- a/packages/tbd/src/cli/commands/doctor.ts
+++ b/packages/tbd/src/cli/commands/doctor.ts
@@ -64,7 +64,7 @@ class DoctorHandler extends BaseCommand {
     const tbdRoot = await requireInit();
 
     this.cwd = tbdRoot;
-    this.dataSyncDir = await resolveDataSyncDir(tbdRoot);
+    this.dataSyncDir = await resolveDataSyncDir(tbdRoot, { allowFallback: true });
 
     // Load config
     try {
@@ -125,7 +125,7 @@ class DoctorHandler extends BaseCommand {
     // If data was migrated, reload issues and refresh dataSyncDir so
     // subsequent checks (especially ID mappings) see the current state.
     if (dataLocationResult.status === 'ok' && dataLocationResult.message?.includes('migrated')) {
-      this.dataSyncDir = await resolveDataSyncDir(this.cwd);
+      this.dataSyncDir = await resolveDataSyncDir(this.cwd, { allowFallback: true });
       try {
         this.issues = await listIssues(this.dataSyncDir);
       } catch {
@@ -742,8 +742,8 @@ class DoctorHandler extends BaseCommand {
    * See: plan-2026-01-28-sync-worktree-recovery-and-hardening.md §4
    */
   private async checkWorktree(fix?: boolean): Promise<DiagnosticResult> {
-    const worktreePath = WORKTREE_DIR;
     const worktreeHealth = await checkWorktreeHealth(this.cwd);
+    const worktreePath = worktreeHealth.path ?? join(this.cwd, WORKTREE_DIR);
 
     switch (worktreeHealth.status) {
       case 'valid':

--- a/packages/tbd/src/cli/commands/status.ts
+++ b/packages/tbd/src/cli/commands/status.ts
@@ -240,9 +240,8 @@ class StatusHandler extends BaseCommand {
     }
 
     // Check worktree health
-    const worktreePath = join(cwd, WORKTREE_DIR);
     const worktreeHealth = await checkWorktreeHealth(cwd);
-    data.worktree_path = worktreePath;
+    data.worktree_path = worktreeHealth.path ?? join(cwd, WORKTREE_DIR);
     data.worktree_healthy = worktreeHealth.valid;
 
     // Check workspaces

--- a/packages/tbd/src/cli/commands/sync.ts
+++ b/packages/tbd/src/cli/commands/sync.ts
@@ -81,6 +81,7 @@ interface SyncStatus {
 class SyncHandler extends BaseCommand {
   private dataSyncDir = '';
   private tbdRoot = '';
+  private worktreePath = '';
 
   async run(options: SyncOptions): Promise<void> {
     const tbdRoot = await requireInit();
@@ -155,6 +156,7 @@ class SyncHandler extends BaseCommand {
       }
     }
 
+    this.worktreePath = worktreeHealth.path ?? join(tbdRoot, WORKTREE_DIR);
     this.dataSyncDir = await resolveDataSyncDir(tbdRoot);
 
     // Load config to get sync branch
@@ -366,8 +368,7 @@ class SyncHandler extends BaseCommand {
     // Now check worktree status directly.
     // See: plan-2026-01-28-sync-worktree-recovery-and-hardening.md
     try {
-      const worktreePath = join(this.tbdRoot, WORKTREE_DIR);
-      const status = await git('-C', worktreePath, 'status', '--porcelain');
+      const status = await git('-C', this.worktreePath, 'status', '--porcelain');
       if (status) {
         for (const line of status.split('\n')) {
           if (!line) continue;
@@ -499,14 +500,12 @@ class SyncHandler extends BaseCommand {
     // Use tbdRoot to derive worktree path consistently
     // FIX Bug 1: Previously used process.cwd() which fails if not in repo root
     // See: plan-2026-01-28-sync-worktree-recovery-and-hardening.md
-    const worktreePath = join(this.tbdRoot, WORKTREE_DIR);
-
     try {
       // Ensure worktree is attached to sync branch (repair old tbd repos)
-      await ensureWorktreeAttached(worktreePath);
+      await ensureWorktreeAttached(this.worktreePath);
 
       // Check for uncommitted changes (untracked, modified, or deleted)
-      const status = await git('-C', worktreePath, 'status', '--porcelain');
+      const status = await git('-C', this.worktreePath, 'status', '--porcelain');
       if (!status || status.trim() === '') {
         return emptyTallies(); // Nothing to commit
       }
@@ -516,13 +515,13 @@ class SyncHandler extends BaseCommand {
       const fileCount = tallies.new + tallies.updated + tallies.deleted;
 
       // Stage all changes
-      await git('-C', worktreePath, 'add', '-A');
+      await git('-C', this.worktreePath, 'add', '-A');
 
       // Commit the changes
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
       await git(
         '-C',
-        worktreePath,
+        this.worktreePath,
         'commit',
         '-m',
         `tbd sync: ${timestamp} (${fileCount} file${fileCount === 1 ? '' : 's'})`,
@@ -669,8 +668,6 @@ class SyncHandler extends BaseCommand {
     const spinner = this.output.spinner('Syncing with remote...');
     const summary: SyncSummary = emptySummary();
     const conflicts: ConflictEntry[] = [];
-    // Use tbdRoot for consistent path resolution
-    const worktreePath = join(this.tbdRoot, WORKTREE_DIR);
 
     try {
       // STEP 1: Commit local changes FIRST (before pulling)
@@ -726,7 +723,7 @@ class SyncHandler extends BaseCommand {
         // Track HEAD before merge for debug log
         let headBeforeMerge = '';
         try {
-          headBeforeMerge = (await git('-C', worktreePath, 'rev-parse', 'HEAD')).trim();
+          headBeforeMerge = (await git('-C', this.worktreePath, 'rev-parse', 'HEAD')).trim();
         } catch {
           // Ignore - just won't show debug log
         }
@@ -736,7 +733,7 @@ class SyncHandler extends BaseCommand {
         try {
           await git(
             '-C',
-            worktreePath,
+            this.worktreePath,
             'merge',
             `${remote}/${syncBranch}`,
             '-m',
@@ -782,11 +779,11 @@ class SyncHandler extends BaseCommand {
           if (totalReconciled > 0) {
             await saveIdMapping(this.dataSyncDir, postMergeMapping);
             // Commit the updated mapping so it's included in the push
-            await git('-C', worktreePath, 'add', '-A');
+            await git('-C', this.worktreePath, 'add', '-A');
             try {
               await git(
                 '-C',
-                worktreePath,
+                this.worktreePath,
                 'commit',
                 '--no-verify',
                 '-m',
@@ -881,14 +878,14 @@ class SyncHandler extends BaseCommand {
 
           // Stage resolved files and complete merge
           // Use --no-verify to bypass parent repo hooks (lefthook, husky, etc.)
-          await git('-C', worktreePath, 'add', '-A');
+          await git('-C', this.worktreePath, 'add', '-A');
 
           // SAFETY CHECK: Never commit files with unresolved merge conflict markers
           // This prevents the bug where ids.yml or other files get committed with
           // <<<<<<< HEAD markers still present
           const conflictCheck = await git(
             '-C',
-            worktreePath,
+            this.worktreePath,
             'diff',
             '--cached',
             '-S<<<<<<< ',
@@ -900,14 +897,14 @@ class SyncHandler extends BaseCommand {
               `Cannot commit: ${conflictedFiles.length} file(s) still have merge conflict markers:\n` +
                 conflictedFiles.map((f) => `  - ${f}`).join('\n') +
                 `\n\nThis is a bug in tbd sync. Please report it and manually resolve conflicts in:\n` +
-                `  ${worktreePath}`,
+                `  ${this.worktreePath}`,
             );
           }
 
           try {
             await git(
               '-C',
-              worktreePath,
+              this.worktreePath,
               'commit',
               '--no-verify',
               '-m',

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -12,7 +12,7 @@
 import { execFile } from 'node:child_process';
 import { mkdir } from 'node:fs/promises';
 import { promisify } from 'node:util';
-import { join } from 'node:path';
+import { join, normalize } from 'node:path';
 
 import { writeFile } from 'atomically';
 
@@ -717,21 +717,81 @@ export async function getRemoteUrl(remote: string): Promise<string | null> {
 
 import { access, rm, cp } from 'node:fs/promises';
 import {
-  WORKTREE_DIR,
   WORKTREE_DIR_NAME,
   TBD_DIR,
   DATA_SYNC_DIR_NAME,
   SYNC_BRANCH,
+  clearPathCache,
+  getDataSyncDirForWorktree,
+  getLocalSyncWorktreePath,
+  resolveSyncWorktreePath,
 } from '../lib/paths.js';
+
+interface RegisteredGitWorktree {
+  path: string;
+  prunable: boolean;
+}
+
+const SYNC_WORKTREE_SUFFIX = normalize(join(TBD_DIR, WORKTREE_DIR_NAME));
+
+function isSyncWorktreePath(worktreePath: string): boolean {
+  return normalize(worktreePath).endsWith(SYNC_WORKTREE_SUFFIX);
+}
+
+async function listRegisteredSyncWorktrees(baseDir: string): Promise<RegisteredGitWorktree[]> {
+  try {
+    const worktreeList = await git('-C', baseDir, 'worktree', 'list', '--porcelain');
+    const worktrees: RegisteredGitWorktree[] = [];
+    let current: RegisteredGitWorktree | null = null;
+
+    for (const line of worktreeList.split('\n')) {
+      if (line.startsWith('worktree ')) {
+        if (current && isSyncWorktreePath(current.path)) {
+          worktrees.push(current);
+        }
+        current = {
+          path: line.slice('worktree '.length),
+          prunable: false,
+        };
+        continue;
+      }
+
+      if (!current) {
+        continue;
+      }
+
+      if (line.startsWith('prunable')) {
+        current.prunable = true;
+      }
+
+      if (line === '') {
+        if (isSyncWorktreePath(current.path)) {
+          worktrees.push(current);
+        }
+        current = null;
+      }
+    }
+
+    if (current && isSyncWorktreePath(current.path)) {
+      worktrees.push(current);
+    }
+
+    return worktrees;
+  } catch {
+    return [];
+  }
+}
 
 /**
  * Check if the hidden worktree exists and is valid.
  */
 export async function worktreeExists(baseDir: string): Promise<boolean> {
-  const worktreePath = join(baseDir, WORKTREE_DIR);
+  const worktreePath = await resolveSyncWorktreePath(baseDir);
+  if (!worktreePath) {
+    return false;
+  }
+
   try {
-    await access(worktreePath);
-    // Also verify it's a valid git worktree by checking for .git file
     await access(join(worktreePath, '.git'));
     return true;
   } catch {
@@ -749,6 +809,8 @@ export type WorktreeStatus = 'valid' | 'missing' | 'prunable' | 'corrupted';
  * Worktree health status.
  */
 export interface WorktreeHealth {
+  /** The resolved worktree path, which may be in another linked checkout */
+  path: string | null;
   /** Whether the worktree directory exists on disk */
   exists: boolean;
   /** Whether the worktree is valid and functional */
@@ -769,124 +831,105 @@ export interface WorktreeHealth {
  * See: plan-2026-01-28-sync-worktree-recovery-and-hardening.md §3
  */
 export async function checkWorktreeHealth(baseDir: string): Promise<WorktreeHealth> {
-  const worktreePath = join(baseDir, WORKTREE_DIR);
+  const localWorktreePath = getLocalSyncWorktreePath(baseDir);
+  const registeredSyncWorktrees = await listRegisteredSyncWorktrees(baseDir);
+  const activeWorktree = registeredSyncWorktrees.find((entry) => !entry.prunable);
 
-  // First check if git reports the worktree as prunable
-  // This catches the case where worktree directory was deleted but git still tracks it
-  try {
-    const worktreeList = await git('-C', baseDir, 'worktree', 'list', '--porcelain');
+  if (activeWorktree) {
+    const worktreePath = activeWorktree.path;
 
-    // Check if our worktree path appears in the list as prunable
-    const lines = worktreeList.split('\n');
-    let foundWorktree = false;
-    let isPrunable = false;
-
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i];
-      // Check if this entry is for our worktree path
-      if (line?.startsWith('worktree ') && line.includes(WORKTREE_DIR_NAME)) {
-        foundWorktree = true;
-        // Look for prunable marker in subsequent lines until next worktree entry
-        for (let j = i + 1; j < lines.length && !lines[j]?.startsWith('worktree '); j++) {
-          if (lines[j]?.startsWith('prunable')) {
-            isPrunable = true;
-            break;
-          }
-        }
-        break;
-      }
-    }
-
-    if (isPrunable) {
+    try {
+      await access(worktreePath);
+    } catch {
       return {
+        path: worktreePath,
         exists: false,
         valid: false,
-        status: 'prunable',
+        status: 'corrupted',
         branch: null,
         commit: null,
-        error: 'Worktree directory was deleted but git still tracks it. Run: git worktree prune',
+        error: 'Worktree is registered with git but missing on disk',
       };
     }
 
-    // If git doesn't know about the worktree, check if directory exists
-    if (!foundWorktree) {
-      try {
-        await access(worktreePath);
-        // Directory exists but git doesn't know about it - corrupted
-        return {
-          exists: true,
-          valid: false,
-          status: 'corrupted',
-          branch: null,
-          commit: null,
-          error: 'Worktree directory exists but is not registered with git',
-        };
-      } catch {
-        // Directory doesn't exist and git doesn't know about it - missing
-        return {
-          exists: false,
-          valid: false,
-          status: 'missing',
-          branch: null,
-          commit: null,
-        };
-      }
+    try {
+      await access(join(worktreePath, '.git'));
+    } catch {
+      return {
+        path: worktreePath,
+        exists: true,
+        valid: false,
+        status: 'corrupted',
+        branch: null,
+        commit: null,
+        error: 'Worktree directory exists but is not a valid git worktree (missing .git)',
+      };
     }
-  } catch {
-    // git worktree list failed - likely not in a git repo
-    // Fall through to directory-based checks
+
+    try {
+      const commit = await git('-C', worktreePath, 'rev-parse', 'HEAD');
+      let branch: string | null = null;
+
+      try {
+        const refName = await git('-C', worktreePath, 'symbolic-ref', '-q', 'HEAD');
+        branch = refName.replace('refs/heads/', '');
+      } catch {
+        branch = null;
+      }
+
+      return {
+        path: worktreePath,
+        exists: true,
+        valid: true,
+        status: 'valid',
+        branch,
+        commit,
+      };
+    } catch (error) {
+      return {
+        path: worktreePath,
+        exists: true,
+        valid: false,
+        status: 'corrupted',
+        branch: null,
+        commit: null,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
   }
 
-  // Check if worktree directory exists
+  const prunableWorktree = registeredSyncWorktrees.find((entry) => entry.prunable);
+  if (prunableWorktree) {
+    return {
+      path: prunableWorktree.path,
+      exists: false,
+      valid: false,
+      status: 'prunable',
+      branch: null,
+      commit: null,
+      error: 'Worktree directory was deleted but git still tracks it. Run: git worktree prune',
+    };
+  }
+
   try {
-    await access(worktreePath);
+    await access(localWorktreePath);
+    return {
+      path: localWorktreePath,
+      exists: true,
+      valid: false,
+      status: 'corrupted',
+      branch: null,
+      commit: null,
+      error: 'Worktree directory exists but is not registered with git',
+    };
   } catch {
     return {
+      path: localWorktreePath,
       exists: false,
       valid: false,
       status: 'missing',
       branch: null,
       commit: null,
-    };
-  }
-
-  // Check if it's a valid git worktree
-  try {
-    await access(join(worktreePath, '.git'));
-  } catch {
-    return {
-      exists: true,
-      valid: false,
-      status: 'corrupted',
-      branch: null,
-      commit: null,
-      error: 'Worktree directory exists but is not a valid git worktree (missing .git)',
-    };
-  }
-
-  // Get current commit and branch info
-  try {
-    const commit = await git('-C', worktreePath, 'rev-parse', 'HEAD');
-    let branch: string | null = null;
-
-    try {
-      // Check if we're on detached HEAD pointing to tbd-sync
-      const refName = await git('-C', worktreePath, 'symbolic-ref', '-q', 'HEAD');
-      branch = refName.replace('refs/heads/', '');
-    } catch {
-      // Detached HEAD - expected state
-      branch = null;
-    }
-
-    return { exists: true, valid: true, status: 'valid', branch, commit };
-  } catch (error) {
-    return {
-      exists: true,
-      valid: false,
-      status: 'corrupted',
-      branch: null,
-      commit: null,
-      error: error instanceof Error ? error.message : String(error),
     };
   }
 }
@@ -905,12 +948,24 @@ export async function initWorktree(
   remote = 'origin',
   syncBranch: string = SYNC_BRANCH,
 ): Promise<{ success: boolean; path?: string; created?: boolean; error?: string }> {
-  const worktreePath = join(baseDir, WORKTREE_DIR);
-
-  // Check if worktree already exists and is valid
-  if (await worktreeExists(baseDir)) {
-    return { success: true, path: worktreePath, created: false };
+  const worktreeHealth = await checkWorktreeHealth(baseDir);
+  if (worktreeHealth.status === 'valid' && worktreeHealth.path) {
+    return { success: true, path: worktreeHealth.path, created: false };
   }
+
+  if (worktreeHealth.status === 'corrupted' && worktreeHealth.path) {
+    return {
+      success: false,
+      error: `Existing sync worktree is corrupted at ${worktreeHealth.path}. Run 'tbd doctor --fix' to repair.`,
+    };
+  }
+
+  if (worktreeHealth.status === 'prunable') {
+    await git('-C', baseDir, 'worktree', 'prune');
+    clearPathCache();
+  }
+
+  const worktreePath = getLocalSyncWorktreePath(baseDir);
 
   // Remove any stale worktree directory
   try {
@@ -926,6 +981,7 @@ export async function initWorktree(
       // Create worktree on local branch (no --detach, so commits update the branch)
       // Note: Don't use --detach here - we want commits to update tbd-sync branch
       await git('-C', baseDir, 'worktree', 'add', worktreePath, syncBranch);
+      clearPathCache();
       return { success: true, path: worktreePath, created: true };
     }
 
@@ -946,6 +1002,7 @@ export async function initWorktree(
         worktreePath,
         `${remote}/${syncBranch}`,
       );
+      clearPathCache();
       return { success: true, path: worktreePath, created: true };
     }
 
@@ -970,6 +1027,7 @@ export async function initWorktree(
     await git('-C', worktreePath, 'add', '.');
     await git('-C', worktreePath, 'commit', '--no-verify', '-m', 'Initialize tbd-sync branch');
 
+    clearPathCache();
     return { success: true, path: worktreePath, created: true };
   } catch (error) {
     return {
@@ -992,14 +1050,15 @@ export async function updateWorktree(
   remote = 'origin',
   syncBranch: string = SYNC_BRANCH,
 ): Promise<{ success: boolean; error?: string }> {
-  const worktreePath = join(baseDir, WORKTREE_DIR);
+  let worktreePath = await resolveSyncWorktreePath(baseDir);
 
   // Ensure worktree exists
-  if (!(await worktreeExists(baseDir))) {
+  if (!worktreePath) {
     const initResult = await initWorktree(baseDir, remote, syncBranch);
-    if (!initResult.success) {
+    if (!initResult.success || !initResult.path) {
       return { success: false, error: initResult.error };
     }
+    worktreePath = initResult.path;
   }
 
   try {
@@ -1157,10 +1216,12 @@ export async function checkSyncConsistency(
   syncBranch: string = SYNC_BRANCH,
   remote = 'origin',
 ): Promise<SyncConsistency> {
-  const worktreePath = join(baseDir, WORKTREE_DIR);
+  const worktreePath = await resolveSyncWorktreePath(baseDir);
 
   // Get worktree HEAD
-  const worktreeHead = await git('-C', worktreePath, 'rev-parse', 'HEAD').catch(() => '');
+  const worktreeHead = worktreePath
+    ? await git('-C', worktreePath, 'rev-parse', 'HEAD').catch(() => '')
+    : '';
 
   // Get local branch HEAD
   const localHead = await git('-C', baseDir, 'rev-parse', syncBranch).catch(() => '');
@@ -1254,7 +1315,8 @@ export async function countRemoteIssues(
 export async function removeWorktree(
   baseDir: string,
 ): Promise<{ success: boolean; error?: string }> {
-  const worktreePath = join(baseDir, WORKTREE_DIR);
+  const worktreePath =
+    (await resolveSyncWorktreePath(baseDir)) ?? getLocalSyncWorktreePath(baseDir);
 
   try {
     // First try to properly remove via git
@@ -1267,6 +1329,7 @@ export async function removeWorktree(
 
     // Prune stale worktree references
     await git('-C', baseDir, 'worktree', 'prune');
+    clearPathCache();
 
     return { success: true };
   } catch (error) {
@@ -1298,13 +1361,15 @@ export async function repairWorktree(
   remote = 'origin',
   syncBranch: string = SYNC_BRANCH,
 ): Promise<{ success: boolean; path?: string; backedUp?: string; error?: string }> {
-  const worktreePath = join(baseDir, WORKTREE_DIR);
+  const worktreeHealth = await checkWorktreeHealth(baseDir);
+  const worktreePath = worktreeHealth.path ?? getLocalSyncWorktreePath(baseDir);
 
   try {
     // Always prune stale worktree entries first for missing and prunable states
     // This ensures git's worktree list is clean before creating a new worktree
     if (status === 'missing' || status === 'prunable') {
       await git('-C', baseDir, 'worktree', 'prune');
+      clearPathCache();
     }
 
     // Handle corrupted status: backup before removal
@@ -1324,8 +1389,13 @@ export async function repairWorktree(
       }
 
       // Remove the corrupted worktree
-      await rm(worktreePath, { recursive: true, force: true });
+      try {
+        await git('-C', baseDir, 'worktree', 'remove', worktreePath, '--force');
+      } catch {
+        await rm(worktreePath, { recursive: true, force: true });
+      }
       await git('-C', baseDir, 'worktree', 'prune');
+      clearPathCache();
 
       // Initialize fresh worktree
       const result = await initWorktree(baseDir, remote, syncBranch);
@@ -1395,8 +1465,9 @@ export async function migrateDataToWorktree(
   error?: string;
 }> {
   const wrongPath = join(baseDir, TBD_DIR, DATA_SYNC_DIR_NAME);
-  const correctPath = join(baseDir, WORKTREE_DIR, TBD_DIR, DATA_SYNC_DIR_NAME);
-  const worktreePath = join(baseDir, WORKTREE_DIR);
+  const worktreePath =
+    (await resolveSyncWorktreePath(baseDir)) ?? getLocalSyncWorktreePath(baseDir);
+  const correctPath = getDataSyncDirForWorktree(worktreePath);
 
   try {
     // Ensure worktree is attached to sync branch (repair old tbd repos)

--- a/packages/tbd/src/lib/paths.ts
+++ b/packages/tbd/src/lib/paths.ts
@@ -24,7 +24,11 @@
  *       meta.yml
  */
 
-import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { access } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { isAbsolute, join, normalize } from 'node:path';
+import { promisify } from 'node:util';
 
 /** The tbd configuration directory on main branch */
 export const TBD_DIR = '.tbd';
@@ -61,6 +65,20 @@ export const DATA_SYNC_DIR = join(TBD_DIR, DATA_SYNC_DIR_NAME);
  * Use this once worktree management is implemented.
  */
 export const DATA_SYNC_DIR_VIA_WORKTREE = join(WORKTREE_DIR, TBD_DIR, DATA_SYNC_DIR_NAME);
+
+/**
+ * Get the local default path for the hidden sync worktree in a checkout.
+ */
+export function getLocalSyncWorktreePath(baseDir: string): string {
+  return join(baseDir, WORKTREE_DIR);
+}
+
+/**
+ * Get the data-sync directory path inside a specific sync worktree.
+ */
+export function getDataSyncDirForWorktree(worktreePath: string): string {
+  return join(worktreePath, TBD_DIR, DATA_SYNC_DIR_NAME);
+}
 
 /** Issues directory */
 export const ISSUES_DIR = join(DATA_SYNC_DIR, 'issues');
@@ -270,7 +288,81 @@ export function getAtticPath(issueId: string, filename: string): string {
 // Dynamic Path Resolution
 // =============================================================================
 
-import { access } from 'node:fs/promises';
+const execFileAsync = promisify(execFile);
+
+interface GitWorktreeListEntry {
+  path: string;
+  prunable: boolean;
+}
+
+const SYNC_WORKTREE_SUFFIX = normalize(join(TBD_DIR, WORKTREE_DIR_NAME));
+
+async function isAccessiblePath(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isValidWorktreePath(worktreePath: string): Promise<boolean> {
+  return (
+    (await isAccessiblePath(worktreePath)) && (await isAccessiblePath(join(worktreePath, '.git')))
+  );
+}
+
+function isSyncWorktreePath(worktreePath: string): boolean {
+  return normalize(worktreePath).endsWith(SYNC_WORKTREE_SUFFIX);
+}
+
+async function listRegisteredWorktrees(baseDir: string): Promise<GitWorktreeListEntry[]> {
+  try {
+    const { stdout } = await execFileAsync('git', [
+      '-C',
+      baseDir,
+      'worktree',
+      'list',
+      '--porcelain',
+    ]);
+    const entries: GitWorktreeListEntry[] = [];
+    let current: GitWorktreeListEntry | null = null;
+
+    for (const line of stdout.split('\n')) {
+      if (line.startsWith('worktree ')) {
+        if (current) {
+          entries.push(current);
+        }
+        current = {
+          path: line.slice('worktree '.length),
+          prunable: false,
+        };
+        continue;
+      }
+
+      if (!current) {
+        continue;
+      }
+
+      if (line.startsWith('prunable')) {
+        current.prunable = true;
+      }
+
+      if (line === '') {
+        entries.push(current);
+        current = null;
+      }
+    }
+
+    if (current) {
+      entries.push(current);
+    }
+
+    return entries;
+  } catch {
+    return [];
+  }
+}
 
 /**
  * Options for resolveDataSyncDir.
@@ -279,7 +371,7 @@ export interface ResolveDataSyncDirOptions {
   /**
    * Allow fallback to direct path when worktree is missing.
    * Set to true for test environments or diagnostic tools.
-   * Default: true. When false and worktree is missing, throws WorktreeMissingError.
+   * Default: false. When false and worktree is missing, throws WorktreeMissingError.
    */
   allowFallback?: boolean;
 }
@@ -290,7 +382,7 @@ export interface ResolveDataSyncDirOptions {
  */
 export class WorktreeMissingError extends Error {
   constructor(
-    message = "Worktree not found at .tbd/data-sync-worktree/. Run 'tbd doctor --fix' to repair.",
+    message = "No active sync worktree found for this clone. Run 'tbd doctor --fix' to repair.",
   ) {
     super(message);
     this.name = 'WorktreeMissingError';
@@ -298,12 +390,53 @@ export class WorktreeMissingError extends Error {
 }
 
 /**
- * Cache for resolved data sync directory.
- * Reset when baseDir changes.
+ * Cache for resolved sync worktree path.
  */
-let _resolvedDataSyncDir: string | null = null;
+let _resolvedSyncWorktreePath: string | null = null;
 let _resolvedBaseDir: string | null = null;
-let _resolvedAllowFallback: boolean | null = null;
+
+/**
+ * Resolve the active sync worktree path for this git clone.
+ *
+ * Resolution order:
+ * 1. Current checkout's local .tbd/data-sync-worktree/
+ * 2. Another registered worktree in the same clone whose path ends with
+ *    .tbd/data-sync-worktree
+ *
+ * Returns null when no active sync worktree is available.
+ */
+export async function resolveSyncWorktreePath(baseDir: string): Promise<string | null> {
+  if (
+    _resolvedSyncWorktreePath &&
+    _resolvedBaseDir === baseDir &&
+    (await isValidWorktreePath(_resolvedSyncWorktreePath))
+  ) {
+    return _resolvedSyncWorktreePath;
+  }
+
+  const localWorktreePath = getLocalSyncWorktreePath(baseDir);
+  if (await isValidWorktreePath(localWorktreePath)) {
+    _resolvedSyncWorktreePath = localWorktreePath;
+    _resolvedBaseDir = baseDir;
+    return localWorktreePath;
+  }
+
+  const registeredWorktrees = await listRegisteredWorktrees(baseDir);
+  for (const worktree of registeredWorktrees) {
+    if (worktree.prunable || !isSyncWorktreePath(worktree.path)) {
+      continue;
+    }
+    if (await isValidWorktreePath(worktree.path)) {
+      _resolvedSyncWorktreePath = worktree.path;
+      _resolvedBaseDir = baseDir;
+      return worktree.path;
+    }
+  }
+
+  _resolvedSyncWorktreePath = null;
+  _resolvedBaseDir = null;
+  return null;
+}
 
 /**
  * Resolve the actual data sync directory path.
@@ -312,7 +445,7 @@ let _resolvedAllowFallback: boolean | null = null;
  * (production) or in a test environment without worktree.
  *
  * Order of preference:
- * 1. Worktree path if worktree exists: .tbd/data-sync-worktree/.tbd/data-sync/
+ * 1. Active sync worktree path for this clone
  * 2. Direct path as fallback (only if allowFallback: true)
  *
  * @param baseDir - The tbd root directory (from requireInit or findTbdRoot)
@@ -326,46 +459,26 @@ export async function resolveDataSyncDir(
   baseDir: string,
   options?: ResolveDataSyncDirOptions,
 ): Promise<string> {
-  const allowFallback = options?.allowFallback ?? true;
+  const allowFallback = options?.allowFallback ?? false;
 
-  // Return cached result if baseDir and options haven't changed
-  if (
-    _resolvedDataSyncDir &&
-    _resolvedBaseDir === baseDir &&
-    _resolvedAllowFallback === allowFallback
-  ) {
-    return _resolvedDataSyncDir;
-  }
-
-  const worktreePath = join(baseDir, DATA_SYNC_DIR_VIA_WORKTREE);
+  const resolvedWorktreePath = await resolveSyncWorktreePath(baseDir);
   const directPath = join(baseDir, DATA_SYNC_DIR);
 
-  // Check if worktree path exists
-  try {
-    await access(worktreePath);
-    _resolvedDataSyncDir = worktreePath;
-    _resolvedBaseDir = baseDir;
-    _resolvedAllowFallback = allowFallback;
-    return worktreePath;
-  } catch {
-    // Worktree doesn't exist
-    if (!allowFallback) {
-      throw new WorktreeMissingError();
-    }
-
-    // Fallback to direct path (test mode or diagnostic tools)
-    // Note: In production, sync.ts checks worktree health before calling this
-    // Debug warning to help detect unintended fallback usage
-    if (process.env.DEBUG || process.env.TBD_DEBUG) {
-      console.warn(
-        '[tbd:paths] resolveDataSyncDir: worktree not found, falling back to direct path',
-      );
-    }
-    _resolvedDataSyncDir = directPath;
-    _resolvedBaseDir = baseDir;
-    _resolvedAllowFallback = allowFallback;
-    return directPath;
+  if (resolvedWorktreePath) {
+    return getDataSyncDirForWorktree(resolvedWorktreePath);
   }
+
+  if (!allowFallback) {
+    throw new WorktreeMissingError();
+  }
+
+  if (process.env.DEBUG || process.env.TBD_DEBUG) {
+    console.warn(
+      '[tbd:paths] resolveDataSyncDir: active sync worktree not found, falling back to direct path',
+    );
+  }
+
+  return directPath;
 }
 
 /**
@@ -406,17 +519,13 @@ export async function resolveAtticDir(
  * Call this when the repository state changes (e.g., after init).
  */
 export function clearPathCache(): void {
-  _resolvedDataSyncDir = null;
+  _resolvedSyncWorktreePath = null;
   _resolvedBaseDir = null;
-  _resolvedAllowFallback = null;
 }
 
 // =============================================================================
 // Doc Path Resolution
 // =============================================================================
-
-import { isAbsolute } from 'node:path';
-import { homedir } from 'node:os';
 
 /**
  * Resolve a doc path for consistent handling across the codebase.

--- a/packages/tbd/tests/linked-worktree.test.ts
+++ b/packages/tbd/tests/linked-worktree.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Regression tests for linked git worktree support.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, realpath, rm, writeFile as fsWriteFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir, platform } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { checkGitVersion, checkWorktreeHealth, initWorktree } from '../src/file/git.js';
+import {
+  SYNC_BRANCH,
+  WORKTREE_DIR_NAME,
+  getDataSyncDirForWorktree,
+  resolveDataSyncDir,
+  resolveSyncWorktreePath,
+  clearPathCache,
+} from '../src/lib/paths.js';
+
+const execFileAsync = promisify(execFile);
+
+const isWindows = platform() === 'win32';
+const describeUnlessWindows = isWindows ? describe.skip : describe;
+
+async function gitInDir(dir: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, { cwd: dir });
+  return stdout.trim();
+}
+
+async function initRepo(repoPath: string): Promise<void> {
+  await mkdir(repoPath, { recursive: true });
+  await gitInDir(repoPath, 'init', '-b', 'main');
+  await gitInDir(repoPath, 'config', 'user.email', 'test@test.com');
+  await gitInDir(repoPath, 'config', 'user.name', 'Test User');
+  await gitInDir(repoPath, 'config', 'commit.gpgsign', 'false');
+
+  await fsWriteFile(join(repoPath, 'README.md'), '# Linked Worktree Test Repo\n');
+  await gitInDir(repoPath, 'add', 'README.md');
+  await gitInDir(repoPath, 'commit', '-m', 'Initial commit');
+}
+
+async function addLinkedCheckout(
+  repoPath: string,
+  linkedPath: string,
+  branchName: string,
+): Promise<void> {
+  await gitInDir(repoPath, 'worktree', 'add', '-b', branchName, linkedPath, 'HEAD');
+}
+
+async function countSyncWorktrees(repoPath: string): Promise<number> {
+  const worktreeList = await gitInDir(repoPath, 'worktree', 'list', '--porcelain');
+  return worktreeList
+    .split('\n')
+    .filter((line) => line.startsWith('worktree ') && line.includes(WORKTREE_DIR_NAME)).length;
+}
+
+async function canonicalizePath(path: string): Promise<string> {
+  return realpath(path).catch(() => path);
+}
+
+describeUnlessWindows('linked git worktree support', () => {
+  let testDir: string;
+  let mainRepoPath: string;
+  let linkedRepoPath: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    const { supported } = await checkGitVersion();
+    if (!supported) {
+      console.log('Skipping linked worktree tests - Git 2.42+ required');
+      return;
+    }
+
+    originalCwd = process.cwd();
+    testDir = join(tmpdir(), `tbd-linked-worktree-test-${randomBytes(4).toString('hex')}`);
+    mainRepoPath = join(testDir, 'main');
+    linkedRepoPath = join(testDir, 'linked');
+
+    await initRepo(mainRepoPath);
+    process.chdir(mainRepoPath);
+    clearPathCache();
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    clearPathCache();
+    if (testDir) {
+      await rm(testDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  it('reuses the existing sync worktree from another checkout in the same clone', async () => {
+    const initResult = await initWorktree(mainRepoPath);
+    expect(initResult.success).toBe(true);
+
+    await addLinkedCheckout(mainRepoPath, linkedRepoPath, 'linked-worktree-a');
+    clearPathCache();
+
+    const sharedWorktreePath = await resolveSyncWorktreePath(mainRepoPath);
+    const resolvedWorktreePath = await resolveSyncWorktreePath(linkedRepoPath);
+    const dataSyncDir = await resolveDataSyncDir(linkedRepoPath);
+
+    expect(sharedWorktreePath).toBeTruthy();
+    expect(await canonicalizePath(resolvedWorktreePath!)).toBe(
+      await canonicalizePath(sharedWorktreePath!),
+    );
+    expect(await canonicalizePath(dataSyncDir)).toBe(
+      await canonicalizePath(getDataSyncDirForWorktree(sharedWorktreePath!)),
+    );
+  });
+
+  it('reports a linked checkout as healthy when a shared sync worktree exists', async () => {
+    const initResult = await initWorktree(mainRepoPath);
+    expect(initResult.success).toBe(true);
+
+    await addLinkedCheckout(mainRepoPath, linkedRepoPath, 'linked-worktree-b');
+    clearPathCache();
+
+    const sharedWorktreePath = await resolveSyncWorktreePath(mainRepoPath);
+    const health = await checkWorktreeHealth(linkedRepoPath);
+
+    expect(health.status).toBe('valid');
+    expect(health.valid).toBe(true);
+    expect(await canonicalizePath(health.path!)).toBe(await canonicalizePath(sharedWorktreePath!));
+    expect(health.branch).toBe(SYNC_BRANCH);
+  });
+
+  it('does not create a second hidden sync worktree from a linked checkout', async () => {
+    const initResult = await initWorktree(mainRepoPath);
+    expect(initResult.success).toBe(true);
+
+    await addLinkedCheckout(mainRepoPath, linkedRepoPath, 'linked-worktree-c');
+    clearPathCache();
+
+    expect(await countSyncWorktrees(linkedRepoPath)).toBe(1);
+
+    const sharedWorktreePath = await resolveSyncWorktreePath(mainRepoPath);
+    const linkedInitResult = await initWorktree(linkedRepoPath);
+
+    expect(linkedInitResult.success).toBe(true);
+    expect(linkedInitResult.created).toBe(false);
+    expect(await canonicalizePath(linkedInitResult.path!)).toBe(
+      await canonicalizePath(sharedWorktreePath!),
+    );
+    expect(await countSyncWorktrees(linkedRepoPath)).toBe(1);
+  });
+});

--- a/packages/tbd/tests/worktree-health.test.ts
+++ b/packages/tbd/tests/worktree-health.test.ts
@@ -253,14 +253,6 @@ describe('resolveDataSyncDir with allowFallback option', () => {
     }
   });
 
-  it('returns direct path when allowFallback is true (default) and worktree missing', async () => {
-    // No worktree exists, but allowFallback defaults to true
-    const dataSyncDir = await resolveDataSyncDir(testDir);
-
-    expect(dataSyncDir).toContain('data-sync');
-    expect(dataSyncDir).not.toContain('data-sync-worktree');
-  });
-
   it('returns direct path when allowFallback is explicitly true', async () => {
     const dataSyncDir = await resolveDataSyncDir(testDir, { allowFallback: true });
 
@@ -268,16 +260,15 @@ describe('resolveDataSyncDir with allowFallback option', () => {
     expect(dataSyncDir).not.toContain('data-sync-worktree');
   });
 
-  it('throws WorktreeMissingError when allowFallback is false and worktree missing', async () => {
-    await expect(resolveDataSyncDir(testDir, { allowFallback: false })).rejects.toThrow(
-      WorktreeMissingError,
-    );
+  it('throws WorktreeMissingError by default when worktree is missing', async () => {
+    await expect(resolveDataSyncDir(testDir)).rejects.toThrow(WorktreeMissingError);
   });
 
   it('returns worktree path when worktree exists', async () => {
     // Create the worktree directory structure
     const worktreePath = join(testDir, WORKTREE_DIR, TBD_DIR, DATA_SYNC_DIR_NAME);
     await mkdir(worktreePath, { recursive: true });
+    await fsWriteFile(join(testDir, WORKTREE_DIR, '.git'), 'gitdir: /tmp/fake-worktree\n');
 
     clearPathCache();
     const dataSyncDir = await resolveDataSyncDir(testDir);


### PR DESCRIPTION
## Summary

This PR fixes a linked git worktree bug in `tbd`.

`tbd` stores synced issue state in a hidden worktree at `.tbd/data-sync-worktree/`, but the current implementation treated that path as if it were local to each checkout. That assumption breaks when the user's repository itself is being used with `git worktree add`.

The fix is to treat the hidden sync worktree as a singleton per git clone: linked checkouts now discover and reuse the existing sync worktree instead of falling back to an empty local path or trying to create a second copy.

## The Problem

In a normal single checkout, `tbd` can resolve issue data from the hidden worktree path and everything behaves as expected. In a linked git worktree setup, that breaks down:

- A new linked checkout usually does not have its own local `.tbd/data-sync-worktree/` directory.
- Read commands like `tbd ready`, `tbd list`, and `tbd show` can therefore miss the real sync store.
- The code then falls back to `.tbd/data-sync/`, which is often empty in a fresh linked checkout.
- The result is that the new worktree appears to have no beads at all.

That was only the visible symptom. The more serious issue was that separate linked worktrees inside the same clone were not reliably reading from the same local sync store. One worktree could mark a bead `in_progress` while another still read stale or empty local state and offered the same bead again via `tbd ready`.

There was also a repository health problem. Every hidden sync worktree checks out the same branch, `tbd-sync`. If a second linked checkout tried to initialize or repair its own hidden sync worktree, Git could refuse because that branch was already checked out elsewhere in the same clone, or leave behind stale worktree state.

In short, the bug was not primarily about remote sync. It was a local path-resolution and topology bug inside a single clone using multiple linked worktrees.

## Why Data Copying Was Not the Right Fix

A workaround like importing from another checkout's `.tbd/data-sync-worktree/.tbd/data-sync/` could make a second checkout appear to work temporarily, but it does not fix the root cause.

That approach copies state instead of resolving the shared worktree location, risks creating multiple divergent local stores in one clone, bypasses the intended worktree lifecycle, and makes ID mapping and sync behavior harder to reason about.

This PR fixes discovery and reuse instead of duplicating data.

## Solution

The hidden sync worktree is now treated as effectively clone-scoped rather than checkout-scoped.

Concretely, this PR:

- adds clone-wide sync worktree discovery by inspecting `git worktree list --porcelain`
- reuses an existing registered `.tbd/data-sync-worktree` from another linked checkout in the same clone
- switches `resolveDataSyncDir()` to use the resolved active sync worktree rather than assuming the current checkout owns the only hidden store
- restricts fallback to `.tbd/data-sync/` to explicit test, migration, and diagnostic scenarios instead of using it silently in normal operation
- updates worktree lifecycle helpers to operate on the resolved active sync worktree path
- changes `initWorktree()` so it reuses an existing clone-wide sync worktree instead of attempting to create a second one
- updates command-layer reporting and behavior so `sync`, `status`, and `doctor` use the resolved active worktree path

## User-Visible Effect

After this change:

- a newly created linked git worktree can see the existing bead store immediately
- linked worktrees in the same clone share the same local sync worktree view
- `tbd ready` no longer offers the same bead independently from two linked checkouts just because one of them fell back to an empty local path
- new linked checkouts no longer try to initialize a second hidden `tbd-sync` worktree when one already exists for the clone

## Validation

Validated with:

- `pnpm format:check`
- `pnpm lint:check`
- `pnpm build`
- `pnpm --filter get-tbd exec vitest run tests/linked-worktree.test.ts tests/worktree-health.test.ts tests/git-remote.test.ts`

The regression coverage includes a dedicated linked-worktree test that verifies:

1. a linked checkout reuses the existing sync worktree from the same clone
2. a linked checkout is reported as healthy when that shared sync worktree exists
3. `initWorktree()` does not try to create a second hidden sync worktree

## Scope

This fixes the linked-worktree problem for multiple checkouts within the same git clone.

It does not change propagation behavior across separate clones, separate machines, or users who have not run `tbd sync`. That remains separate future work.
