### PR TITLE
chore: release get-tbd v0.1.28

### DIFF
--- a/.changeset/clarify-show-dependencies.md
+++ b/.changeset/clarify-show-dependencies.md
@@ -1,5 +1,0 @@
----
-"get-tbd": patch
----
-Clarify dependency direction in `tbd show` output with `Blocks:` and `Blocked by:`
-comments.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -79,7 +79,81 @@ Choose version bump:
 - `minor` (0.1.0 → 0.2.0): New features, non-breaking changes
 - `major` (0.1.0 → 1.0.0): Breaking changes
 
-### Step 3: Create Changeset
+### Step 3: Supply-Chain Review
+
+Before bumping the version, review every dependency change since the previous release.
+Recent npm supply-chain attacks (typosquatted packages, hijacked maintainer accounts,
+post-install scripts) make this step non-optional even when the manifests look clean.
+
+#### 3a. Diff manifests and lockfile
+
+```bash
+PREV=$(git describe --tags --abbrev=0)
+
+# Manifest changes (what the project intended)
+git diff $PREV..HEAD -- '**/package.json'
+
+# Lockfile delta (what actually gets installed, including transitives)
+git diff $PREV..HEAD -- pnpm-lock.yaml | head -200
+
+# Hash check: if lockfile is byte-identical, the resolved tree is unchanged
+sha256sum pnpm-lock.yaml
+git show $PREV:pnpm-lock.yaml | sha256sum
+```
+
+If the lockfile hash is unchanged, the resolved dependency tree is identical to the
+previous release — record this in the release notes and skip to 3c.
+
+For each lockfile change, classify it:
+
+- **New direct dependency**: review on npm (publish date, maintainers, weekly downloads,
+  provenance attestation), check `package.json` for `scripts` entries (`preinstall`,
+  `install`, `postinstall`).
+- **Removed dependency**: confirm intentional.
+- **Version bump**: skim the upstream CHANGELOG and diff between the two versions on
+  https://diffs.dev or `npm diff <pkg>@<old> <pkg>@<new>`. Treat large unexpected diffs
+  as a stop sign.
+- **New transitive dependency**: same scrutiny as a new direct dep — supply-chain
+  attacks often arrive through deep transitives.
+
+#### 3b. Vulnerability audit
+
+```bash
+pnpm audit                   # All advisories
+pnpm audit --prod            # Runtime-only (shipped to users)
+```
+
+Triage:
+
+- **Runtime advisories** (paths through `packages/tbd>...` that don’t traverse dev
+  tooling): treat as release-blockers unless the impact is documented as
+  out-of-threat-model.
+  Fix by bumping the affected dependency.
+- **Dev-only advisories** (paths through `vitest`, `c8`, `tsdown`, `@changesets`,
+  `typescript-eslint`, `eslint`, `prettier`, `lefthook`, etc.): note them but do not
+  block release.
+
+#### 3c. Package-age and provenance check
+
+```bash
+pnpm check:package-age       # Enforces the 14-day rule
+```
+
+For any newly added direct dependency, manually verify on npm:
+
+- Publication date >=14 days old for the resolved version
+- Maintainer list is recognizable / unchanged from the prior release
+- Provenance attestation present where the upstream publishes with one:
+  `npm view <pkg>@<version> --json | jq '.dist.attestations // "none"'`
+
+#### 3d. Record findings
+
+Capture the audit summary in `release-notes.md` under a `### Security` section whenever
+there is anything notable (lockfile changes, new advisories, deferred fixes, new direct
+dependencies). If the lockfile is byte-identical and no new advisories landed, a single
+sentence ("Lockfile unchanged since vX.X.X; no new advisories.") is enough.
+
+### Step 4: Create Changeset
 
 Run the interactive changeset command:
 
@@ -96,7 +170,7 @@ git add .changeset
 git commit -m "chore: add changeset for vX.X.X"
 ```
 
-### Step 4: Version Packages
+### Step 5: Version Packages
 
 Run changesets to bump version and update CHANGELOG:
 
@@ -112,7 +186,7 @@ git add .
 git commit -m "chore: release get-tbd vX.X.X"
 ```
 
-### Step 5: Write Release Notes
+### Step 6: Write Release Notes
 
 **Before pushing**, write release notes following
 `tbd guidelines release-notes-guidelines`.
