### PR TITLE
chore: release get-tbd v0.1.29

### DIFF
--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -1,5 +1,30 @@
 # get-tbd
 
+## 0.1.29
+
+### Patch Changes
+
+- Documentation release: agent-skill guidelines refresh and supply-chain hardening.
+  - Rewrote the `cli-agent-skill-patterns` guideline into a broad, multi-agent **Agent
+    Skills & CLI Integration Patterns** guide: a non-dogmatic simple baseline (one
+    `SKILL.md`), a 15-agent integration matrix (Claude Code, Codex, Cursor, Copilot,
+    Gemini CLI, Windsurf, Cline, Aider, opencode, Amp, Jules, Goose, Zed, Factory, pi),
+    the `AGENTS.md` / Agent Skills open-standard model, CLI-as-skill vs.
+    MCP guidance, a CLI install-vs-zero-install section, and security/testing/versioning
+    sections.
+  - Added a new **`supply-chain-hardening`** guideline
+    (`tbd guidelines supply-chain-hardening`): the cross-ecosystem 14-day cool-off plus
+    Node/pnpm/Bun enforcement (lifecycle-script allowlists, lockfile discipline,
+    `ncu --cooldown`, a CI audit gate, a pre-push age guard, and the exception process),
+    strongly recommended for every repo and referencing
+    github.com/jlevy/supply-chain-hardening for the full playbooks.
+    De-duplicated the Supply-Chain Mitigation content out of the bun and pnpm monorepo
+    guides into this standalone guideline.
+  - Fixed generated skill/agent files: `tbd setup` no longer emits a stray mid-document
+    YAML frontmatter block in `.claude/skills/<tool>/SKILL.md` or the `AGENTS.md`
+    integration section, so the generated files are stable and idempotent under Prettier
+    and flowmark.
+
 ## 0.1.28
 
 ### Patch Changes

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-tbd",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "Git-native issue tracking for AI agents and humans",
   "license": "MIT",
   "author": "Joshua Levy <joshua@cal.berkeley.edu> (https://github.com/jlevy)",


### PR DESCRIPTION
## What's Changed

A documentation-focused release: a major refresh of the agent-skill guidelines plus new supply-chain hardening guidance. No dependency changes — the lockfile is byte-identical to v0.1.28.

### Documentation

- **Agent Skills & CLI Integration Patterns** (`tbd guidelines cli-agent-skill-patterns`): rewritten to be broad, multi-agent, and current as of May 2026. Leads with a non-dogmatic simple baseline (one `SKILL.md`) and layers up to CLI-as-skill and MCP only when needed. Adds a 15-agent integration matrix (Claude Code, Codex, Cursor, Copilot, Gemini CLI, Windsurf, Cline, Aider, opencode, Amp, Jules, Goose, Zed, Factory, pi), the `AGENTS.md` / Agent Skills open-standard model, a CLI **install vs. zero-install** design section, and sections on security, testing skills before publishing, and versioning.
- **New `supply-chain-hardening` guideline** (`tbd guidelines supply-chain-hardening`): a concise cross-ecosystem policy — the 14-day cool-off plus Node/pnpm/Bun enforcement (lifecycle-script allowlists, lockfile discipline, `ncu --cooldown`, a CI audit gate, a pre-push age guard, and the exception process). Strongly recommended for every repo, and it references the [Supply Chain Hardening guidebook](https://github.com/jlevy/supply-chain-hardening) for the full playbooks. The duplicated Supply-Chain Mitigation content was removed from the bun and pnpm monorepo guides and consolidated here.

### Fixes

- **Cleaner generated skill files**: `tbd setup` no longer writes a stray mid-document YAML frontmatter block into `.claude/skills/<tool>/SKILL.md` or the `AGENTS.md` integration section. The composed skill now strips the baseline's own frontmatter, so the generated files are stable and idempotent under Prettier and flowmark (no more spurious diffs after running `tbd setup`).

### Security

- Lockfile byte-identical to v0.1.28; no dependency or manifest changes, so no new advisories.

**Full commit history**: https://github.com/jlevy/tbd/compare/v0.1.28...v0.1.29

---

Release prepared per `docs/publishing.md`: changeset (patch) + `changeset version` → `0.1.29`, supply-chain review done (lockfile unchanged). On merge, tag `v0.1.29` on the merge commit to trigger the publish workflow.

https://claude.ai/code/session_01TexoccD1HdU5Lv3jTz65X7

---
_Generated by [Claude Code](https://claude.ai/code/session_01TexoccD1HdU5Lv3jTz65X7)_