### PR TITLE
Pin supply-chain installs to vetted, cool-off-compliant versions

### DIFF
--- a/.claude/scripts/ensure-gh-cli.sh
+++ b/.claude/scripts/ensure-gh-cli.sh
@@ -1,17 +1,38 @@
 #!/bin/bash
 # Automated GitHub CLI setup for Claude Code sessions
 # This script runs on SessionStart to ensure gh CLI is available and authenticated
+#
+# Supply-chain policy (see SUPPLY-CHAIN-SECURITY.md): the gh version is PINNED to
+# a release at least 14 days old, and every download is verified against a pinned
+# SHA-256 checksum. Do NOT change this to fetch "latest" from the API at runtime;
+# that bypasses the cool-off window. To bump the pin, pick a release that is >=14
+# days old and copy its checksums from:
+#   https://github.com/cli/cli/releases/download/v<VERSION>/gh_<VERSION>_checksums.txt
 
-set -e
+set -euo pipefail
 
 # Add common binary locations to PATH
 export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
+
+# Pinned gh release (>=14 days old per supply-chain cool-off) and its checksums.
+GH_VERSION="2.92.0"
+
+# SHA-256 checksums from gh_2.92.0_checksums.txt, keyed by asset suffix.
+checksum_for() {
+    case "$1" in
+        linux_amd64.tar.gz) echo "b57848131bdf0c229cd35e1f2a51aa718199858b2e728410b37e89a428943ec4" ;;
+        linux_arm64.tar.gz) echo "c2248526dd0160c08d3fccca2332c3c1a07c15a78b23978e77735f1b5a18cfee" ;;
+        macOS_amd64.zip)    echo "ae9bb327ab0d91071bdada79f8f14034a2a0f19b0e001835a782eafa519d2af0" ;;
+        macOS_arm64.zip)    echo "b11c54f6bd7d15ed6590475079e5b2fcf36f45d3991a80041b29c9d0cc1f1d07" ;;
+        *) echo "" ;;
+    esac
+}
 
 # Check if gh is already installed
 if command -v gh &> /dev/null; then
     echo "[gh] CLI found at $(which gh)"
 else
-    echo "[gh] CLI not found, installing..."
+    echo "[gh] CLI not found, installing pinned v${GH_VERSION}..."
 
     # Detect platform
     OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -19,38 +40,52 @@ else
     [ "$ARCH" = "x86_64" ] && ARCH="amd64"
     [ "$ARCH" = "aarch64" ] && ARCH="arm64"
 
-    echo "[gh] Detected platform: ${OS}_${ARCH}"
-
-    # Get latest version from GitHub API (with fallback)
-    GH_VERSION=$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest 2>/dev/null \
-        | grep -o '"tag_name": *"v[^"]*"' | head -1 | sed 's/.*"v\([^"]*\)".*/\1/')
-
-    # Fallback version if API fails
-    GH_VERSION=${GH_VERSION:-2.83.1}
-
-    echo "[gh] Version: ${GH_VERSION}"
-
-    # Build download URL based on platform
+    # Build the asset suffix and archive type per platform.
     if [ "$OS" = "darwin" ]; then
-        DOWNLOAD_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_macOS_${ARCH}.zip"
+        PLATFORM="macOS_${ARCH}.zip"
         ARCHIVE_EXT="zip"
+        EXTRACT_DIR="/tmp/gh_${GH_VERSION}_macOS_${ARCH}"
     else
-        DOWNLOAD_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_${OS}_${ARCH}.tar.gz"
+        PLATFORM="${OS}_${ARCH}.tar.gz"
         ARCHIVE_EXT="tar.gz"
+        EXTRACT_DIR="/tmp/gh_${GH_VERSION}_${OS}_${ARCH}"
     fi
 
-    echo "[gh] Downloading from ${DOWNLOAD_URL}..."
+    echo "[gh] Detected platform: ${PLATFORM}"
 