@@ -124,7 +198,7 @@ git log $(git describe --tags --abbrev=0 2>/dev/null || echo "HEAD~20")..HEAD --
 # Write release notes to release-notes.md or prepare for PR body
 ```
 
-### Step 6: Push and Tag
+### Step 7: Push and Tag
 
 **Option A: Direct git push (local development)**
 
@@ -155,7 +229,7 @@ gh api repos/jlevy/tbd/git/refs -X POST \
   -f sha="$MERGE_SHA"
 ```
 
-### Step 7: Update GitHub Release
+### Step 8: Update GitHub Release
 
 After the release workflow completes:
 
@@ -167,7 +241,7 @@ gh run list -R jlevy/tbd --limit 3
 gh release edit vX.X.X -R jlevy/tbd --notes-file release-notes.md
 ```
 
-### Step 8: Verify
+### Step 9: Verify
 
 ```bash
 gh release view vX.X.X -R jlevy/tbd
@@ -180,6 +254,12 @@ npm view get-tbd
 
 ```bash
 git checkout main && git pull
+
+# Supply-chain review (Step 3) — never skip
+PREV=$(git describe --tags --abbrev=0)
+git diff $PREV..HEAD -- '**/package.json' pnpm-lock.yaml | less
+pnpm audit && pnpm check:package-age
+
 pnpm changeset  # Interactive: select package, bump type, summary
 git add .changeset && git commit -m "chore: add changeset for v0.2.0"
 pnpm changeset version
@@ -195,6 +275,11 @@ gh release edit v0.2.0 -R jlevy/tbd --notes-file release-notes.md
 ### Restricted Environments (via PR and API)
 
 ```bash
+# Supply-chain review (Step 3) — never skip
+PREV=$(git describe --tags --abbrev=0)
+git diff $PREV..HEAD -- '**/package.json' pnpm-lock.yaml | less
+pnpm audit && pnpm check:package-age
+
 pnpm changeset  # Interactive: select package, bump type, summary
 git add .changeset && git commit -m "chore: add changeset for v0.2.0"
 pnpm changeset version
@@ -236,7 +321,7 @@ The release workflow automatically creates a GitHub Release when a tag is pushed
 After pushing a tag:
 
 1. Verify the release appears at: https://github.com/jlevy/tbd/releases
-2. Update the release with formatted notes (Step 7 above)
+2. Update the release with formatted notes (Step 8 above)
 
 ## Troubleshooting
 

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -1,5 +1,20 @@
 # get-tbd
 
+## 0.1.28
+
+### Patch Changes
+
+- 2322a95: Clarify dependency direction in `tbd show` output with `Blocks:` and
+  `Blocked by:` comments.
+- Fix `tbd doctor` “Temp files” check: display the actual scanned path
+  (`.tbd/data-sync/issues`) instead of the stale `.tbd/issues`, and widen the filter to
+  catch `atomically`’s `*.md.tmp-NNNN` leftover intermediates.
+- Refresh Bun/pnpm monorepo and TypeScript guidelines to May 2026 versions (Bun 1.3.x,
+  TS 6.0/7.0 Beta, pnpm 11, ESLint 10, Vitest 4.1, Zod 4, Commander 15, Biome 2.4) and
+  add a normative Supply-Chain Mitigation section to both monorepo guides codifying a
+  14-day package-age rule with lockfile discipline, provenance checks, and exception
+  process.
+
 ## 0.1.27
 
 ### Patch Changes

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -14,6 +14,9 @@
   add a normative Supply-Chain Mitigation section to both monorepo guides codifying a
   14-day package-age rule with lockfile discipline, provenance checks, and exception
   process.
+- Bump `yaml` to `~2.8.3` (resolves to 2.8.4) to patch GHSA-48c2-rrv3-qjmp (moderate
+  stack-overflow DoS on deeply nested YAML); range narrowed from `^2.8.2` to `~2.8.3` so
+  the resolved minor satisfies the project’s 14-day package-age rule.
 
 ## 0.1.27
 

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-tbd",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "Git-native issue tracking for AI agents and humans",
   "license": "MIT",
   "author": "Joshua Levy <joshua@cal.berkeley.edu> (https://github.com/jlevy)",

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -76,7 +76,7 @@
     "pretty-bytes": "^7.0.0",
     "pretty-ms": "^9.0.0",
     "ulid": "^3.0.2",
