### PR TITLE
fix: Address PR #121 review feedback

### DIFF
--- a/.changeset/shared-common-dir-worktree.md
+++ b/.changeset/shared-common-dir-worktree.md
@@ -6,3 +6,8 @@ linked worktrees share one `tbd-sync` worktree.
 This adds the `f04` local layout format, `sync.storage: git-common-dir-v1`, common-dir
 layout metadata, shared locking, legacy per-checkout worktree migration, and clearer
 upgrade errors when a repository requires a newer tbd version.
+
+Upgrade note: after this release writes `tbd_format: f04` to `.tbd/config.yml`, older
+tbd clients (pre-f04) on the same repository will fail closed with a “newer tbd version”
+error rather than silently rewriting the legacy per-checkout layout.
+Run `npm install -g get-tbd@latest` on every machine that touches the repo.

--- a/docs/project/specs/active/plan-2026-05-17-shared-common-dir-sync-worktree.md
+++ b/docs/project/specs/active/plan-2026-05-17-shared-common-dir-sync-worktree.md
@@ -550,39 +550,39 @@ Doctor output will change to show the shared local sync location.
 
 ### Phase 1: Design Spike And Shared Resolver
 
-- [ ] Add a small research tryscript proving a hidden worktree under
+- [x] Add a small research tryscript proving a hidden worktree under
   `$GIT_COMMON_DIR/tbd/data-sync-worktree/` works from the main checkout and a linked
   worktree.
-- [ ] Add the common-dir layout metadata module and `layout.yml` schema.
-- [ ] Add path helpers for absolute Git common directory resolution.
-- [ ] Add shared lock path helper.
-- [ ] Add shared worktree health detection without changing production writes yet.
-- [ ] Add doctor output that reports both the current legacy location and the proposed
+- [x] Add the common-dir layout metadata module and `layout.yml` schema.
+- [x] Add path helpers for absolute Git common directory resolution.
+- [x] Add shared lock path helper.
+- [x] Add shared worktree health detection without changing production writes yet.
+- [x] Add doctor output that reports both the current legacy location and the proposed
   shared location.
 
 ### Phase 2: Format Migration And Old-Client Guard
 
-- [ ] Add `f04` to `.tbd/config.yml` format history.
-- [ ] Add the selected sync storage marker to config schema and migration.
-- [ ] Add a shared command entry helper that reads config and checks format
+- [x] Add `f04` to `.tbd/config.yml` format history.
+- [x] Add the selected sync storage marker to config schema and migration.
+- [x] Add a shared command entry helper that reads config and checks format
   compatibility before resolving data paths or initializing worktrees.
-- [ ] Audit every command that can create or mutate `.tbd/data-sync-worktree/` so config
+- [x] Audit every command that can create or mutate `.tbd/data-sync-worktree/` so config
   compatibility is checked before legacy writes happen.
-- [ ] Make `f04` plus missing `layout.yml` initialize or migrate under the common lock.
-- [ ] Make `f04` plus corrupt, mismatched, or future-version `layout.yml` fail closed,
+- [x] Make `f04` plus missing `layout.yml` initialize or migrate under the common lock.
+- [x] Make `f04` plus corrupt, mismatched, or future-version `layout.yml` fail closed,
   with repair routed through `tbd doctor --fix`.
-- [ ] Add an idempotent migration path for rerunning setup or doctor after a partial
+- [x] Add an idempotent migration path for rerunning setup or doctor after a partial
   migration.
 
 ### Phase 3: Shared Worktree Write Path
 
-- [ ] Initialize the shared worktree from local or remote `tbd-sync`.
-- [ ] Route production `resolveDataSyncDir()` to the shared data-sync directory.
-- [ ] Wrap mutating commands and sync in the shared lock.
-- [ ] Update sync to commit/merge/push through the shared worktree.
-- [ ] Add migration from legacy per-checkout worktrees.
-- [ ] Update uninstall and cleanup behavior.
-- [ ] Update docs and troubleshooting guidance.
+- [x] Initialize the shared worktree from local or remote `tbd-sync`.
+- [x] Route production `resolveDataSyncDir()` to the shared data-sync directory.
+- [x] Wrap mutating commands and sync in the shared lock.
+- [x] Update sync to commit/merge/push through the shared worktree.
+- [x] Add migration from legacy per-checkout worktrees.
+- [x] Update uninstall and cleanup behavior.
+- [x] Update docs and troubleshooting guidance.
 
 ## Testing Strategy
 

--- a/packages/tbd/docs/tbd-design.md
+++ b/packages/tbd/docs/tbd-design.md
@@ -3412,9 +3412,12 @@ The `--fix` flag performs repairs in this order:
 5. Rebuild ID mappings if corrupted
 6. Remove orphaned dependency references
 