-    # Download
-    curl -fsSL -o "/tmp/gh.${ARCHIVE_EXT}" "$DOWNLOAD_URL"
+    EXPECTED=$(checksum_for "$PLATFORM")
+    if [ -z "$EXPECTED" ]; then
+        echo "[gh] ERROR: no pinned checksum for platform ${PLATFORM}; refusing to install"
+        echo "[gh] Add the checksum from gh_${GH_VERSION}_checksums.txt to this script"
+        exit 1
+    fi
+
+    ASSET="gh_${GH_VERSION}_${PLATFORM}"
+    DOWNLOAD_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${ASSET}"
+
+    echo "[gh] Downloading from ${DOWNLOAD_URL}..."
+    curl -fsSL -o "/tmp/${ASSET}" "$DOWNLOAD_URL"
+
+    # Verify the download against the pinned checksum before extracting.
+    if command -v sha256sum &> /dev/null; then
+        ACTUAL=$(sha256sum "/tmp/${ASSET}" | awk '{print $1}')
+    else
+        ACTUAL=$(shasum -a 256 "/tmp/${ASSET}" | awk '{print $1}')
+    fi
+    if [ "$ACTUAL" != "$EXPECTED" ]; then
+        echo "[gh] ERROR: checksum mismatch for ${ASSET}"
+        echo "[gh]   expected ${EXPECTED}"
+        echo "[gh]   actual   ${ACTUAL}"
+        rm -f "/tmp/${ASSET}"
+        exit 1
+    fi
+    echo "[gh] Checksum verified for ${ASSET}"
 
     # Extract based on archive type
     if [ "$ARCHIVE_EXT" = "zip" ]; then
-        unzip -q "/tmp/gh.zip" -d /tmp
-        EXTRACT_DIR="/tmp/gh_${GH_VERSION}_macOS_${ARCH}"
+        unzip -q "/tmp/${ASSET}" -d /tmp
     else
-        tar -xzf "/tmp/gh.tar.gz" -C /tmp
-        EXTRACT_DIR="/tmp/gh_${GH_VERSION}_${OS}_${ARCH}"
+        tar -xzf "/tmp/${ASSET}" -C /tmp
     fi
 
     # Install to ~/.local/bin (works in cloud and local)
@@ -59,7 +94,7 @@ else
     chmod +x ~/.local/bin/gh
 
     # Clean up
-    rm -rf "${EXTRACT_DIR}" "/tmp/gh.${ARCHIVE_EXT}"
+    rm -rf "${EXTRACT_DIR}" "/tmp/${ASSET}"
 
     echo "[gh] Installed to ~/.local/bin/gh"
 fi
@@ -72,7 +107,7 @@ if ! command -v gh &> /dev/null; then
 fi
 
 # Check authentication status
-if [ -n "$GH_TOKEN" ]; then
+if [ -n "${GH_TOKEN:-}" ]; then
     # GH_TOKEN is set, verify it works
     if gh auth status &> /dev/null; then
         echo "[gh] Authenticated successfully"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,7 +19,7 @@ pre-commit:
     format-md:
       glob: '*.md'
       exclude: '(\.tbd/|\.claude/skills/|AGENTS\.md)'
-      run: npx prettier --write --log-level warn {staged_files} && uvx flowmark@latest --auto {staged_files}
+      run: npx prettier --write --log-level warn {staged_files} && uvx flowmark@0.6.5 --auto {staged_files}
       stage_fixed: true
       priority: 1
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "publint": "pnpm -r publint",
     "format": "prettier --write --log-level warn . && pnpm format:md",
     "format:check": "prettier --check --log-level warn .",
-    "format:md": "find README.md docs packages/tbd -name '*.md' -type f -not -path '*/dist/*' -not -path '*/node_modules/*' 2>/dev/null | xargs uvx flowmark@latest --auto",
+    "format:md": "find README.md docs packages/tbd -name '*.md' -type f -not -path '*/dist/*' -not -path '*/node_modules/*' 2>/dev/null | xargs uvx flowmark@0.6.5 --auto",
     "lint": "eslint . --fix && pnpm typecheck && eslint . --max-warnings 0",
     "lint:check": "pnpm typecheck && eslint . --max-warnings 0",
     "precommit": "pnpm format && pnpm lint && pnpm build && pnpm test",

--- a/packages/tbd/docs/install/ensure-gh-cli.sh
+++ b/packages/tbd/docs/install/ensure-gh-cli.sh
@@ -1,17 +1,38 @@
 #!/bin/bash
 # Automated GitHub CLI setup for Claude Code sessions
 # This script runs on SessionStart to ensure gh CLI is available and authenticated
