### PR TITLE
fix: Clarify dependency direction in show output

### DIFF
--- a/.changeset/clarify-show-dependencies.md
+++ b/.changeset/clarify-show-dependencies.md
@@ -1,0 +1,5 @@
+---
+"get-tbd": patch
+---
+Clarify dependency direction in `tbd show` output with `Blocks:` and `Blocked by:`
+comments.

--- a/packages/tbd/docs/tbd-design.md
+++ b/packages/tbd/docs/tbd-design.md
@@ -2631,9 +2631,24 @@ Options:
 
 **Output:**
 
-The `show` command outputs the issue in the exact storage format (YAML frontmatter +
+The `show` command outputs the issue in a storage-compatible format (YAML frontmatter +
 Markdown body). This format is both human-readable and machine-parseable, enabling
 round-trip editing workflows.
+For dependency direction, text output may include YAML comments immediately above the
+`dependencies` field:
+
+```yaml
+# Blocks: proj-c3d4
+# Blocked by: proj-f14c
+dependencies:
+  - type: blocks
+    target: is-c3d4...
+```
+
+These comments are ignored by `tbd update --from-file` and exist only to clarify the raw
+edge list. In storage, `type: blocks` means the shown issue blocks the target.
+For dependency-direction checks, prefer `tbd dep list <id>`, which renders the
+human-facing `Blocks:` and `Blocked by:` sections directly.
 
 **Parent context (auto-displayed for child issues):**
 

--- a/packages/tbd/docs/tbd-docs.md
+++ b/packages/tbd/docs/tbd-docs.md
@@ -292,8 +292,13 @@ tbd show proj-a7k2 --no-parent                # Suppress parent context
 
 Output includes all fields: title, description, status, priority, labels, dependencies,
 timestamps, and working notes.
-For child issues, the parent’s details (ID, title, status, priority, description) are
-automatically displayed below the child for context.
+The raw `dependencies` field is a storage-format edge list: an entry with `type: blocks`
+means the shown issue blocks the target.
+When dependency directions exist, text output adds YAML comments above `dependencies`
+with human-facing `Blocks:` and `Blocked by:` sections using display IDs.
+For dependency-direction checks, prefer `tbd dep list <id>`. For child issues, the
+parent’s details (ID, title, status, priority, description) are automatically displayed
+below the child for context.
 
 ### update
 
@@ -449,6 +454,10 @@ Subcommands:
 - `add <issue> <depends-on>` - Issue depends on depends-on (depends-on blocks issue)
 - `remove <issue> <depends-on>` - Remove dependency
 - `list <id>` - List dependencies for an issue (what it blocks and what blocks it)
+
+Use `tbd dep list <id>` when checking dependency direction.
+The raw `dependencies` frontmatter in `tbd show` stores graph edges where `type: blocks`
+means the shown issue blocks the target.
 
 ### sync
 

--- a/packages/tbd/src/cli/commands/dep.ts
+++ b/packages/tbd/src/cli/commands/dep.ts
@@ -8,6 +8,7 @@ import { Command } from 'commander';
 
 import { BaseCommand } from '../lib/base-command.js';
 import { requireInit, NotFoundError, ValidationError } from '../lib/errors.js';
+import { getDependencyDirections } from '../lib/dependency-format.js';
 import { readIssue, writeIssue, listIssues } from '../../file/storage.js';
 import { formatDisplayId, formatDebugId } from '../../lib/ids.js';
 import type { Issue } from '../../lib/types.js';
@@ -220,30 +221,11 @@ class DependsListHandler extends BaseCommand {
     const config = await readConfig(tbdRoot);
     const prefix = config.display.id_prefix;
 
-    // Find what this issue blocks (from its dependencies)
-    const blocks = issue.dependencies
-      .filter((dep) => dep.type === 'blocks')
-      .map((dep) =>
-        showDebug
-          ? formatDebugId(dep.target, mapping, prefix)
-          : formatDisplayId(dep.target, mapping, prefix),
-      );
-
-    // Find what blocks this issue (reverse lookup)
-    const blockedBy: string[] = [];
-    for (const other of allIssues) {
-      for (const dep of other.dependencies) {
-        if (dep.type === 'blocks' && dep.target === internalId) {
-          blockedBy.push(
-            showDebug
-              ? formatDebugId(other.id, mapping, prefix)
-              : formatDisplayId(other.id, mapping, prefix),
-          );
-        }
-      }
-    }
-
-    const deps = { blocks, blockedBy };
+    const deps = getDependencyDirections(issue, allIssues, (dependencyId) =>
+      showDebug
+        ? formatDebugId(dependencyId, mapping, prefix)
+        : formatDisplayId(dependencyId, mapping, prefix),
+    );
     this.output.data(deps, () => {
       const colors = this.output.getColors();
       if (deps.blocks.length > 0) {

--- a/packages/tbd/src/cli/commands/show.ts
+++ b/packages/tbd/src/cli/commands/show.ts
@@ -9,7 +9,12 @@ import { Command } from 'commander';
 import { BaseCommand } from '../lib/base-command.js';
 import { NotFoundError } from '../lib/errors.js';
 import { loadFullContext } from '../lib/data-context.js';
-import { readIssue } from '../../file/storage.js';
+import {
+  formatDependencyDirectionComments,
+  getDependencyDirections,
+  type DependencyDirections,
+} from '../lib/dependency-format.js';
+import { readIssue, listIssues } from '../../file/storage.js';
 import { serializeIssue } from '../../file/parser.js';
 import { formatPriority, getPriorityColor } from '../../lib/priority.js';
 import { getStatusColor } from '../../lib/status.js';
@@ -28,16 +33,28 @@ interface ShowOptions {
  *
  * @param issue - The issue to render
  * @param colors - Color functions
- * @param maxLines - If set, truncate output to this many lines with an omission notice
+ * @param dependencyDirections - Optional human-facing dependency direction comments
  * @returns Array of formatted lines
  */
-function renderIssueLines(issue: Issue, colors: ReturnType<typeof createColors>): string[] {
+function renderIssueLines(
+  issue: Issue,
+  colors: ReturnType<typeof createColors>,
+  dependencyDirections?: DependencyDirections,
+): string[] {
   const serialized = serializeIssue(issue);
   const output: string[] = [];
+  const dependencyDirectionComments = dependencyDirections
+    ? formatDependencyDirectionComments(dependencyDirections)
+    : [];
 
   for (const line of serialized.split('\n')) {
     if (line === '---') {
       output.push(colors.dim(line));
+    } else if (line.startsWith('dependencies:')) {
+      for (const comment of dependencyDirectionComments) {
+        output.push(colors.dim(comment));
+      }
+      output.push(line);
     } else if (line.startsWith('id:')) {
       output.push(`${colors.dim('id:')} ${colors.id(line.slice(4))}`);
     } else if (line.startsWith('status:')) {
@@ -116,6 +133,15 @@ class ShowHandler extends BaseCommand {
 
     // Format display ID using helper (respects debug mode automatically)
     const displayId = ctx.displayId(issue.id);
+    const allIssues = ctx.cli.json ? undefined : await listIssues(ctx.dataSyncDir);
+    const displayDependencyId = (dependencyId: string) => ctx.displayId(dependencyId);
+    const dependencyDirections = allIssues
+      ? getDependencyDirections(issue, allIssues, displayDependencyId)
+      : undefined;
+    const parentDependencyDirections =
+      allIssues && parentIssue
+        ? getDependencyDirections(parentIssue, allIssues, displayDependencyId)
+        : undefined;
 
     // Create display version with short display ID
     const displayIssue = {
@@ -135,14 +161,14 @@ class ShowHandler extends BaseCommand {
       const colors = this.output.getColors();
 
       // Render main issue first (what the user asked for)
-      const issueLines = renderIssueLines(issue, colors);
+      const issueLines = renderIssueLines(issue, colors, dependencyDirections);
       printWithTruncation(issueLines, colors, maxLines);
 
       // Show parent context below if this is a child issue
       if (parentIssue) {
         console.log('');
         console.log(colors.dim('The parent of this bead is:'));
-        const parentLines = renderIssueLines(parentIssue, colors);
+        const parentLines = renderIssueLines(parentIssue, colors, parentDependencyDirections);
         printWithTruncation(parentLines, colors, PARENT_CONTEXT_MAX_LINES);
       }
 

--- a/packages/tbd/src/cli/lib/dependency-format.ts
+++ b/packages/tbd/src/cli/lib/dependency-format.ts
@@ -1,0 +1,55 @@
+/**
+ * Dependency direction formatting shared by CLI commands.
+ */
+
+import type { Issue } from '../../lib/types.js';
+
+/**
+ * Human-facing dependency directions for an issue.
+ */
+export interface DependencyDirections {
+  /** Issues this issue blocks. */
+  blocks: string[];
+  /** Issues that block this issue. */
+  blockedBy: string[];
+}
+
+/**
+ * Compute display-ready dependency directions for an issue.
+ */
+export function getDependencyDirections(
+  issue: Issue,
+  allIssues: Issue[],
+  displayId: (internalId: string) => string,
+): DependencyDirections {
+  const blocks = issue.dependencies
+    .filter((dep) => dep.type === 'blocks')
+    .map((dep) => displayId(dep.target));
+
+  const blockedBy: string[] = [];
+  for (const other of allIssues) {
+    for (const dep of other.dependencies) {
+      if (dep.type === 'blocks' && dep.target === issue.id) {
+        blockedBy.push(displayId(other.id));
+      }
+    }
+  }
+
+  return { blocks, blockedBy };
+}
+
+/**
+ * Render dependency directions as YAML comments for round-trippable show output.
+ */
+export function formatDependencyDirectionComments(directions: DependencyDirections): string[] {
+  const lines: string[] = [];
+
+  if (directions.blocks.length > 0) {
+    lines.push(`# Blocks: ${directions.blocks.join(', ')}`);
+  }
+  if (directions.blockedBy.length > 0) {
+    lines.push(`# Blocked by: ${directions.blockedBy.join(', ')}`);
+  }
+
+  return lines;
+}

--- a/packages/tbd/tests/cli-workflow.tryscript.md
+++ b/packages/tbd/tests/cli-workflow.tryscript.md
@@ -382,6 +382,22 @@ Blocks: test-[SHORTID]
 ? 0
 ```
 
+# Test: Show child explains what blocks it
+
+```console
+$ tbd show $(cat dep_child.txt) | grep "# Blocked by:"
+# Blocked by: test-[SHORTID]
+? 0
+```
+
+# Test: Show parent explains what it blocks
+
+```console
+$ tbd show $(cat dep_parent.txt) | grep "# Blocks:"
+# Blocks: test-[SHORTID]
+? 0
+```
+
 # Test: Dep list as JSON
 
 ```console


### PR DESCRIPTION
## Summary
- Add shared dependency-direction formatting for CLI output.
- Add `Blocks:` / `Blocked by:` YAML comments to text `tbd show` output while preserving round-trip YAML parsing and JSON output.
- Update docs, workflow coverage, and patch changeset.
- Refresh generated agent integration docs after the setup/test run.

Fixes #119.

## Validation
- `pnpm format:check`
- `pnpm lint:check`
- `pnpm build`
- `pnpm test` (57 files, 1064 tests)
- `pnpm --filter get-tbd exec tryscript run tests/cli-workflow.tryscript.md` (54 passed)
- pre-push hook: build check up to date, `pnpm test` passed (57 files, 1064 tests)