-    "yaml": "^2.8.2",
+    "yaml": "~2.8.3",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/packages/tbd/tests/corrupted-data.test.ts
+++ b/packages/tbd/tests/corrupted-data.test.ts
@@ -48,11 +48,19 @@ describe('corrupted data scenarios', { timeout: 15000 }, () => {
 
   /**
    * Initialize git repo and tbd in temp directory.
+   *
+   * Disables commit signing so the test is hermetic against any global git
+   * config (e.g., remote-execution containers that wire commit.gpgsign to a
+   * signing server). Without this, `tbd init`'s initial worktree commit can
+   * silently fail and leave the worktree HEAD unresolved, which makes the
+   * doctor's Worktree health check fire spuriously.
    */
   function initGitAndTbd(): void {
     execSync('git init --initial-branch=main', { cwd: tempDir });
     execSync('git config user.email "test@example.com"', { cwd: tempDir });
     execSync('git config user.name "Test"', { cwd: tempDir });
+    execSync('git config commit.gpgsign false', { cwd: tempDir });
+    execSync('git config tag.gpgsign false', { cwd: tempDir });
     runTbd(['init', '--prefix=test']);
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       yaml:
-        specifier: ^2.8.2
-        version: 2.8.2
+        specifier: ~2.8.3
+        version: 2.8.4
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -86,7 +86,7 @@ importers:
         version: 24.10.13
       '@vitest/coverage-v8':
         specifier: ^4.0.0
-        version: 4.0.18(vitest@4.0.18(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.0.18(vitest@4.0.18(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
       c8:
         specifier: ^10.1.3
         version: 10.1.3(monocart-coverage-reports@2.12.9)
@@ -107,7 +107,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: ^4.0.0
-        version: 4.0.18(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)
 
 packages:
 
@@ -2131,8 +2131,8 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
-  yaml@2.8.2:
-    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+  yaml@2.8.4:
+    resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -2823,7 +2823,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -2835,7 +2835,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -2846,13 +2846,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -3906,7 +3906,7 @@ snapshots:
       picocolors: 1.1.1
       strip-ansi: 7.1.2
       tree-kill: 1.2.2
-      yaml: 2.8.2
+      yaml: 2.8.4
       zod: 3.25.76
     optionalDependencies:
       c8: 10.1.3(monocart-coverage-reports@2.12.9)
@@ -3998,7 +3998,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -4011,12 +4011,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.21.0
-      yaml: 2.8.2
+      yaml: 2.8.4
 
-  vitest@4.0.18(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -4033,7 +4033,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.13
@@ -4077,7 +4077,7 @@ snapshots:
 
   y18n@5.0.8: {}
 
-  yaml@2.8.2: {}
+  yaml@2.8.4: {}
 
   yargs-parser@20.2.9: {}
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,11 +2,23 @@
 
 ### Fixes
 
-- **Invalid issue files**: `tbd list` and other commands now skip parse-invalid issue
-  files with a readable warning instead of crashing or dumping raw validation errors.
-- **Issue validation**: `tbd create` and `tbd update` now reject empty or overlong
-  titles before writing issue files, with guidance to move long details into the body.
-- **Doctor diagnostics**: `tbd doctor` now reports invalid issue files explicitly so
-  users can repair or delete them.
+- **`tbd show` dependency direction**: Now renders `Blocks:` and `Blocked by:` comments
+  in text output so dependency direction is unambiguous, while preserving round-trip
+  YAML parsing. Fixes #119.
+- **`tbd doctor` temp file check**: Now reports the actual scanned path
+  (`.tbd/data-sync/issues`) instead of the stale `.tbd/issues`, and catches
+  `atomically`’s `*.md.tmp-NNNN` leftover intermediates in addition to plain `*.tmp`
+  files.
 
-**Full commit history**: https://github.com/jlevy/tbd/compare/v0.1.26...v0.1.27
+### Documentation
+
+- **Refreshed coding guidelines** (loaded via `tbd guidelines <name>`) to May 2026
+  versions: Bun 1.3.x monorepo, pnpm 11 monorepo, TypeScript 6.0 / 7.0 Beta, TypeScript
+  CLI tooling, code coverage, YAML handling.
+  Covers ESLint 10, Vitest 4.1, Zod 4, Commander 15, Biome 2.4, and current best
+  practices.
+- **New supply-chain mitigation policy** in both `bun-monorepo-patterns` and
+  `pnpm-monorepo-patterns` guidelines: codifies a normative 14-day package-age rule with
+  lockfile discipline, provenance checks, and an exception process.
+
+**Full commit history**: https://github.com/jlevy/tbd/compare/v0.1.27...v0.1.28

--- a/release-notes.md
+++ b/release-notes.md
@@ -21,4 +21,19 @@
   `pnpm-monorepo-patterns` guidelines: codifies a normative 14-day package-age rule with
   lockfile discipline, provenance checks, and an exception process.
 
+### Security
+
+- **`yaml` bumped to ~2.8.3** (resolves to `yaml@2.8.4`): patches
+  [GHSA-48c2-rrv3-qjmp](https://github.com/advisories/GHSA-48c2-rrv3-qjmp) (moderate;
+  stack-overflow DoS on deeply nested YAML parsing).
+  Range narrowed from `^2.8.2` to `~2.8.3` so the resolved minor satisfies the project’s
+  14-day package-age rule.
+- **No other dependency changes**: aside from the `yaml` bump and its peer-resolution
+  string updates in `vitest`/`vite`, the resolved dependency tree is unchanged from
+  v0.1.27. Root `package.json` adds `--cooldown 14` to the `upgrade*` scripts and a new
+  `check:package-age` script (no new deps).
+- **Pre-existing dev-only advisories** (15, unchanged from v0.1.27): transitive through
+  `vitest`, `c8`, `tsdown`, `@changesets/cli`, and `typescript-eslint`; not shipped to
+  users.
+
 **Full commit history**: https://github.com/jlevy/tbd/compare/v0.1.27...v0.1.28


### PR DESCRIPTION
## What's Changed

### Fixes

- **`tbd show` dependency direction**: Now renders `Blocks:` and `Blocked by:` comments
  in text output so dependency direction is unambiguous, while preserving round-trip
  YAML parsing. Fixes #119.
- **`tbd doctor` temp file check**: Now reports the actual scanned path
  (`.tbd/data-sync/issues`) instead of the stale `.tbd/issues`, and catches
  `atomically`'s `*.md.tmp-NNNN` leftover intermediates in addition to plain `*.tmp`
  files.

### Documentation

- **Refreshed coding guidelines** (loaded via `tbd guidelines <name>`) to May 2026
  versions: Bun 1.3.x monorepo, pnpm 11 monorepo, TypeScript 6.0 / 7.0 Beta, TypeScript
  CLI tooling, code coverage, YAML handling. Covers ESLint 10, Vitest 4.1, Zod 4,
  Commander 15, Biome 2.4, and current best practices.
- **New supply-chain mitigation policy** in both `bun-monorepo-patterns` and
  `pnpm-monorepo-patterns` guidelines: codifies a normative 14-day package-age rule
  with lockfile discipline, provenance checks, and an exception process.
- **New Step 3 "Supply-Chain Review" in `docs/publishing.md`**: documents the
  manifest+lockfile diff, `pnpm audit` triage (runtime vs dev-only), package-age and
  provenance checks, and how to record findings. Subsequent steps renumbered; both
  Quick Reference flows updated.

### Security

- **`yaml` bumped to `~2.8.3`** (resolves to `yaml@2.8.4`): patches
  [GHSA-48c2-rrv3-qjmp](https://github.com/advisories/GHSA-48c2-rrv3-qjmp) (moderate;
  stack-overflow DoS on deeply nested YAML parsing). Range narrowed from `^2.8.2` to
  `~2.8.3` so the resolved minor satisfies the project's 14-day package-age rule.
- **No other dependency changes**: aside from the `yaml` bump and its peer-resolution
  string updates in `vitest`/`vite`, the resolved dependency tree is unchanged from
  v0.1.27. Root `package.json` adds `--cooldown 14` to the `upgrade*` scripts and a
  new `check:package-age` script (no new deps).
- **Pre-existing dev-only advisories** (15, unchanged from v0.1.27): transitive
  through `vitest`, `c8`, `tsdown`, `@changesets/cli`, and `typescript-eslint`; not
  shipped to users.

### Tests

- **`corrupted-data.test.ts`**: Test init helper now disables commit signing in the
  temp repo (`commit.gpgsign=false`, `tag.gpgsign=false`) so `tbd init`'s initial
  worktree commit cannot be silently broken by a global git signing config (e.g., on
  remote-execution containers wired to a signing server).

## Test plan

- [x] `pnpm test` (full suite, 57 files) — passes on pre-push
- [x] `pnpm audit --prod` — no known vulnerabilities
- [x] `pnpm check:package-age` — 0 violations, 32 pins checked
- [x] `pnpm build` — clean
- [ ] CI green on this PR
- [ ] After merge: tag `v0.1.28` and verify release workflow publishes to npm with provenance
- [ ] `npm view get-tbd@0.1.28` shows correct metadata

**Full commit history**: https://github.com/jlevy/tbd/compare/v0.1.27...v0.1.28

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7shnYjE8V4yyHXEGNhfcf)_