+#
+# Supply-chain policy (see SUPPLY-CHAIN-SECURITY.md): the gh version is PINNED to
+# a release at least 14 days old, and every download is verified against a pinned
+# SHA-256 checksum. Do NOT change this to fetch "latest" from the API at runtime;
+# that bypasses the cool-off window. To bump the pin, pick a release that is >=14
+# days old and copy its checksums from:
+#   https://github.com/cli/cli/releases/download/v<VERSION>/gh_<VERSION>_checksums.txt
 
-set -e
+set -euo pipefail
 
 # Add common binary locations to PATH
 export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
+
+# Pinned gh release (>=14 days old per supply-chain cool-off) and its checksums.
+GH_VERSION="2.92.0"
+
+# SHA-256 checksums from gh_2.92.0_checksums.txt, keyed by asset suffix.
+checksum_for() {
+    case "$1" in
+        linux_amd64.tar.gz) echo "b57848131bdf0c229cd35e1f2a51aa718199858b2e728410b37e89a428943ec4" ;;
+        linux_arm64.tar.gz) echo "c2248526dd0160c08d3fccca2332c3c1a07c15a78b23978e77735f1b5a18cfee" ;;
+        macOS_amd64.zip)    echo "ae9bb327ab0d91071bdada79f8f14034a2a0f19b0e001835a782eafa519d2af0" ;;
+        macOS_arm64.zip)    echo "b11c54f6bd7d15ed6590475079e5b2fcf36f45d3991a80041b29c9d0cc1f1d07" ;;
+        *) echo "" ;;
+    esac
+}
 
 # Check if gh is already installed
 if command -v gh &> /dev/null; then
     echo "[gh] CLI found at $(which gh)"
 else
-    echo "[gh] CLI not found, installing..."
+    echo "[gh] CLI not found, installing pinned v${GH_VERSION}..."
 
     # Detect platform
     OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -19,38 +40,52 @@ else
     [ "$ARCH" = "x86_64" ] && ARCH="amd64"
     [ "$ARCH" = "aarch64" ] && ARCH="arm64"
 
-    echo "[gh] Detected platform: ${OS}_${ARCH}"
-
-    # Get latest version from GitHub API (with fallback)
-    GH_VERSION=$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest 2>/dev/null \
-        | grep -o '"tag_name": *"v[^"]*"' | head -1 | sed 's/.*"v\([^"]*\)".*/\1/')
-
-    # Fallback version if API fails
-    GH_VERSION=${GH_VERSION:-2.83.1}
-
-    echo "[gh] Version: ${GH_VERSION}"
-
-    # Build download URL based on platform
+    # Build the asset suffix and archive type per platform.
     if [ "$OS" = "darwin" ]; then
-        DOWNLOAD_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_macOS_${ARCH}.zip"
+        PLATFORM="macOS_${ARCH}.zip"
         ARCHIVE_EXT="zip"
+        EXTRACT_DIR="/tmp/gh_${GH_VERSION}_macOS_${ARCH}"
     else
-        DOWNLOAD_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_${OS}_${ARCH}.tar.gz"
+        PLATFORM="${OS}_${ARCH}.tar.gz"
         ARCHIVE_EXT="tar.gz"
+        EXTRACT_DIR="/tmp/gh_${GH_VERSION}_${OS}_${ARCH}"
     fi
 
-    echo "[gh] Downloading from ${DOWNLOAD_URL}..."
+    echo "[gh] Detected platform: ${PLATFORM}"
 
-    # Download
-    curl -fsSL -o "/tmp/gh.${ARCHIVE_EXT}" "$DOWNLOAD_URL"
+    EXPECTED=$(checksum_for "$PLATFORM")
+    if [ -z "$EXPECTED" ]; then
+        echo "[gh] ERROR: no pinned checksum for platform ${PLATFORM}; refusing to install"
+        echo "[gh] Add the checksum from gh_${GH_VERSION}_checksums.txt to this script"
+        exit 1
+    fi
+
+    ASSET="gh_${GH_VERSION}_${PLATFORM}"
+    DOWNLOAD_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${ASSET}"
+
+    echo "[gh] Downloading from ${DOWNLOAD_URL}..."
+    curl -fsSL -o "/tmp/${ASSET}" "$DOWNLOAD_URL"
+
+    # Verify the download against the pinned checksum before extracting.
+    if command -v sha256sum &> /dev/null; then
+        ACTUAL=$(sha256sum "/tmp/${ASSET}" | awk '{print $1}')
+    else
+        ACTUAL=$(shasum -a 256 "/tmp/${ASSET}" | awk '{print $1}')
+    fi
+    if [ "$ACTUAL" != "$EXPECTED" ]; then
+        echo "[gh] ERROR: checksum mismatch for ${ASSET}"
+        echo "[gh]   expected ${EXPECTED}"
+        echo "[gh]   actual   ${ACTUAL}"
+        rm -f "/tmp/${ASSET}"
+        exit 1
+    fi
+    echo "[gh] Checksum verified for ${ASSET}"
 
     # Extract based on archive type
     if [ "$ARCHIVE_EXT" = "zip" ]; then