-> **Note:** Backups are stored in `.tbd/backups/` which is gitignored.
-> Users can manually inspect backups to recover any data that wasn’t committed before
-> the worktree became corrupted.
+> **Note:** Migration and repair backups are stored under `$GIT_COMMON_DIR/tbd/backups/`
+> (alongside the shared sync worktree, outside the working tree and never committed).
+> Older clients may still have data in `.tbd/backups/`, which is kept gitignored for
+> legacy compatibility but is no longer the active write location.
+> Users can manually inspect backups in either location to recover any data that wasn’t
+> committed before the worktree became corrupted.
 
 #### Compact (Future)
 

--- a/packages/tbd/src/cli/commands/setup.ts
+++ b/packages/tbd/src/cli/commands/setup.ts
@@ -1102,28 +1102,27 @@ class SetupDefaultHandler extends BaseCommand {
       console.log(`  ${colors.success('✓')} tbd initialized (prefix: ${config.display.id_prefix})`);
 
       // Apply --no-gh-cli flag to config if specified
-      let needsConfigWrite = migrated;
+      let ghCliChanged = false;
       if (options.ghCli === false && config.settings.use_gh_cli !== false) {
         config.settings.use_gh_cli = false;
-        needsConfigWrite = true;
+        ghCliChanged = true;
       }
 
       if (migrated) {
+        // Initialize the shared common-dir layout under the data-sync lock.
+        // prepareDataSyncContext also persists the migrated config to disk, so
+        // we don't need a separate writeConfig() for the migration itself.
         await withDataSyncContext(projectDir, { lock: true }, async () => undefined);
+        console.log(`  ${colors.success('✓')} Config migrated to latest format`);
+        for (const change of changes) {
+          console.log(`      ${colors.dim(change)}`);
+        }
       }
 
-      // Persist config if migrated or --no-gh-cli was applied
-      if (needsConfigWrite) {
+      // Persist non-migration changes (e.g., --no-gh-cli) as a single explicit write.
+      if (ghCliChanged) {
         await writeConfig(projectDir, config);
-        if (migrated) {
-          console.log(`  ${colors.success('✓')} Config migrated to latest format`);
-          for (const change of changes) {
-            console.log(`      ${colors.dim(change)}`);
-          }
-        }
-        if (options.ghCli === false) {
-          console.log(`  ${colors.success('✓')} Disabled gh CLI auto-setup`);
-        }
+        console.log(`  ${colors.success('✓')} Disabled gh CLI auto-setup`);
       }
 
       console.log('');

--- a/packages/tbd/src/cli/commands/sync.ts
+++ b/packages/tbd/src/cli/commands/sync.ts
@@ -19,6 +19,8 @@ import {
 } from '../../file/git.js';
 import { DATA_SYNC_DIR } from '../../lib/paths.js';
 import { join } from 'node:path';
+import { access, readFile } from 'node:fs/promises';
+import { writeFile } from 'atomically';
 import {
   type SyncSummary,
   type SyncTallies,
@@ -643,7 +645,6 @@ class SyncHandler extends BaseCommand {
       // This prevents conflicts when both sides add non-overlapping keys.
       // Written before every merge so existing repos get it on their next sync.
       {
-        const { access, writeFile } = await import('node:fs/promises');
         const attrPath = join(this.dataSyncDir, 'mappings', '.gitattributes');
         try {
           await access(attrPath);
@@ -787,7 +788,6 @@ class SyncHandler extends BaseCommand {
             if (remoteIdsContent) {
               conflictRemoteMapping = parseIdMappingFromYaml(remoteIdsContent);
               // Read the on-disk file (which may have conflict markers) and resolve
-              const { readFile } = await import('node:fs/promises');
               const idsPath = join(this.dataSyncDir, 'mappings', 'ids.yml');
               const rawContent = await readFile(idsPath, 'utf-8');
               const localMapping = resolveIdMappingConflicts(rawContent);

--- a/packages/tbd/src/cli/commands/uninstall.ts
+++ b/packages/tbd/src/cli/commands/uninstall.ts
@@ -41,7 +41,15 @@ class UninstallHandler extends BaseCommand {
     const syncBranch = config?.sync.branch ?? SYNC_BRANCH;
     const remote = config?.sync.remote ?? 'origin';
     const tbdDir = join(tbdRoot, '.tbd');
-    const sharedPaths = await resolveSharedTbdPaths(tbdRoot).catch(() => null);
+    const sharedPaths = await resolveSharedTbdPaths(tbdRoot).catch((error: unknown) => {
+      // Most often this is "not in a git repo" or git is unavailable; either way we
+      // can still uninstall, but surface the real cause when --debug is set so the
+      // operator can investigate later "Could not remove shared common-dir metadata".
+      this.output.debug(
+        `resolveSharedTbdPaths failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return null;
+    });
     const worktreePath = sharedPaths?.sharedWorktreePath ?? join(tbdDir, 'data-sync-worktree');
     const legacyWorktreePath = join(tbdDir, 'data-sync-worktree');
 

--- a/packages/tbd/src/cli/lib/data-context.ts
+++ b/packages/tbd/src/cli/lib/data-context.ts
@@ -116,10 +116,8 @@ export async function prepareDataSyncContext(tbdRoot: string): Promise<TbdDataCo
     }
   }
 
-  if (existingLayout) {
-    validateCommonDirLayout(existingLayout, config);
-  } else {
-    await writeCommonDirLayout(sharedPaths, config, existingLayout);
+  if (!existingLayout) {
+    await writeCommonDirLayout(sharedPaths, config, null);
   }
 
   if (migrated) {
@@ -154,8 +152,17 @@ export async function withDataSyncContext<T>(
   return run();
 }
 
+/**
+ * Load the shared data-sync context for a read-only command.
+ *
+ * Reads do not need to serialize behind the heavy data-sync lock: a concurrent
+ * sync may produce a momentarily inconsistent view, but write-side commands use
+ * `withDataSyncContext(..., { lock: true }, ...)` so concurrent writers remain
+ * mutually exclusive. Avoiding the lock here keeps trivial reads from waiting
+ * out a long sync.
+ */
 export async function loadDataContext(tbdRoot: string): Promise<TbdDataContext> {
-  return withDataSyncContext(tbdRoot, { lock: true }, async (context) => context);
+  return withDataSyncContext(tbdRoot, { lock: false }, async (context) => context);
 }
 
 /**

--- a/packages/tbd/src/cli/lib/errors.ts
+++ b/packages/tbd/src/cli/lib/errors.ts
@@ -79,34 +79,6 @@ export class SyncError extends CLIError {
 }
 
 /**
- * Worktree missing error - the shared data-sync-worktree directory doesn't exist.
- * This indicates the worktree was never created or was deleted.
- * See: tbd-design.md §2.3.6 Worktree Error Classes
- */
-export class WorktreeMissingError extends CLIError {
-  constructor(
-    message = "Shared worktree not found under $GIT_COMMON_DIR/tbd/data-sync-worktree/. Run 'tbd doctor --fix' to repair.",
-  ) {
-    super(message, 1);
-    this.name = 'WorktreeMissingError';
-  }
-}
-
-/**
- * Worktree corrupted error - the worktree exists but is invalid.
- * This can occur when the .git file is missing or points to an invalid location.
- * See: tbd-design.md §2.3.6 Worktree Error Classes
- */
-export class WorktreeCorruptedError extends CLIError {
-  constructor(
-    message = "Shared worktree under $GIT_COMMON_DIR/tbd/data-sync-worktree/ is corrupted. Run 'tbd doctor --fix' to repair.",
-  ) {
-    super(message, 1);
-    this.name = 'WorktreeCorruptedError';
-  }
-}
-
-/**
  * Sync branch error - issues with the tbd-sync branch.
  * This can indicate the branch is missing, orphaned, or has diverged.
  * See: tbd-design.md §2.3.6 Worktree Error Classes

--- a/packages/tbd/src/file/common-dir-layout.ts
+++ b/packages/tbd/src/file/common-dir-layout.ts
@@ -57,7 +57,9 @@ export function validateCommonDirLayout(layout: CommonDirLayout, config: Config)
   if (layout.tbd_format !== config.tbd_format) {
     throw new CommonDirLayoutError(
       `Common-dir layout format '${layout.tbd_format}' does not match config format ` +
-        `'${config.tbd_format}'. Run 'tbd doctor --fix' to repair.`,
+        `'${config.tbd_format}'. This indicates a partial migration or manual edit. ` +
+        `To recover, delete the layout file so it is rewritten from the current config: ` +
+        `rm "$(git rev-parse --git-common-dir)/tbd/layout.yml"`,
     );
   }
 
@@ -66,7 +68,9 @@ export function validateCommonDirLayout(layout: CommonDirLayout, config: Config)
   if (layoutStorage !== configStorage) {
     throw new CommonDirLayoutError(
       `Common-dir sync storage '${layoutStorage}' does not match config storage ` +
-        `'${configStorage}'. Run 'tbd doctor --fix' to repair.`,
+        `'${configStorage}'. This indicates a partial migration or manual edit. ` +
+        `To recover, delete the layout file so it is rewritten from the current config: ` +
+        `rm "$(git rev-parse --git-common-dir)/tbd/layout.yml"`,
     );
   }
 }

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -1051,7 +1051,7 @@ async function preserveLegacyWorktreeHead(
     return;
   }
 
-  const backupBranch = `tbd-legacy-preserve-${nowFilenameTimestamp().replace(/[^0-9A-Za-z-]/g, '-')}`;
+  const backupBranch = `tbd-legacy-preserve-${nowFilenameTimestamp()}`;
   await git('-C', baseDir, 'branch', backupBranch, head);
   throw new Error(
     `Legacy sync worktree at ${legacyPath} diverges from ${syncBranch}. ` +

--- a/packages/tbd/src/lib/paths.ts
+++ b/packages/tbd/src/lib/paths.ts
@@ -51,12 +51,14 @@ export const WORKTREE_DIR_NAME = 'data-sync-worktree';
 export const LEGACY_WORKTREE_DIR = join(TBD_DIR, WORKTREE_DIR_NAME);
 
 /**
- * Shared worktree path relative to a primary checkout whose .git is a directory.
+ * @internal Primary-checkout relative path to the shared sync worktree.
  *
- * Production code should use resolveSharedTbdPaths() because linked worktrees have
- * a .git file rather than a .git directory.
+ * Only valid when `.git` is a directory (i.e., the primary checkout). Production
+ * code must call resolveSharedTbdPaths() instead: linked worktrees have a `.git`
+ * file, so this constant resolves to the wrong location for them. Intended for
+ * tests and the non-git fallback in resolveDataSyncDir().
  */
-export const WORKTREE_DIR = join('.git', 'tbd', WORKTREE_DIR_NAME);
+export const PRIMARY_CHECKOUT_WORKTREE_DIR = join('.git', 'tbd', WORKTREE_DIR_NAME);
 
 /** The data directory name on the sync branch */
 export const DATA_SYNC_DIR_NAME = 'data-sync';
@@ -70,11 +72,17 @@ export const DATA_SYNC_DIR_NAME = 'data-sync';
 export const DATA_SYNC_DIR = join(TBD_DIR, DATA_SYNC_DIR_NAME);
 
 /**
- * Static primary-checkout path for synced data via the shared worktree.
- * Production code should use resolveSharedTbdPaths() so linked worktrees with .git files
- * resolve to the same Git common-dir location.
+ * @internal Primary-checkout relative path to the synced data via the shared worktree.
+ *
+ * Same caveat as `PRIMARY_CHECKOUT_WORKTREE_DIR`: only valid for a primary checkout.
+ * Production code should resolve the absolute path with resolveDataSyncDir(); this
+ * constant is intended for tests and the non-git fallback path.
  */
-export const DATA_SYNC_DIR_VIA_WORKTREE = join(WORKTREE_DIR, TBD_DIR, DATA_SYNC_DIR_NAME);
+export const PRIMARY_CHECKOUT_DATA_SYNC_DIR = join(
+  PRIMARY_CHECKOUT_WORKTREE_DIR,
+  TBD_DIR,
+  DATA_SYNC_DIR_NAME,
+);
 
 /** Issues directory */
 export const ISSUES_DIR = join(DATA_SYNC_DIR, 'issues');
@@ -453,7 +461,7 @@ export async function resolveDataSyncDir(
   } catch {
     // Not in a git repository or git is unavailable. Check the static primary-checkout
     // path for unit tests before falling back to the direct diagnostic path.
-    worktreePath = join(baseDir, DATA_SYNC_DIR_VIA_WORKTREE);
+    worktreePath = join(baseDir, PRIMARY_CHECKOUT_DATA_SYNC_DIR);
   }
   const directPath = join(baseDir, DATA_SYNC_DIR);
 
@@ -484,9 +492,9 @@ export async function resolveDataSyncDir(
         '[tbd:paths] resolveDataSyncDir: worktree not found, falling back to direct path',
       );
     }
-    _resolvedDataSyncDir = directPath;
-    _resolvedBaseDir = baseDir;
-    _resolvedAllowFallback = allowFallback;
+    // Intentionally do NOT cache the fallback result: a later call after the
+    // worktree is created must rediscover the real path, not keep returning
+    // the stale fallback.
     return directPath;
   }
 }

--- a/packages/tbd/src/utils/lockfile.ts
+++ b/packages/tbd/src/utils/lockfile.ts
@@ -63,11 +63,13 @@ const DEFAULT_STALE_MS = 5_000;
  * Lock timing profile for shared data-sync operations.
  *
  * Issue sync can include fetch, merge, push, and outbox import work, so it must
- * not use the short stale window intended for single-file writes.
+ * not use the short stale window intended for single-file writes. `timeoutMs`
+ * is kept just above `staleMs` so a crashed-process lock is always broken as
+ * stale before the timeout expires, matching the invariant documented above.
  */
 export const DATA_SYNC_LOCK_OPTIONS: Required<LockfileOptions> = {
-  timeoutMs: 120_000,
-  pollMs: 100,
+  timeoutMs: 35 * 60_000,
+  pollMs: 250,
   staleMs: 30 * 60_000,
 };
 

--- a/packages/tbd/tests/git-remote.test.ts
+++ b/packages/tbd/tests/git-remote.test.ts
@@ -29,7 +29,12 @@ import {
   checkGitVersion,
 } from '../src/file/git.js';
 import { getUpdatedIssues } from '../src/file/workspace.js';
-import { WORKTREE_DIR, TBD_DIR, DATA_SYNC_DIR_NAME, SYNC_BRANCH } from '../src/lib/paths.js';
+import {
+  PRIMARY_CHECKOUT_WORKTREE_DIR,
+  TBD_DIR,
+  DATA_SYNC_DIR_NAME,
+  SYNC_BRANCH,
+} from '../src/lib/paths.js';
 import { TEST_ULIDS, testId, createTestIssue } from './test-helpers.js';
 
 const execFileAsync = promisify(execFile);
@@ -134,7 +139,7 @@ describeUnlessWindows('git remote integration', () => {
       expect(await worktreeExists(workRepoPath)).toBe(true);
 
       // Verify worktree has the expected structure
-      const worktreePath = join(workRepoPath, WORKTREE_DIR);
+      const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
       const dataSyncPath = join(worktreePath, TBD_DIR, DATA_SYNC_DIR_NAME);
       const issuesDir = await readdir(join(dataSyncPath, 'issues'));
       expect(issuesDir).toContain('.gitkeep');
@@ -157,7 +162,7 @@ describeUnlessWindows('git remote integration', () => {
       await initWorktree(workRepoPath);
 
       // Remove the worktree but keep the branch
-      const worktreePath = join(workRepoPath, WORKTREE_DIR);
+      const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
       await gitInDir(workRepoPath, 'worktree', 'remove', worktreePath, '--force');
 
       // Now init should use existing branch
@@ -174,7 +179,7 @@ describeUnlessWindows('git remote integration', () => {
       await initWorktree(workRepoPath);
 
       // Write an issue to the worktree
-      const worktreePath = join(workRepoPath, WORKTREE_DIR);
+      const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
       const dataSyncPath = join(worktreePath, TBD_DIR, DATA_SYNC_DIR_NAME);
 
       const issue = createTestIssue({
@@ -197,7 +202,7 @@ describeUnlessWindows('git remote integration', () => {
     it('verifies remote branch exists after push', async () => {
       // Initialize in first repo
       await initWorktree(workRepoPath);
-      const worktreePath = join(workRepoPath, WORKTREE_DIR);
+      const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
       const dataSyncPath = join(worktreePath, TBD_DIR, DATA_SYNC_DIR_NAME);
 
       // Write and push an issue
@@ -218,7 +223,7 @@ describeUnlessWindows('git remote integration', () => {
     it('updates worktree after local commits', async () => {
       // Setup repo with sync branch
       await initWorktree(workRepoPath);
-      const worktreePath = join(workRepoPath, WORKTREE_DIR);
+      const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
       const dataSyncPath = join(worktreePath, TBD_DIR, DATA_SYNC_DIR_NAME);
 
       // Add first issue
@@ -366,7 +371,7 @@ describeUnlessWindows('concurrent sync operations', () => {
 
     // Initialize worktree and push initial state
     await initWorktree(repo1Path);
-    const worktree1 = join(repo1Path, WORKTREE_DIR);
+    const worktree1 = join(repo1Path, PRIMARY_CHECKOUT_WORKTREE_DIR);
     const dataSync1 = join(worktree1, TBD_DIR, DATA_SYNC_DIR_NAME);
 
     const issue1 = createTestIssue({
@@ -437,7 +442,7 @@ describeUnlessWindows('bulk outbox save bug fix', () => {
   it('mergeIssues does not bump version when merging identical issues', async () => {
     // Setup: create N issues in worktree and push to remote
     await initWorktree(workRepoPath);
-    const worktreePath = join(workRepoPath, WORKTREE_DIR);
+    const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
     const dataSyncPath = join(worktreePath, TBD_DIR, DATA_SYNC_DIR_NAME);
 
     const ISSUE_COUNT = 20;
@@ -479,7 +484,7 @@ describeUnlessWindows('bulk outbox save bug fix', () => {
 
   it('mergeIssues only bumps version for substantively changed issues', async () => {
     await initWorktree(workRepoPath);
-    const worktreePath = join(workRepoPath, WORKTREE_DIR);
+    const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
     const dataSyncPath = join(worktreePath, TBD_DIR, DATA_SYNC_DIR_NAME);
 
     // Create base issue
@@ -578,7 +583,7 @@ describeUnlessWindows('bulk outbox save bug fix', () => {
     // Setup: create issues, push to remote, then simulate a merge that
     // touches all issues with version/timestamp bumps
     await initWorktree(workRepoPath);
-    const worktreePath = join(workRepoPath, WORKTREE_DIR);
+    const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
     const dataSyncPath = join(worktreePath, TBD_DIR, DATA_SYNC_DIR_NAME);
 
     const ISSUE_COUNT = 10;

--- a/packages/tbd/tests/tbd-format.test.ts
+++ b/packages/tbd/tests/tbd-format.test.ts
@@ -238,7 +238,7 @@ describe('tbd-format', () => {
   });
 
   describe('describeMigration', () => {
-    it('describes f01 migration (two steps)', () => {
+    it('describes f01 migration (three steps)', () => {
       const descriptions = describeMigration('f01');
       expect(descriptions).toHaveLength(3);
       expect(descriptions[0]).toContain('f01 → f02');

--- a/packages/tbd/tests/worktree-health.test.ts
+++ b/packages/tbd/tests/worktree-health.test.ts
@@ -29,7 +29,7 @@ import {
   clearPathCache,
 } from '../src/lib/paths.js';
 import {
-  WORKTREE_DIR,
+  PRIMARY_CHECKOUT_WORKTREE_DIR,
   TBD_DIR,
   DATA_SYNC_DIR_NAME,
   SYNC_BRANCH,
@@ -143,7 +143,7 @@ describeUnlessWindows('worktree health checks', () => {
       expect(health.status).toBe('valid');
 
       // Delete the worktree directory manually (simulating user deletion)
-      const worktreePath = join(workRepoPath, WORKTREE_DIR);
+      const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
       await rm(worktreePath, { recursive: true, force: true });
 
       // Check health again - git worktree list should show it as prunable
@@ -188,7 +188,7 @@ describeUnlessWindows('worktree health checks', () => {
       await initWorktree(workRepoPath);
 
       // Push the sync branch to remote
-      const worktreePath = join(workRepoPath, WORKTREE_DIR);
+      const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
       await gitInDir(worktreePath, 'push', '-u', 'origin', SYNC_BRANCH);
 
       const health = await checkRemoteBranchHealth('origin', SYNC_BRANCH);
@@ -204,7 +204,7 @@ describeUnlessWindows('worktree health checks', () => {
       await initWorktree(workRepoPath);
 
       // Push to remote
-      const worktreePath = join(workRepoPath, WORKTREE_DIR);
+      const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
       await gitInDir(worktreePath, 'push', '-u', 'origin', SYNC_BRANCH);
 
       const consistency = await checkSyncConsistency(workRepoPath, SYNC_BRANCH, 'origin');
@@ -222,7 +222,7 @@ describeUnlessWindows('worktree health checks', () => {
       await initWorktree(workRepoPath);
 
       // Push to remote
-      const worktreePath = join(workRepoPath, WORKTREE_DIR);
+      const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
       await gitInDir(worktreePath, 'push', '-u', 'origin', SYNC_BRANCH);
 
       // Create a new commit in worktree (making local ahead)
@@ -281,7 +281,7 @@ describe('resolveDataSyncDir with allowFallback option', () => {
 
   it('returns worktree path when worktree exists', async () => {
     // Create the worktree directory structure
-    const worktreePath = join(testDir, WORKTREE_DIR, TBD_DIR, DATA_SYNC_DIR_NAME);
+    const worktreePath = join(testDir, PRIMARY_CHECKOUT_WORKTREE_DIR, TBD_DIR, DATA_SYNC_DIR_NAME);
     await mkdir(worktreePath, { recursive: true });
 
     clearPathCache();
@@ -350,7 +350,7 @@ describeUnlessWindows('repairWorktree', () => {
     await initWorktree(workRepoPath);
 
     // Delete the worktree directory to make it prunable
-    const worktreePath = join(workRepoPath, WORKTREE_DIR);
+    const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
     await rm(worktreePath, { recursive: true, force: true });
 
     // Repair the prunable worktree
@@ -369,7 +369,7 @@ describeUnlessWindows('repairWorktree', () => {
     await initWorktree(workRepoPath);
 
     // Corrupt the worktree by removing .git file but keeping directory
-    const worktreePath = join(workRepoPath, WORKTREE_DIR);
+    const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
     const dotGitPath = join(worktreePath, '.git');
     await rm(dotGitPath, { force: true });
 
@@ -457,7 +457,7 @@ describeUnlessWindows('migrateDataToWorktree', () => {
     // Verify data is now in the correct location
     const correctIssuesPath = join(
       workRepoPath,
-      WORKTREE_DIR,
+      PRIMARY_CHECKOUT_WORKTREE_DIR,
       TBD_DIR,
       DATA_SYNC_DIR_NAME,
       'issues',
@@ -484,7 +484,7 @@ describeUnlessWindows('migrateDataToWorktree', () => {
     // Verify data is now in the correct location
     const correctMappingsPath = join(
       workRepoPath,
-      WORKTREE_DIR,
+      PRIMARY_CHECKOUT_WORKTREE_DIR,
       TBD_DIR,
       DATA_SYNC_DIR_NAME,
       'mappings',
@@ -515,7 +515,7 @@ dd44: 01aaaaaaaaaaaaaaaaaaaaaa04
 
     const correctMappingsPath = join(
       workRepoPath,
-      WORKTREE_DIR,
+      PRIMARY_CHECKOUT_WORKTREE_DIR,
       TBD_DIR,
       DATA_SYNC_DIR_NAME,
       'mappings',
@@ -641,7 +641,7 @@ This issue tests that all data is preserved during migration.
     // Verify data integrity
     const correctIssuesPath = join(
       workRepoPath,
-      WORKTREE_DIR,
+      PRIMARY_CHECKOUT_WORKTREE_DIR,
       TBD_DIR,
       DATA_SYNC_DIR_NAME,
       'issues',
@@ -711,7 +711,13 @@ describeUnlessWindows('worktree health after init (CI check)', () => {
     await initWorktree(workRepoPath);
 
     // Create a test issue file in the worktree
-    const issuesPath = join(workRepoPath, WORKTREE_DIR, TBD_DIR, DATA_SYNC_DIR_NAME, 'issues');
+    const issuesPath = join(
+      workRepoPath,
+      PRIMARY_CHECKOUT_WORKTREE_DIR,
+      TBD_DIR,
+      DATA_SYNC_DIR_NAME,
+      'issues',
+    );
     await mkdir(issuesPath, { recursive: true });
     await fsWriteFile(
       join(issuesPath, 'is-0000000000000000000000test.md'),
@@ -812,7 +818,7 @@ describeUnlessWindows('architectural test: issues written to worktree path', () 
     // Verify issue exists in worktree path
     const worktreeIssuesPath = join(
       workRepoPath,
-      WORKTREE_DIR,
+      PRIMARY_CHECKOUT_WORKTREE_DIR,
       TBD_DIR,
       DATA_SYNC_DIR_NAME,
       'issues',
@@ -880,7 +886,7 @@ describeUnlessWindows('Bug tbd-vuuq: doctor --fix respects --dry-run flag', () =
   it('--dry-run should NOT repair prunable worktree', async () => {
     // Step 1: Initialize worktree
     await initWorktree(workRepoPath);
-    const worktreePath = join(workRepoPath, WORKTREE_DIR);
+    const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
 
     // Step 2: Delete worktree to make it prunable
     await rm(worktreePath, { recursive: true, force: true });
@@ -962,7 +968,7 @@ describeUnlessWindows('Bug tbd-m0wl: sync consistency detects unpushed commits',
   it('checkSyncConsistency detects local ahead when worktree has unpushed commits', async () => {
     // Step 1: Initialize worktree and push initial commit
     await initWorktree(workRepoPath);
-    const worktreePath = join(workRepoPath, WORKTREE_DIR);
+    const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
     await gitInDir(worktreePath, 'push', '-u', 'origin', SYNC_BRANCH);
 
     // Step 2: Create a new commit in worktree (not pushed)
@@ -981,7 +987,7 @@ describeUnlessWindows('Bug tbd-m0wl: sync consistency detects unpushed commits',
   it('checkSyncConsistency returns worktreeMatchesLocal=true after commits on branch', async () => {
     // This test verifies that after tbd-tg55 fix, commits in worktree update the branch
     await initWorktree(workRepoPath);
-    const worktreePath = join(workRepoPath, WORKTREE_DIR);
+    const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
 
     // Create a commit
     const testFile = join(worktreePath, TBD_DIR, DATA_SYNC_DIR_NAME, 'branch-test.txt');
@@ -1037,7 +1043,7 @@ describeUnlessWindows(
       await initWorktree(workRepoPath);
 
       // Verify initial state is on branch
-      const worktreePath = join(workRepoPath, WORKTREE_DIR);
+      const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
       const initialBranch = await gitInDir(worktreePath, 'branch', '--show-current');
       expect(initialBranch).toBe(SYNC_BRANCH);
 
@@ -1057,7 +1063,7 @@ describeUnlessWindows(
     it('commits after repair go to tbd-sync branch (not orphaned)', async () => {
       // Step 1: Initialize worktree
       await initWorktree(workRepoPath);
-      const worktreePath = join(workRepoPath, WORKTREE_DIR);
+      const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
 
       // Step 2: Get initial commit hash
       const _initialHead = await gitInDir(worktreePath, 'rev-parse', 'HEAD');
@@ -1094,7 +1100,7 @@ describeUnlessWindows(
       expect(result.success).toBe(true);
 
       // Get the worktree path
-      const worktreePath = join(workRepoPath, WORKTREE_DIR);
+      const worktreePath = join(workRepoPath, PRIMARY_CHECKOUT_WORKTREE_DIR);
 
       // Check that we're on the tbd-sync branch, not detached HEAD
       const branchOutput = await gitInDir(worktreePath, 'branch', '--show-current');


### PR DESCRIPTION
## Summary

Addresses the senior engineering review feedback on PR #121. Targets the PR #121 branch so the fixes can be merged into that PR.

## Blocking issues

- **Lock timing invariant (Issue #1):** `DATA_SYNC_LOCK_OPTIONS.timeoutMs` was 2 min while `staleMs` was 30 min, violating the documented `timeoutMs > staleMs` invariant. A crashed sync would have stuck callers for 2 min then failed with no stale-break ever triggering. Bumped `timeoutMs` to 35 min (and slowed `pollMs` from 100 → 250 ms to reduce wakeups during long syncs). Stale crashed locks are now reliably broken before the timeout.
- **`CommonDirLayoutError` told users to run `tbd doctor --fix` (Issue #2):** doctor has no awareness of `layout.yml` yet, so the error pointed at a tool that couldn't help. Replaced the message with a concrete recovery command: `rm "$(git rev-parse --git-common-dir)/tbd/layout.yml"`. Verified the recovery path works end-to-end (delete layout → next mutating command regenerates it from config).

## High-priority

- **Read-only commands serialized behind the heavy lock (Issue #3):** `loadDataContext` now defaults to `{ lock: false }`. Pure reads (`list`, `show`, `search`, `stale`, `blocked`, `ready`, `attic list`, `attic show`, `stats`, `prime`, `dep show`, `label list`) no longer wait out a 35-min sync. Mutations still explicitly call `withDataSyncContext(..., { lock: true }, ...)`.
- **Duplicate `WorktreeMissingError` (Issue #4):** Deleted the dead `errors.ts` copies of `WorktreeMissingError` and `WorktreeCorruptedError`; the live class in `paths.ts` is the one the production code actually throws.

## Medium-priority

- **Redundant validation + duplicate config write in migration path (Issue #5):** Removed the dead re-validation block in `prepareDataSyncContext` and restructured `setup.ts` so migration uses a single writer (the lock-scoped `prepareDataSyncContext`); the explicit `writeConfig` is now only invoked when `--no-gh-cli` is also applied.
- **`paths.ts` cache stale fallback (Issue #6):** `resolveDataSyncDir` no longer caches the fallback result — a later call after the shared worktree is created now rediscovers the real path instead of returning the stale fallback.
- **Misleading constant names (Issue #7):** Renamed `WORKTREE_DIR` → `PRIMARY_CHECKOUT_WORKTREE_DIR` and `DATA_SYNC_DIR_VIA_WORKTREE` → `PRIMARY_CHECKOUT_DATA_SYNC_DIR`, marked both `@internal`, and updated all test usages. The "primary-checkout-only, don't actually use this in production" caveat is now in the name itself.
- **`uninstall.ts` swallowed real cause of shared-paths failure (Issue #8):** Added `this.output.debug(...)` logging of the underlying `resolveSharedTbdPaths` error so `--debug` surfaces it.
- **Spec checkboxes still empty despite "Status: Implemented" (Issue #10):** Ticked all Implementation Plan / Testing Strategy boxes that landed in this PR.

## Nits

- `git.ts:1054` – removed the dead `.replace(/[^0-9A-Za-z-]/g, '-')` strip on the already filename-safe timestamp.
- `sync.ts:646,790` – replaced two inline `await import('node:fs/promises')` calls with top-level imports (using `writeFile` from `atomically` to satisfy the project's no-restricted-imports rule).
- `tbd-format.test.ts:241` – fixed "(two steps)" → "(three steps)" since `f01 → f04` is now three migrations.
- `.changeset/shared-common-dir-worktree.md` – added an explicit upgrade note that older clients fail closed on f04 repos.
- `tbd-design.md` – clarified that migration backups now live under `$GIT_COMMON_DIR/tbd/backups/`, with `.tbd/backups/` only retained for legacy compatibility.

## Items deferred (not in this commit)

- **Issue #9 (`let didX = false; ... if (!didX) return;` pattern across 6 commands):** Reviewer notes this would be a reasonable follow-up bundled with lock-hardening; left as-is to keep this change focused on correctness fixes rather than mechanical refactors.

## Upgrade-path verification

Verified end-to-end:

- New client (this branch's f04 build) on a fresh repo: `tbd init` + `tbd create` succeeds, writes `.tbd/config.yml` and `$GIT_COMMON_DIR/tbd/layout.yml` with `tbd_format: f04`.
- Old client (npm `get-tbd@0.1.27`, f03) on an f04 repo: rejected with `Config format 'f04' is from a newer tbd version. ... Please upgrade tbd: npm install -g get-tbd@latest`, exits non-zero, does not write legacy layout.
- New client on a future `tbd_format: f99` repo: new error message format reads `This repository requires a newer version of tbd. / ... is from a newer tbd version. / This tbd version supports up to format 'f04'. / Upgrade tbd: npm install -g get-tbd@latest`.
- Layout/config mismatch (f03 layout, f04 config): error tells the user exactly which file to delete; after deletion, the next `tbd create` regenerates the layout and succeeds.

## Test plan

- [x] `pnpm --filter get-tbd typecheck`
- [x] `pnpm lint:check`
- [x] `pnpm format:check`
- [x] `pnpm --filter get-tbd test` — 1071/1071 pass
- [x] `pnpm --filter get-tbd test:tryscript` — 795/795 pass
- [x] Pre-push hook (build + test) passed
- [x] Manual upgrade-path scenarios as described above

https://claude.ai/code/session_01UUy1cXJzUekQQJcLNNuqcp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUy1cXJzUekQQJcLNNuqcp)_