### PR TITLE
fix: handle invalid issue files safely

### DIFF
--- a/.changeset/valid-issue-files.md
+++ b/.changeset/valid-issue-files.md
@@ -1,0 +1,5 @@
+---
+"get-tbd": patch
+---
+Reject invalid issue titles before writing issue files, skip parse-invalid issue files
+without crashing, and report invalid issue files in `tbd doctor`.

--- a/packages/tbd/src/cli/commands/create.ts
+++ b/packages/tbd/src/cli/commands/create.ts
@@ -54,6 +54,7 @@ class CreateHandler extends BaseCommand {
         ? undefined
         : validateIssueTitle(title, {
             emptyMessage: 'Title is required. Use: tbd create "Issue title"',
+            rejectBlank: true,
           });
 
     // Parse and validate options

--- a/packages/tbd/src/cli/commands/create.ts
+++ b/packages/tbd/src/cli/commands/create.ts
@@ -25,6 +25,7 @@ import { resolveDataSyncDir } from '../../lib/paths.js';
 import { now } from '../../utils/time-utils.js';
 import { readConfig } from '../../file/config.js';
 import { resolveAndValidatePath, getPathErrorMessage } from '../../lib/project-paths.js';
+import { validateIssueTitle } from '../lib/issue-input-validation.js';
 
 interface CreateOptions {
   fromFile?: string;
@@ -48,6 +49,12 @@ class CreateHandler extends BaseCommand {
     if (!title && !options.fromFile) {
       throw new ValidationError('Title is required. Use: tbd create "Issue title"');
     }
+    const validatedTitle =
+      title === undefined
+        ? undefined
+        : validateIssueTitle(title, {
+            emptyMessage: 'Title is required. Use: tbd create "Issue title"',
+          });
 
     // Parse and validate options
     const kind = this.parseKind(options.type ?? 'task');
@@ -76,7 +83,13 @@ class CreateHandler extends BaseCommand {
     }
 
     if (
-      this.checkDryRun('Would create issue', { title, kind, priority, spec: specPath, ...options })
+      this.checkDryRun('Would create issue', {
+        title: validatedTitle,
+        kind,
+        priority,
+        spec: specPath,
+        ...options,
+      })
     ) {
       return;
     }
@@ -122,7 +135,7 @@ class CreateHandler extends BaseCommand {
         type: 'is',
         id,
         version: 1,
-        title: title!,
+        title: validatedTitle!,
         kind,
         status: 'open',
         priority,
@@ -163,8 +176,8 @@ class CreateHandler extends BaseCommand {
 
     // Output with display ID (prefix + short ID)
     const displayId = `${prefix!}-${shortId!}`;
-    this.output.data({ id: displayId, internalId: id, title }, () => {
-      this.output.success(`Created ${displayId}: ${title}`);
+    this.output.data({ id: displayId, internalId: id, title: validatedTitle }, () => {
+      this.output.success(`Created ${displayId}: ${validatedTitle}`);
     });
   }
 

--- a/packages/tbd/src/cli/commands/doctor.ts
+++ b/packages/tbd/src/cli/commands/doctor.ts
@@ -12,7 +12,7 @@ import { join } from 'node:path';
 
 import { BaseCommand } from '../lib/base-command.js';
 import { requireInit } from '../lib/errors.js';
-import { listIssues } from '../../file/storage.js';
+import { listIssues, type InvalidIssueFile } from '../../file/storage.js';
 import { readConfig } from '../../file/config.js';
 import type { Config, Issue, IssueStatusType } from '../../lib/types.js';
 import { resolveDataSyncDir, TBD_DIR, WORKTREE_DIR, DATA_SYNC_DIR } from '../../lib/paths.js';
@@ -59,6 +59,7 @@ class DoctorHandler extends BaseCommand {
   private cwd = '';
   private config: Config | null = null;
   private issues: Issue[] = [];
+  private invalidIssueFiles: InvalidIssueFile[] = [];
 
   async run(options: DoctorOptions): Promise<void> {
     const tbdRoot = await requireInit();
@@ -75,7 +76,11 @@ class DoctorHandler extends BaseCommand {
 
     // Load issues
     try {
-      this.issues = await listIssues(this.dataSyncDir);
+      this.invalidIssueFiles = [];
+      this.issues = await listIssues(this.dataSyncDir, {
+        warnOnInvalid: false,
+        onInvalidIssue: (invalidIssue) => this.invalidIssueFiles.push(invalidIssue),
+      });
     } catch {
       // May fail if no issues yet
     }
@@ -114,7 +119,7 @@ class DoctorHandler extends BaseCommand {
     healthChecks.push(await this.checkTempFiles(options.fix));
 
     // Check 8: Issue validity
-    healthChecks.push(this.checkIssueValidity(this.issues));
+    healthChecks.push(this.checkIssueValidity(this.issues, this.invalidIssueFiles));
 
     // Check 9: Worktree health (with fix support)
     // Run BEFORE ID mapping check — worktree repair and data migration can
@@ -130,7 +135,11 @@ class DoctorHandler extends BaseCommand {
     if (dataLocationResult.status === 'ok' && dataLocationResult.message?.includes('migrated')) {
       this.dataSyncDir = await resolveDataSyncDir(this.cwd);
       try {
-        this.issues = await listIssues(this.dataSyncDir);
+        this.invalidIssueFiles = [];
+        this.issues = await listIssues(this.dataSyncDir, {
+          warnOnInvalid: false,
+          onInvalidIssue: (invalidIssue) => this.invalidIssueFiles.push(invalidIssue),
+        });
       } catch {
         // Will be caught by other health checks
       }
@@ -596,8 +605,15 @@ class DoctorHandler extends BaseCommand {
     };
   }
 
-  private checkIssueValidity(issues: Issue[]): DiagnosticResult {
+  private checkIssueValidity(
+    issues: Issue[],
+    invalidIssueFiles: InvalidIssueFile[],
+  ): DiagnosticResult {
     const invalid: { id: string; reason: string }[] = [];
+
+    for (const invalidIssueFile of invalidIssueFiles) {
+      invalid.push({ id: invalidIssueFile.file, reason: invalidIssueFile.reason });
+    }
 
     for (const issue of issues) {
       const issueId = issue.id ?? 'unknown';
@@ -636,7 +652,8 @@ class DoctorHandler extends BaseCommand {
     return {
       name: 'Issue validity',
       status: 'error',
-      message: `${invalid.length} invalid issue(s)`,
+      message: `${invalid.length} invalid issue file(s)`,
+      path: join(CONFIG_DIR, 'issues'),
       details: invalid.map((i) => `${i.id}: ${i.reason}`),
       suggestion: 'Manually fix or delete invalid issue files',
     };

--- a/packages/tbd/src/cli/commands/update.ts
+++ b/packages/tbd/src/cli/commands/update.ts
@@ -20,6 +20,7 @@ import { now } from '../../utils/time-utils.js';
 import { loadIdMapping, resolveToInternalId, type IdMapping } from '../../file/id-mapping.js';
 import { readConfig } from '../../file/config.js';
 import { resolveAndValidatePath, getPathErrorMessage } from '../../lib/project-paths.js';
+import { validateIssueTitle } from '../lib/issue-input-validation.js';
 
 interface UpdateOptions {
   fromFile?: string;
@@ -229,7 +230,10 @@ class UpdateHandler extends BaseCommand {
 
         // Extract mutable fields from frontmatter
         if (typeof frontmatter.title === 'string') {
-          updates.title = frontmatter.title;
+          updates.title = validateIssueTitle(frontmatter.title, {
+            emptyMessage: 'Title cannot be empty',
+            rejectBlank: true,
+          });
         }
         if (typeof frontmatter.status === 'string') {
           const result = IssueStatus.safeParse(frontmatter.status);
@@ -297,10 +301,10 @@ class UpdateHandler extends BaseCommand {
     }
 
     if (options.title !== undefined) {
-      if (!options.title.trim()) {
-        throw new ValidationError('Title cannot be empty');
-      }
-      updates.title = options.title;
+      updates.title = validateIssueTitle(options.title, {
+        emptyMessage: 'Title cannot be empty',
+        rejectBlank: true,
+      });
     }
 
     if (options.status) {

--- a/packages/tbd/src/cli/lib/issue-input-validation.ts
+++ b/packages/tbd/src/cli/lib/issue-input-validation.ts
@@ -22,16 +22,16 @@ export function validateIssueTitle(title: string, options: IssueTitleValidationO
     throw new ValidationError(options.emptyMessage);
   }
 
-  const result = IssueTitle.safeParse(title);
-  if (result.success) {
-    return result.data;
-  }
-
   if (title.length > ISSUE_TITLE_MAX_LENGTH) {
     throw new ValidationError(
       `Title is too long (${title.length} chars, max ${ISSUE_TITLE_MAX_LENGTH}). Move detail into the description body.`,
     );
   }
 
-  throw new ValidationError(`Invalid title: ${formatZodError(result.error)}`);
+  const result = IssueTitle.safeParse(title);
+  if (!result.success) {
+    throw new ValidationError(`Invalid title: ${formatZodError(result.error)}`);
+  }
+
+  return title;
 }

--- a/packages/tbd/src/cli/lib/issue-input-validation.ts
+++ b/packages/tbd/src/cli/lib/issue-input-validation.ts
@@ -1,0 +1,37 @@
+/**
+ * CLI validation helpers for user-provided issue fields.
+ */
+
+import { ISSUE_TITLE_MAX_LENGTH, IssueTitle } from '../../lib/schemas.js';
+import { formatZodError } from '../../utils/zod-error-utils.js';
+import { ValidationError } from './errors.js';
+
+interface IssueTitleValidationOptions {
+  /** Error message used when the title is empty. */
+  emptyMessage: string;
+  /** When true, whitespace-only titles are treated as empty. */
+  rejectBlank?: boolean;
+}
+
+/**
+ * Validate a CLI-provided issue title with actionable user-facing errors.
+ */
+export function validateIssueTitle(title: string, options: IssueTitleValidationOptions): string {
+  const isEmpty = options.rejectBlank ? title.trim().length === 0 : title.length === 0;
+  if (isEmpty) {
+    throw new ValidationError(options.emptyMessage);
+  }
+
+  const result = IssueTitle.safeParse(title);
+  if (result.success) {
+    return result.data;
+  }
+
+  if (title.length > ISSUE_TITLE_MAX_LENGTH) {
+    throw new ValidationError(
+      `Title is too long (${title.length} chars, max ${ISSUE_TITLE_MAX_LENGTH}). Move detail into the description body.`,
+    );
+  }
+
+  throw new ValidationError(`Invalid title: ${formatZodError(result.error)}`);
+}

--- a/packages/tbd/src/file/storage.ts
+++ b/packages/tbd/src/file/storage.ts
@@ -12,7 +12,31 @@ import { join } from 'node:path';
 import { writeFile } from 'atomically';
 
 import type { Issue } from '../lib/types.js';
+import { IssueSchema } from '../lib/schemas.js';
+import { formatUnknownError } from '../utils/zod-error-utils.js';
 import { parseIssue, serializeIssue } from './parser.js';
+
+/**
+ * Maximum issue files read concurrently to avoid exhausting file descriptors in large repos.
+ */
+const ISSUE_READ_BATCH_SIZE = 200;
+
+/**
+ * Parse or read failure for an issue file.
+ */
+export interface InvalidIssueFile {
+  /** Issue filename relative to the issues directory. */
+  file: string;
+  /** Safe, human-readable read or parse failure reason. */
+  reason: string;
+}
+
+interface ListIssuesOptions {
+  /** When true, emit skipped-file warnings to stderr. */
+  warnOnInvalid?: boolean;
+  /** Optional callback for callers that need structured skipped-file diagnostics. */
+  onInvalidIssue?: (invalidIssue: InvalidIssueFile) => void;
+}
 
 /**
  * Get the path to an issue file.
@@ -36,8 +60,9 @@ export async function readIssue(baseDir: string, id: string): Promise<Issue> {
  * Uses atomic write to prevent corruption.
  */
 export async function writeIssue(baseDir: string, issue: Issue): Promise<void> {
-  const filePath = getIssuePath(baseDir, issue.id);
-  const content = serializeIssue(issue);
+  const validIssue = IssueSchema.parse(issue);
+  const filePath = getIssuePath(baseDir, validIssue.id);
+  const content = serializeIssue(validIssue);
   await writeFile(filePath, content);
 }
 
@@ -47,7 +72,11 @@ export async function writeIssue(baseDir: string, issue: Issue): Promise<void> {
  *
  * Uses parallel file reading for better performance with many issues.
  */
-export async function listIssues(baseDir: string): Promise<Issue[]> {
+export async function listIssues(
+  baseDir: string,
+  options: ListIssuesOptions = {},
+): Promise<Issue[]> {
+  const warnOnInvalid = options.warnOnInvalid ?? true;
   const issuesDir = join(baseDir, 'issues');
 
   let files: string[];
@@ -61,38 +90,68 @@ export async function listIssues(baseDir: string): Promise<Issue[]> {
   // Filter to only .md files
   const mdFiles = files.filter((f) => f.endsWith('.md'));
 
-  // Read files in batches to avoid EMFILE (too many open files) on large repos.
-  // Unbounded Promise.all on thousands of files exceeds typical fd limits (1024-4096).
-  const BATCH_SIZE = 200;
   const issues: Issue[] = [];
 
-  for (let i = 0; i < mdFiles.length; i += BATCH_SIZE) {
-    const batch = mdFiles.slice(i, i + BATCH_SIZE);
+  for (let i = 0; i < mdFiles.length; i += ISSUE_READ_BATCH_SIZE) {
+    const batch = mdFiles.slice(i, i + ISSUE_READ_BATCH_SIZE);
     const fileContents = await Promise.all(
       batch.map(async (file) => {
         const filePath = join(issuesDir, file);
         try {
           const content = await readFile(filePath, 'utf-8');
           return { file, content };
-        } catch {
-          return { file, content: null };
+        } catch (error) {
+          return { file, error: formatUnknownError(error) };
         }
       }),
     );
 
-    for (const { file, content } of fileContents) {
-      if (content === null) continue;
+    for (const result of fileContents) {
+      if ('error' in result) {
+        reportInvalidIssueFile(
+          { file: result.file, reason: `failed to read file: ${result.error}` },
+          warnOnInvalid,
+          options.onInvalidIssue,
+        );
+        continue;
+      }
       try {
-        const issue = parseIssue(content);
+        const issue = parseIssue(result.content);
         issues.push(issue);
       } catch (error) {
-        // Skip invalid files with a warning
-        console.warn(`Skipping invalid issue file: ${file}`, error);
+        reportInvalidIssueFile(
+          { file: result.file, reason: formatUnknownError(error) },
+          warnOnInvalid,
+          options.onInvalidIssue,
+        );
       }
     }
   }
 
   return issues;
+}
+
+/**
+ * Return issue files that cannot be parsed without emitting warnings.
+ */
+export async function listInvalidIssueFiles(baseDir: string): Promise<InvalidIssueFile[]> {
+  const invalidIssueFiles: InvalidIssueFile[] = [];
+  await listIssues(baseDir, {
+    warnOnInvalid: false,
+    onInvalidIssue: (invalidIssue) => invalidIssueFiles.push(invalidIssue),
+  });
+  return invalidIssueFiles;
+}
+
+function reportInvalidIssueFile(
+  invalidIssue: InvalidIssueFile,
+  warnOnInvalid: boolean,
+  onInvalidIssue?: (invalidIssue: InvalidIssueFile) => void,
+): void {
+  onInvalidIssue?.(invalidIssue);
+  if (warnOnInvalid) {
+    console.warn(`Skipping invalid issue file: ${invalidIssue.file}: ${invalidIssue.reason}`);
+  }
 }
 
 /**

--- a/packages/tbd/src/file/storage.ts
+++ b/packages/tbd/src/file/storage.ts
@@ -131,18 +131,6 @@ export async function listIssues(
   return issues;
 }
 
-/**
- * Return issue files that cannot be parsed without emitting warnings.
- */
-export async function listInvalidIssueFiles(baseDir: string): Promise<InvalidIssueFile[]> {
-  const invalidIssueFiles: InvalidIssueFile[] = [];
-  await listIssues(baseDir, {
-    warnOnInvalid: false,
-    onInvalidIssue: (invalidIssue) => invalidIssueFiles.push(invalidIssue),
-  });
-  return invalidIssueFiles;
-}
-
 function reportInvalidIssueFile(
   invalidIssue: InvalidIssueFile,
   warnOnInvalid: boolean,

--- a/packages/tbd/src/lib/schemas.ts
+++ b/packages/tbd/src/lib/schemas.ts
@@ -92,6 +92,21 @@ export const IssueStatus = z.enum(['open', 'in_progress', 'blocked', 'deferred',
 export const IssueKind = z.enum(['bug', 'feature', 'task', 'epic', 'chore']);
 
 /**
+ * Maximum issue title length before detail belongs in the description body.
+ */
+export const ISSUE_TITLE_MAX_LENGTH = 500;
+
+/**
+ * Maximum issue body section length to keep issue files practical to review and sync.
+ */
+export const ISSUE_BODY_MAX_LENGTH = 50_000;
+
+/**
+ * Issue title text as persisted in issue files.
+ */
+export const IssueTitle = z.string().min(1).max(ISSUE_TITLE_MAX_LENGTH);
+
+/**
  * Priority: 0 (highest/critical) to 4 (lowest).
  */
 export const Priority = z.number().int().min(0).max(4);
@@ -130,14 +145,14 @@ export const IssueSchema = BaseEntity.extend({
   // Header seven: the fields you always want to see at a glance
   type: z.literal('is'),
   // id, version inherited from BaseEntity
-  title: z.string().min(1).max(500),
+  title: IssueTitle,
   kind: IssueKind.default('task'),
   status: IssueStatus.default('open'),
   priority: Priority.default(2),
 
   // Body content (serialized outside frontmatter)
-  description: z.string().max(50000).nullable().optional(),
-  notes: z.string().max(50000).nullable().optional(),
+  description: z.string().max(ISSUE_BODY_MAX_LENGTH).nullable().optional(),
+  notes: z.string().max(ISSUE_BODY_MAX_LENGTH).nullable().optional(),
 
   // Linkages
   spec_path: z.string().nullable().optional(),

--- a/packages/tbd/src/utils/zod-error-utils.ts
+++ b/packages/tbd/src/utils/zod-error-utils.ts
@@ -1,0 +1,30 @@
+/**
+ * Helpers for rendering Zod errors without relying on object inspection.
+ */
+
+import { ZodError } from 'zod';
+
+/**
+ * Format a ZodError as concise path-qualified messages for CLI output.
+ */
+export function formatZodError(error: ZodError): string {
+  const messages = error.issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+    return `${path}: ${issue.message}`;
+  });
+
+  return messages.length > 0 ? messages.join('; ') : error.message;
+}
+
+/**
+ * Format unknown thrown values as safe strings for warnings and diagnostics.
+ */
+export function formatUnknownError(error: unknown): string {
+  if (error instanceof ZodError) {
+    return formatZodError(error);
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}

--- a/packages/tbd/tests/cli-edge-cases.tryscript.md
+++ b/packages/tbd/tests/cli-edge-cases.tryscript.md
@@ -191,7 +191,7 @@ Error: Issue cannot depend on itself
 # Test: Very long title (200 chars)
 
 ```console
-$ tbd create "$(printf 'A%.0s' {1..200})"
+$ tbd create "$(awk 'BEGIN { for (i = 0; i < 200; i++) printf "A" }')"
 ✓ Created test-[SHORTID]: [..]
 ? 0
 ```
@@ -199,7 +199,7 @@ $ tbd create "$(printf 'A%.0s' {1..200})"
 # Test: Too long title is rejected before writing
 
 ```console
-$ tbd create "$(printf 'A%.0s' {1..501})" 2>&1
+$ tbd create "$(awk 'BEGIN { for (i = 0; i < 501; i++) printf "A" }')" 2>&1
 Error: Title is too long (501 chars, max 500). Move detail into the description body.
 ? 2
 ```

--- a/packages/tbd/tests/cli-edge-cases.tryscript.md
+++ b/packages/tbd/tests/cli-edge-cases.tryscript.md
@@ -196,6 +196,14 @@ $ tbd create "$(printf 'A%.0s' {1..200})"
 ? 0
 ```
 
+# Test: Too long title is rejected before writing
+
+```console
+$ tbd create "$(printf 'A%.0s' {1..501})" 2>&1
+Error: Title is too long (501 chars, max 500). Move detail into the description body.
+? 2
+```
+
 # Test: Many labels
 
 ```console

--- a/packages/tbd/tests/corrupted-data.test.ts
+++ b/packages/tbd/tests/corrupted-data.test.ts
@@ -12,6 +12,8 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execSync, spawnSync } from 'node:child_process';
+import { ISSUE_TITLE_MAX_LENGTH } from '../src/lib/schemas.js';
+import { TEST_ULIDS, testId } from './test-helpers.js';
 
 describe('corrupted data scenarios', { timeout: 15000 }, () => {
   let tempDir: string;
@@ -139,6 +141,57 @@ c3d4: 01hx5zzkbkbctav9wevgemmvrw
       expect(listResult.status).toBe(1);
       // Should show actual YAML error, not "Failed to read issues"
       expect(listResult.stderr).not.toContain('Failed to read issues');
+    });
+  });
+
+  describe('invalid issue files', () => {
+    it('skips invalid issue files and reports them in doctor', async () => {
+      initGitAndTbd();
+
+      const createResult = runTbd(['create', 'Valid issue', '--type=task']);
+      expect(createResult.status).toBe(0);
+
+      const invalidId = testId(TEST_ULIDS.DOCTOR_4);
+      const issuePath = join(
+        tempDir,
+        '.tbd',
+        'data-sync-worktree',
+        '.tbd',
+        'data-sync',
+        'issues',
+        `${invalidId}.md`,
+      );
+      await writeFile(
+        issuePath,
+        `---
+type: is
+id: ${invalidId}
+title: ${'x'.repeat(ISSUE_TITLE_MAX_LENGTH + 1)}
+kind: task
+status: open
+priority: 2
+version: 1
+created_at: 2025-01-01T00:00:00Z
+updated_at: 2025-01-01T00:00:00Z
+labels: []
+dependencies: []
+---
+`,
+      );
+
+      const listResult = runTbd(['list']);
+      expect(listResult.status).toBe(0);
+      expect(listResult.stdout).toContain('Valid issue');
+      expect(listResult.stderr).toContain(`Skipping invalid issue file: ${invalidId}.md: title:`);
+
+      const doctorResult = runTbd(['doctor']);
+      expect(doctorResult.status).toBe(0);
+      expect(doctorResult.stderr).toContain('Issues found that may require manual intervention.');
+      expect(doctorResult.stderr).not.toContain('Skipping invalid issue file');
+      expect(doctorResult.stdout).toContain(
+        '✗ Issue validity - 1 invalid issue file(s) (.tbd/issues)',
+      );
+      expect(doctorResult.stdout).toContain(`${invalidId}.md: title:`);
     });
   });
 });

--- a/packages/tbd/tests/corrupted-data.test.ts
+++ b/packages/tbd/tests/corrupted-data.test.ts
@@ -188,8 +188,8 @@ dependencies: []
       expect(doctorResult.status).toBe(0);
       expect(doctorResult.stderr).toContain('Issues found that may require manual intervention.');
       expect(doctorResult.stderr).not.toContain('Skipping invalid issue file');
-      expect(doctorResult.stdout).toContain(
-        '✗ Issue validity - 1 invalid issue file(s) (.tbd/issues)',
+      expect(doctorResult.stdout).toMatch(
+        /✗ Issue validity - 1 invalid issue file\(s\) \(\.tbd[\\/]issues\)/,
       );
       expect(doctorResult.stdout).toContain(`${invalidId}.md: title:`);
     });

--- a/packages/tbd/tests/issue-input-validation.test.ts
+++ b/packages/tbd/tests/issue-input-validation.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Unit tests for CLI issue title validation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateIssueTitle } from '../src/cli/lib/issue-input-validation.js';
+import { ValidationError } from '../src/cli/lib/errors.js';
+import { ISSUE_TITLE_MAX_LENGTH } from '../src/lib/schemas.js';
+
+describe('validateIssueTitle', () => {
+  it('returns the input unchanged when valid', () => {
+    expect(validateIssueTitle('A normal title', { emptyMessage: 'Title is required' })).toBe(
+      'A normal title',
+    );
+  });
+
+  it('accepts a title exactly at the maximum length', () => {
+    const title = 'x'.repeat(ISSUE_TITLE_MAX_LENGTH);
+    expect(validateIssueTitle(title, { emptyMessage: 'Title is required' })).toBe(title);
+  });
+
+  it('throws the supplied empty message for an empty string', () => {
+    expect(() => validateIssueTitle('', { emptyMessage: 'Custom empty message' })).toThrow(
+      ValidationError,
+    );
+    expect(() => validateIssueTitle('', { emptyMessage: 'Custom empty message' })).toThrow(
+      'Custom empty message',
+    );
+  });
+
+  it('accepts whitespace-only titles when rejectBlank is omitted', () => {
+    expect(validateIssueTitle('   ', { emptyMessage: 'Title is required' })).toBe('   ');
+  });
+
+  it('rejects whitespace-only titles when rejectBlank is true', () => {
+    expect(() =>
+      validateIssueTitle('   ', { emptyMessage: 'Title cannot be empty', rejectBlank: true }),
+    ).toThrow('Title cannot be empty');
+  });
+
+  it('rejects titles longer than the maximum with an actionable message', () => {
+    const title = 'x'.repeat(ISSUE_TITLE_MAX_LENGTH + 1);
+    expect(() => validateIssueTitle(title, { emptyMessage: 'Title is required' })).toThrow(
+      `Title is too long (${ISSUE_TITLE_MAX_LENGTH + 1} chars, max ${ISSUE_TITLE_MAX_LENGTH}). Move detail into the description body.`,
+    );
+  });
+
+  it('throws ValidationError (not a generic Error)', () => {
+    try {
+      validateIssueTitle('', { emptyMessage: 'Title is required' });
+      expect.fail('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ValidationError);
+    }
+  });
+});

--- a/packages/tbd/tests/storage.test.ts
+++ b/packages/tbd/tests/storage.test.ts
@@ -2,12 +2,13 @@
  * Tests for storage layer - issue file operations.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, rm, readFile, writeFile as fsWriteFile } from 'node:fs/promises';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm, readFile, writeFile as fsWriteFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { writeFile } from 'atomically';
 import { readIssue, writeIssue, listIssues, deleteIssue } from '../src/file/storage.js';
+import { ISSUE_TITLE_MAX_LENGTH } from '../src/lib/schemas.js';
 import type { Issue } from '../src/lib/types.js';
 import { TEST_ULIDS, testId } from './test-helpers.js';
 
@@ -144,6 +145,17 @@ describe('writeIssue and readIssue', () => {
   it('throws on non-existent issue', async () => {
     await expect(readIssue(tempDir, testId(TEST_ULIDS.ULID_9))).rejects.toThrow();
   });
+
+  it('rejects invalid issues before writing', async () => {
+    const issueId = testId(TEST_ULIDS.ULID_3);
+    const issue = makeIssue({
+      id: issueId,
+      title: 'x'.repeat(ISSUE_TITLE_MAX_LENGTH + 1),
+    });
+
+    await expect(writeIssue(tempDir, issue)).rejects.toThrow(/title/);
+    await expect(readFile(join(tempDir, 'issues', `${issueId}.md`), 'utf-8')).rejects.toThrow();
+  });
 });
 
 describe('listIssues', () => {
@@ -187,6 +199,46 @@ describe('listIssues', () => {
     const issues = await listIssues(tempDir);
     expect(issues).toHaveLength(1);
     expect(issues[0]!.id).toBe(id1);
+  });
+
+  it('skips invalid issue files with a safe warning', async () => {
+    const validId = testId(TEST_ULIDS.STORAGE_2);
+    const invalidId = testId(TEST_ULIDS.STORAGE_3);
+    await writeIssue(tempDir, makeIssue({ id: validId, title: 'Valid issue' }));
+
+    const issuesDir = join(tempDir, 'issues');
+    await mkdir(issuesDir, { recursive: true });
+    await fsWriteFile(
+      join(issuesDir, `${invalidId}.md`),
+      `---
+type: is
+id: ${invalidId}
+title: ${'x'.repeat(ISSUE_TITLE_MAX_LENGTH + 1)}
+kind: task
+status: open
+priority: 2
+version: 1
+created_at: 2025-01-01T00:00:00Z
+updated_at: 2025-01-01T00:00:00Z
+labels: []
+dependencies: []
+---
+`,
+    );
+
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const issues = await listIssues(tempDir);
+
+      expect(issues).toHaveLength(1);
+      expect(issues[0]!.id).toBe(validId);
+      expect(consoleWarn).toHaveBeenCalledTimes(1);
+      expect(consoleWarn.mock.calls[0]).toEqual([
+        expect.stringContaining(`Skipping invalid issue file: ${invalidId}.md: title:`),
+      ]);
+    } finally {
+      consoleWarn.mockRestore();
+    }
   });
 });
 

--- a/packages/tbd/tests/zod-error-utils.test.ts
+++ b/packages/tbd/tests/zod-error-utils.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for Zod / unknown-error formatting helpers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z, ZodError } from 'zod';
+import { formatZodError, formatUnknownError } from '../src/utils/zod-error-utils.js';
+
+describe('formatZodError', () => {
+  it('formats a simple field error with its path', () => {
+    const schema = z.object({ title: z.string().min(1) });
+    const result = schema.safeParse({ title: '' });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const formatted = formatZodError(result.error);
+    expect(formatted).toContain('title:');
+  });
+
+  it('uses <root> for top-level errors with no path', () => {
+    const schema = z.string().min(5);
+    const result = schema.safeParse('hi');
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const formatted = formatZodError(result.error);
+    expect(formatted).toMatch(/^<root>:/);
+  });
+
+  it('joins multiple issues with semicolons', () => {
+    const schema = z.object({ a: z.string(), b: z.number() });
+    const result = schema.safeParse({ a: 1, b: 'oops' });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const formatted = formatZodError(result.error);
+    expect(formatted).toContain('a:');
+    expect(formatted).toContain('b:');
+    expect(formatted).toContain(';');
+  });
+
+  it('renders nested paths with dots', () => {
+    const schema = z.object({ outer: z.object({ inner: z.string() }) });
+    const result = schema.safeParse({ outer: { inner: 5 } });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    expect(formatZodError(result.error)).toContain('outer.inner:');
+  });
+});
+
+describe('formatUnknownError', () => {
+  it('formats a ZodError via formatZodError', () => {
+    const schema = z.string().max(3);
+    const result = schema.safeParse('toolong');
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    expect(formatUnknownError(result.error)).toBe(formatZodError(result.error));
+  });
+
+  it('returns the message of a regular Error', () => {
+    expect(formatUnknownError(new Error('boom'))).toBe('boom');
+  });
+
+  it('stringifies non-Error values', () => {
+    expect(formatUnknownError('plain string')).toBe('plain string');
+    expect(formatUnknownError(42)).toBe('42');
+    expect(formatUnknownError(null)).toBe('null');
+  });
+
+  it('does not throw on a custom thrown object', () => {
+    const weird = { weird: true } as unknown;
+    expect(() => formatUnknownError(weird)).not.toThrow();
+  });
+
+  it('handles empty ZodError gracefully', () => {
+    const error = new ZodError([]);
+    expect(formatUnknownError(error)).toBe(error.message);
+  });
+});


### PR DESCRIPTION
## Summary

- validate issues in `writeIssue` and reject overlong CLI titles before writing
- format Zod/read errors as strings so invalid issue files are skipped without crashing
- report parse-invalid issue files in `tbd doctor`
- add regression coverage for create, storage, list, and doctor behavior

Fixes #115

## Validation

- `pnpm run ci`
- pre-push hook: `pnpm test`