-        unzip -q "/tmp/gh.zip" -d /tmp
-        EXTRACT_DIR="/tmp/gh_${GH_VERSION}_macOS_${ARCH}"
+        unzip -q "/tmp/${ASSET}" -d /tmp
     else
-        tar -xzf "/tmp/gh.tar.gz" -C /tmp
-        EXTRACT_DIR="/tmp/gh_${GH_VERSION}_${OS}_${ARCH}"
+        tar -xzf "/tmp/${ASSET}" -C /tmp
     fi
 
     # Install to ~/.local/bin (works in cloud and local)
@@ -59,7 +94,7 @@ else
     chmod +x ~/.local/bin/gh
 
     # Clean up
-    rm -rf "${EXTRACT_DIR}" "/tmp/gh.${ARCHIVE_EXT}"
+    rm -rf "${EXTRACT_DIR}" "/tmp/${ASSET}"
 
     echo "[gh] Installed to ~/.local/bin/gh"
 fi
@@ -72,7 +107,7 @@ if ! command -v gh &> /dev/null; then
 fi
 
 # Check authentication status
-if [ -n "$GH_TOKEN" ]; then
+if [ -n "${GH_TOKEN:-}" ]; then
     # GH_TOKEN is set, verify it works
     if gh auth status &> /dev/null; then
         echo "[gh] Authenticated successfully"


### PR DESCRIPTION
## Summary

Self-review against `SUPPLY-CHAIN-SECURITY.md`, focused on install-time fetches that bypassed our 14-day cool-off / verification rules.

- **gh CLI ensure script** (`.claude/scripts/ensure-gh-cli.sh` + the bundled source `packages/tbd/docs/install/ensure-gh-cli.sh`): previously queried the GitHub API for the **latest** gh release at runtime and downloaded it with **no integrity check**. Now pinned to **gh v2.92.0** (released 2026-04-28 — the newest release that is ≥14 days old as of today) and every download is verified against a pinned SHA-256 checksum before extraction; the script refuses to install on an unrecognized platform. A bump procedure is documented in a header comment.
- **Markdown formatter**: `uvx flowmark@latest` → `uvx flowmark@0.6.5` in both `lefthook.yml` and the `format:md` script. `@latest` would auto-adopt a brand-new release with no cool-off (rule 6); 0.6.5 is the current latest and already >14 days old, so this is functionally identical today but closes the gap.

## Audit notes (no change needed)

- `pnpm check:package-age` passes: **0 violations across 32 pins**.
- CI (`ci.yml`/`release.yml`) uses `pnpm install --frozen-lockfile`; lockfile is committed.
- `npx tsx/prettier/eslint` resolve to locally-pinned devDependencies.
- Upgrade scripts already gate with `ncu --cooldown 14`.

## Follow-up (not in this PR)

- `docs/general/agent-setup/shortcut-setup-beads.md` still teaches agents to install the legacy `bd` tool by fetching the latest GitHub release with no checksum — same anti-pattern. Left untouched pending a decision on whether to pin, replace, or remove it (bd is superseded by tbd).
- An unrelated uncommitted edit to `.tbd/config.yml` (removing the `supply-chain-hardening.md` docs-cache entry) was left out of this commit.

## Test plan

- [x] `bash -n` syntax check on both ensure scripts
- [x] Verified the pinned v2.92.0 linux_amd64 download matches its pinned checksum
- [ ] Confirm gh installs cleanly from a clean environment (no pre-installed gh)

https://claude.ai/code/session_012K3oAg5EKGzBVY9WohgSHY

---
_Generated by [Claude Code](https://claude.ai/code/session_012K3oAg5EKGzBVY9WohgSHY)_