### PR TITLE
chore: release get-tbd v0.1.26

### DIFF
--- a/.changeset/fix-ci-and-merge-conflicts.md
+++ b/.changeset/fix-ci-and-merge-conflicts.md
@@ -1,6 +1,0 @@
----
-"get-tbd": patch
----
-Fix CI badge failure by scoping coverage report action to PR events only, auto-resolve
-trivial merge conflicts in ids.yml during sync and doctor --fix, and update
-dependencies.

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -1,5 +1,21 @@
 # get-tbd
 
+## 0.1.26
+
+### Patch Changes
+
+- c9da6aa: Auto-resolve ids.yml merge conflicts during sync and doctor --fix, add
+  merge=union gitattributes inside worktree to prevent future conflicts, fix CI badge
+  scope, remove dead code, and update dependencies.
+
+## 0.1.25
+
+### Patch Changes
+
+- Fix short-ID mapping loss during concurrent creation, improve doctor check ordering,
+  resolve Windows CI test flakiness, and add research docs for orchestration and
+  knowledge architecture.
+
 ## 0.1.24
 
 ### Patch Changes

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-tbd",
-  "version": "0.1.24",
+  "version": "0.1.26",
   "description": "Git-native issue tracking for AI agents and humans",
   "license": "MIT",
   "author": "Joshua Levy <joshua@cal.berkeley.edu> (https://github.com/jlevy)",

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,25 +1,16 @@
 ## What’s Changed
 
-### Features
-
-- **Doctor history scanning**: New `--max-history` option for `tbd doctor` to control
-  how far back mapping recovery scans (defaults to 50 commits for faster execution)
-
 ### Fixes
 
-- **Concurrent create race condition**: Prevent `tbd create` from losing short ID
-  mappings when multiple creates run simultaneously
-- **Migration safety**: Prevent migration from destroying `ids.yml` mappings; remove
-  source files after successful migration and add verbose doctor output
-- **Lockfile reliability**: Tighten lockfile defaults and clarify locking behavior
-- **Sync status reporting**: Make ahead/behind status informational instead of a
-  warning, reducing noise during normal sync operations
-- **Doctor input validation**: Validate `--max-history` input to prevent unbounded
-  history scans
+- **ids.yml merge conflict resolution**: Auto-resolve trivial merge conflicts in
+  `ids.yml` during `tbd sync` and `tbd doctor --fix`, preventing sync failures caused by
+  concurrent ID mapping updates
+- **Worktree merge strategy**: Add `merge=union` gitattributes inside the worktree for
+  `ids.yml` so Git automatically merges concurrent additions without conflict
+- **CI badge**: Scope coverage report action to PR events only to fix CI badge status
 
-### Documentation
+### Refactoring
 
-- **Research brief template**: Improved with optional sections and blockquote
-  instructions
+- Remove dead code and consolidate duplicate constants
 
-**Full commit history**: https://github.com/jlevy/tbd/compare/v0.1.23...v0.1.24
+**Full commit history**: https://github.com/jlevy/tbd/compare/v0.1.25...v0.1.26


### PR DESCRIPTION
## What's Changed

### Fixes

- **ids.yml merge conflict resolution**: Auto-resolve trivial merge conflicts in
  `ids.yml` during `tbd sync` and `tbd doctor --fix`, preventing sync failures caused by
  concurrent ID mapping updates
- **Worktree merge strategy**: Add `merge=union` gitattributes inside the worktree for
  `ids.yml` so Git automatically merges concurrent additions without conflict
- **CI badge**: Scope coverage report action to PR events only to fix CI badge status

### Refactoring

- Remove dead code and consolidate duplicate constants

### Also included

- Fix version regression: PR #113 inadvertently reverted package.json from 0.1.25 to 0.1.24; this release restores the v0.1.25 CHANGELOG entry and bumps to v0.1.26

**Full commit history**: https://github.com/jlevy/tbd/compare/v0.1.25...claude/publish-v0.1.26-IUbTT

---

## Release checklist

After merging this PR:
1. Create tag `v0.1.26` on the merge commit (triggers the release workflow)
2. Update the GitHub Release with formatted release notes

https://claude.ai/code/session_01V83VXefuQq8YUd3RYTNvr5