### PR TITLE
feat: tbd-sync unrelated-history detection, prevention, and rescue (#139, #137, #135)

### DIFF
--- a/docs/project/specs/active/plan-2026-05-29-tbd-sync-unrelated-history-hardening.md
+++ b/docs/project/specs/active/plan-2026-05-29-tbd-sync-unrelated-history-hardening.md
@@ -58,14 +58,14 @@ recovery) — and locks each behavior in with tests.
 
 ### Current control flow (verified against current source, v0.2.0)
 
-**`initWorktree`** (`src/file/git.ts:1119`) decision tree:
+**`initWorktree`** (`packages/tbd/src/file/git.ts:1119`) decision tree:
 
 1. local `tbd-sync` exists → attach worktree to it.
 2. else `remoteBranchExists(remote, syncBranch)` → fetch + create tracking branch.
 3. else → `git worktree add --orphan` + seed structure + commit
    `"Initialize tbd-sync branch"`. **No push.**
 
-**`remoteBranchExists`** (`src/file/git.ts:708`):
+**`remoteBranchExists`** (`packages/tbd/src/file/git.ts:708`):
 
 ```ts
 try {
@@ -80,7 +80,7 @@ try {
 reachable, and exits with other non-zero codes (or throws) on auth/network/transient
 failure. Today both collapse to `false`.
 
-**`checkRemoteBranchHealth`** (`src/file/git.ts:1324`):
+**`checkRemoteBranchHealth`** (`packages/tbd/src/file/git.ts:1324`):
 
 ```ts
 try {
@@ -96,20 +96,21 @@ try {
 That lands in the catch and is reported as `diverged = false` — the worst case looks
 healthy.
 
-**`pushWithRetry`** (`src/file/git.ts:634`) treats `fetch first` / `rejected` /
-`non-fast-forward` as retryable, fetches + runs the field-level merge callback, and
-after `MAX_PUSH_RETRIES` (3) returns `"Remote has conflicting changes."` For unrelated
-histories the merge callback can’t help (the git merge has no base), so it burns three
-identical attempts and falls through to the outbox.
+**`pushWithRetry`** (`packages/tbd/src/file/git.ts:634`) treats `fetch first` /
+`rejected` / `non-fast-forward` as retryable, fetches + runs the field-level merge
+callback, and after `MAX_PUSH_RETRIES` (3) returns `"Remote has conflicting changes."`
+For unrelated histories the merge callback can’t help (the git merge has no base), so it
+burns three identical attempts and falls through to the outbox.
 
 **Recovery machinery that already exists** and we build on:
 
-- Safety-backup-branch idiom (`src/file/git.ts:1062`):
+- Safety-backup-branch idiom (`packages/tbd/src/file/git.ts:1062`):
   `git branch tbd-legacy-preserve-<ts> <head>` before a destructive op.
 - `repairWorktree` / corrupted-worktree backup to `sharedBackupsDir`
-  (`src/file/git.ts:1513+`).
+  (`packages/tbd/src/file/git.ts:1513+`).
 - `reconcileMappings`, `mergeIdMappings`, `resolveIdMappingConflicts`
-  (`src/file/id-mapping.ts`) and the field-level `mergeIssues` (`src/file/git.ts`).
+  (`packages/tbd/src/file/id-mapping.ts`) and the field-level `mergeIssues`
+  (`packages/tbd/src/file/git.ts`).
 - `attic/conflicts/` routing for issue-level conflicts.
 
 ### Why a file-layer rescue is safe (storage model)
@@ -124,7 +125,7 @@ merge must happen at the issue-file layer, not the git-history layer.
 
 ### #135 status (verified)
 
-`assembleDataContext` (`src/cli/lib/data-context.ts:172`) resolves with
+`assembleDataContext` (`packages/tbd/src/cli/lib/data-context.ts:172`) resolves with
 `allowFallback: false`, so a missing worktree throws `WorktreeMissingError` instead of
 silently using the gitignored `.tbd/data-sync/`. `withDataSyncContext` auto-repairs a
 `missing`/`prunable` worktree via `ensureSharedDataSyncLayout` → `repairWorktree`. So
@@ -148,13 +149,13 @@ TDD guidelines.
 
 | Area | File | Change |
 | --- | --- | --- |
-| Remote existence | `src/file/git.ts` `remoteBranchExists` | Return a tri-state result distinguishing absent / present / check-failed |
-| Init | `src/file/git.ts` `initWorktree` | Refuse orphan creation when remote check failed; push orphan immediately (best-effort) |
-| Detection | `src/file/git.ts` `checkRemoteBranchHealth` | Add `unrelated: boolean`; set it when `merge-base` finds no common ancestor (distinguish from “local branch absent”) |
-| Doctor report | `src/cli/commands/doctor.ts` | Report unrelated state as a hard finding (not healthy) and route to rescue, not plain `tbd sync` |
-| Sync messaging | `src/cli/commands/sync.ts` / `pushWithRetry` | Detect unrelated-history push rejection; emit dedicated message + remediation instead of 3 identical retries |
-| Rescue | `src/file/git.ts` (new `rescueUnrelatedHistory`) + `doctor.ts --fix` wiring | Non-destructive issue-file-layer reconciliation |
-| #135 | `tests/` | Regression test(s); small loud-failure tweak only if a gap is found |
+| Remote existence | `packages/tbd/src/file/git.ts` `remoteBranchExists` | Return a tri-state result distinguishing absent / present / check-failed |
+| Init | `packages/tbd/src/file/git.ts` `initWorktree` | Refuse orphan creation when remote check failed; push orphan immediately (best-effort) |
+| Detection | `packages/tbd/src/file/git.ts` `checkRemoteBranchHealth` | Add `unrelated: boolean`; set it when `merge-base` finds no common ancestor (distinguish from “local branch absent”) |
+| Doctor report | `packages/tbd/src/cli/commands/doctor.ts` | Report unrelated state as a hard finding (not healthy) and route to rescue, not plain `tbd sync` |
+| Sync messaging | `packages/tbd/src/cli/commands/sync.ts` (`:865` merge stage + push-failure block) / `pushWithRetry` | Detect unrelated post-fetch before file-level merge/retry; dedicated message + remediation; avoid 3 identical retries |
+| Rescue | `packages/tbd/src/file/git.ts` (new `rescueUnrelatedHistory`) + `doctor.ts --fix` wiring | Non-destructive issue-file-layer reconciliation: ULID buckets + conflict-attic, under `withSharedDataSyncLock` |
+| #135 | `packages/tbd/tests/` | Regression test(s); small loud-failure tweak only if a gap is found |
 
 ### Detailed design
 
@@ -179,8 +180,15 @@ export async function probeRemoteBranch(
 }
 ```
 
-Keep `remoteBranchExists` as a thin `=== 'present'` wrapper for existing callers
-(`uninstall`, `init`) to avoid churn.
+**Caller contract (must be unambiguous):** any path that can create a local orphan
+branch — `initWorktree` and any future writer — MUST call `probeRemoteBranch` directly
+and branch on all three states; it must never collapse `check-failed` to `false`. The
+`remoteBranchExists` boolean wrapper is retained **only** for read-only / status-style
+callers (e.g. `uninstall`, status output) where fail-closed behavior is not required,
+and is forbidden on any orphan-creating path.
+A unit test asserts `initWorktree` does not route orphan decisions through the boolean
+wrapper.
+
 In `initWorktree`, branch on the tri-state:
 
 - `present` → fetch + create tracking branch (as today).
@@ -198,10 +206,28 @@ inspect it without string-matching.
 #### Fault 1b (#137) — push the fresh orphan immediately
 
 After the orphan is created and the initial commit is made, attempt
-`git push origin tbd-sync` best-effort with transient-retry, ignoring failure
-(restricted egress / no auth must not break setup).
-This makes “first init wins” the canonical outcome and shrinks the race window from
-“until first sync” to “until setup completes”.
+`git push origin tbd-sync` with transient-retry.
+Classify the outcome rather than blanket-ignoring failure — a rejection is the race we
+are trying to close, not noise:
+
+- **Success** → “first init wins”; done.
+- **Transient failure** (restricted egress / no auth / network) → ignore best-effort;
+  setup must not break.
+  The branch is local-only for now; the race window shrinks from “until first sync” to
+  “until the first reachable sync”.
+- **Non-fast-forward / fetch-first rejection** → environment B already pushed its
+  orphan, so this is a *detected* unrelated-history race during init.
+  Handle it then and there (before any user issue writes, so it is safe and cheap):
+  `git fetch origin tbd-sync`, verify the local branch contains only the initial
+  scaffold (no user issue files under `issues/`), and if so **adopt the remote** (reset
+  local `tbd-sync` to `origin/tbd-sync`). If the local branch already has user issue
+  files, do **not** silently discard them — fail loudly with the unrelated-history
+  remediation (`tbd doctor --fix`), which routes into the Phase 2 rescue.
+
+This closes the A-probes-absent / B-pushes-first / A-push-rejected interleaving that a
+blanket best-effort push would leave behind as a local branch unrelated to the remote.
+The distinction between a non-fast-forward rejection and a transient failure relies on
+the same `exitCode`-carrying `git()` error introduced for Fault 1.
 
 #### Fault 2 — detect unrelated histories
 
@@ -221,35 +247,75 @@ try/catch so transient errors don’t masquerade as “unrelated”.
 (`"Sync histories are unrelated (no common ancestor) — push cannot succeed"`) whose
 remediation is `tbd doctor --fix` (the rescue), **not** `tbd sync`.
 
-`tbd sync` (`sync.ts` push-failure block, ~line 919): when the push fails and
-`checkRemoteBranchHealth` reports `unrelated`, replace the generic “Remote has
-conflicting changes” with the dedicated message and point at `tbd doctor --fix`.
-Optionally short-circuit `pushWithRetry` so it doesn’t burn 3 identical attempts on an
-unrelated-history rejection.
+`tbd sync` must detect the unrelated state **before** the file-level merge/conflict and
+retry machinery runs, not only in the push-failure block — otherwise sync does
+misleading work first and any diagnostics point at the wrong phase.
+Two coupled changes:
+
+- **Merge stage (`packages/tbd/src/cli/commands/sync.ts:865`)** — the current full-sync
+  path catches `fatal: refusing to merge unrelated histories` together with fetch
+  failures as “may be first sync.”
+  Split this: after the fetch, run an explicit unrelated-history check (or add a
+  dedicated branch to the merge catch keyed on that git message + `merge-base` exit
+  status). On unrelated, short-circuit to the dedicated message and `tbd doctor --fix`
+  remediation **before** file-level conflict resolution and `pushWithRetry`.
+- **Push stage (push-failure block, ~line 919)** — defense in depth: if a push still
+  fails and `checkRemoteBranchHealth` reports `unrelated`, replace the generic “Remote
+  has conflicting changes” with the same dedicated message rather than burning 3
+  identical `pushWithRetry` attempts.
+
+Net effect: an unrelated history is reported the moment it is provable (post-fetch),
+sync does no misleading merge work, and the wasted retries are avoided.
 
 #### Rescue mode — `rescueUnrelatedHistory` (non-destructive)
 
-New function invoked by `tbd doctor --fix` when `unrelated` is detected:
+New function invoked by `tbd doctor --fix` when `unrelated` is detected.
+
+**Locking and preconditions (same contract as `initWorktree` / `repairWorktree`).** The
+whole rescue runs inside `withSharedDataSyncLock` so a concurrent `tbd create` /
+`tbd sync` from a sibling worktree cannot race the reset/replay window.
+Before mutating: require a clean data-sync worktree with no merge/rebase in progress (no
+`MERGE_HEAD`/in-progress operation, no unstaged changes); if dirty, abort with guidance
+to resolve or stash first rather than resetting over uncommitted work.
 
 1. `git fetch origin tbd-sync`.
 2. Safety net: `git branch tbd-backup-<nowFilenameTimestamp()> <local tbd-sync HEAD>`
    (reuse the existing preserve-branch idiom).
    Prior local state is always recoverable.
-3. Compute the content delta keyed by ULID: issue files (and any mapping rows) present
-   on local `tbd-sync` but absent on `origin/tbd-sync`. Robust to the missing merge base
-   because it’s a file-set diff, not a git merge.
+3. **Categorize every issue file by ULID** across local `tbd-sync` and `origin/tbd-sync`
+   into four buckets (a file-set + content diff, robust to the missing merge base —
+   never a git merge):
+   - `remote-only` → already on the adopted base; nothing to do.
+   - `local-only` → re-apply onto the remote base.
+   - `both-identical` → no action.
+   - `both-different` → the **same** `is-<ulid>.md` exists on both unrelated roots with
+     differing content (reachable via copied worktrees, restored backups,
+     force-push/replacement history, or a user editing an issue present in both stores).
+     This must **not** be silently dropped: run it through the existing issue-level
+     `mergeIssues` field-merge, and on a true conflict route to `attic/conflicts/` (the
+     established conflict path) so both versions are preserved with an explicit
+     artifact.
 4. Adopt remote as canonical base: reset the worktree’s `tbd-sync` to `origin/tbd-sync`
    (preserved by step 2).
-5. Re-apply the local-only issue files; union-merge `ids.yml` via existing
-   `mergeIdMappings`; run `reconcileMappings` so every issue has a backing mapping and
-   vice-versa (closes the “62 map entries vs 57 files” inconsistency noted in #139);
-   commit `"tbd rescue: adopt remote base + reapply N local-only issue(s)"`.
+5. Apply the buckets onto the base: write `local-only` files; resolve `both-different`
+   via `mergeIssues`/conflict-attic; union-merge `ids.yml` via existing
+   `mergeIdMappings` and apply `resolveIdMappingConflicts` for divergent public-ID rows;
+   run `reconcileMappings` so every issue has a backing mapping and vice-versa (closes
+   the “62 map entries vs 57 files” inconsistency noted in #139); commit
+   `"tbd rescue: adopt remote base + reconcile N issue(s) (L local-only, D merged)"`.
 6. Return control; the normal push is now a clean fast-forward.
+
+**Failure semantics.** The only destructive step (the reset in step 4) happens *after*
+the backup branch in step 2, so any failure between backup and commit leaves the
+pre-rescue HEAD recoverable from `tbd-backup-<ts>`; the rescue is restartable.
+If the process dies mid-replay, the backup branch + the still-intact `origin/tbd-sync`
+are sufficient to redo it.
 
 Post-conditions asserted by tests:
 `git merge-base --is-ancestor origin/tbd-sync tbd-sync` is true (push fast-forwards);
-issue-file count equals id-map entry count; no duplicate public IDs; the backup branch
-exists and contains the pre-rescue HEAD.
+issue-file count equals id-map entry count; no duplicate public IDs; `local-only` beads
+survive; `both-different` issues are merged or preserved in `attic/conflicts/` (never
+dropped); the backup branch exists and contains the pre-rescue HEAD.
 
 #### #135 — verify + regression
 
@@ -263,10 +329,11 @@ if the test exposes a residual gap.
 
 ### API Changes
 
-- New exported `probeRemoteBranch` + `RemoteBranchProbe` type in `src/file/git.ts`;
-  `remoteBranchExists` retained as a wrapper.
+- New exported `probeRemoteBranch` + `RemoteBranchProbe` type in
+  `packages/tbd/src/file/git.ts`; `remoteBranchExists` retained as a wrapper.
 - `RemoteBranchHealth` gains `unrelated: boolean`.
-- New exported `rescueUnrelatedHistory` (or equivalent) in `src/file/git.ts`.
+- New exported `rescueUnrelatedHistory` (or equivalent) in
+  `packages/tbd/src/file/git.ts`.
 - `git()` wrapper / thrown error carries `exitCode` (internal).
 
 ## Implementation Plan
@@ -276,38 +343,53 @@ if the test exposes a residual gap.
 - [ ] Make the `git()` error carry `exitCode` (structural; commit separately).
 - [ ] `probeRemoteBranch` tri-state + `remoteBranchExists` wrapper; unit tests for
   absent vs check-failed (mock/stub git exit codes).
-- [ ] `initWorktree`: refuse orphan on `check-failed`; best-effort immediate push of the
-  fresh orphan. Tests cover both.
+- [ ] `initWorktree`: use `probeRemoteBranch` directly (not the boolean wrapper); refuse
+  orphan on `check-failed`; immediate orphan push that classifies success / transient /
+  non-fast-forward-rejection.
+  Test the **rejected-race interleaving** (A creates orphan, B pushes first, A’s push
+  rejected → A adopts scaffold-only remote, or fails loudly if A already has user
+  issues), plus the happy-path push and the check-failed refusal.
 - [ ] `checkRemoteBranchHealth`: add `unrelated`; tests for unrelated, genuinely
   diverged, in-sync, and no-local-branch cases.
 - [ ] `tbd doctor`: report `unrelated` as a hard finding routing to `--fix`; update
   `doctor-sync` tests / golden output.
-- [ ] `tbd sync`: dedicated unrelated-history message + remediation; avoid 3 wasted
-  retries.
+- [ ] `tbd sync`: detect unrelated post-fetch at the merge stage (`sync.ts:865`) before
+  file-level conflict/retry runs; dedicated message + remediation; defense-in-depth
+  check in the push-failure block; avoid 3 wasted retries.
 - [ ] #135 regression scenario (tryscript) — missing worktree heals/fails loudly, never
   writes to `.tbd/data-sync/`.
 
 ### Phase 2: Non-destructive rescue
 
-- [ ] `rescueUnrelatedHistory`: fetch → backup branch → file-set delta → adopt remote →
-  replay local-only issues + union ids.yml + `reconcileMappings` → commit.
+- [ ] `rescueUnrelatedHistory` under `withSharedDataSyncLock`, with clean-worktree /
+  no-merge-in-progress preconditions: fetch → backup branch → categorize by ULID
+  (local-only / remote-only / both-identical / both-different) → adopt remote → apply
+  buckets (`mergeIssues`/conflict-attic for both-different) + union ids.yml +
+  `resolveIdMappingConflicts` + `reconcileMappings` → commit.
 - [ ] Wire into `tbd doctor --fix`; after rescue, normal sync fast-forwards.
 - [ ] Tests: construct two unrelated `tbd-sync` roots in a temp repo, run rescue, assert
   fast-forward-ability, file/map consistency, no duplicate IDs, backup branch present,
   and that local-only beads survive.
+  **Same-ULID divergence cases:** identical content (no-op), differing scalar fields,
+  differing labels (field-merge), and a true conflict (preserved in `attic/conflicts/`,
+  never dropped). Plus a precondition test: rescue aborts on a dirty worktree /
+  merge-in-progress.
 - [ ] End-to-end tryscript: race → detect → `tbd doctor --fix` → `tbd sync` → in sync.
 
 ## Testing Strategy
 
-- **Unit** — `probeRemoteBranch` exit-code mapping; `checkRemoteBranchHealth` flag
-  matrix; rescue delta computation (pure where possible).
+- **Unit** — `probeRemoteBranch` exit-code mapping (absent vs check-failed);
+  `checkRemoteBranchHealth` flag matrix; rescue ULID-bucket categorization (local-only /
+  remote-only / both-identical / both-different), pure where possible.
 - **Integration** — temp-repo helpers that build two unrelated orphan roots and a
-  reachable “remote”; assert detection + rescue outcomes against real `git`.
-- **Golden/tryscript** — extend the existing `tests/cli-sync-*.tryscript.md` family (and
-  worktree-scenarios) with the race, unrelated-history doctor output, the rescue flow,
-  and the #135 missing-worktree reproduction.
-  Filter unstable fields (timestamps, ULIDs/backup-branch names) per the golden-testing
-  guideline.
+  reachable “remote”; assert detection, the init rejected-race interleaving, and rescue
+  outcomes (including same-ULID divergence and dirty-worktree precondition) against real
+  `git`.
+- **Golden/tryscript** — extend the existing
+  `packages/tbd/tests/cli-sync-*.tryscript.md` family (and worktree-scenarios) with the
+  race, unrelated-history doctor output, the rescue flow, and the #135 missing-worktree
+  reproduction. Filter unstable fields (timestamps, ULIDs/backup-branch names) per the
+  golden-testing guideline.
 - TDD: one failing test per fault before the fix; run the full (non-long) suite each
   step; keep structural and behavioral commits separate.
 
@@ -320,9 +402,10 @@ are recovered by upgrading and running `tbd doctor --fix`.
 
 ## Open Questions
 
-- Should `tbd sync` short-circuit `pushWithRetry` entirely on a detected unrelated
-  rejection, or keep one attempt for the (rare) benign-race case before reporting?
-  (Lean: detect up front, skip the wasted retries.)
+- **Resolved (per review):** `tbd sync` detects the unrelated state up front
+  (post-fetch, at the merge stage) and does not run `pushWithRetry` against an unrelated
+  remote, so no retries are wasted; the push-failure-block check remains only as defense
+  in depth.
 - Backup-branch retention: leave `tbd-backup-<ts>` branches indefinitely, or have a
   later `tbd doctor` offer to prune old ones?
   (Lean: leave them; cheap and safe.)
@@ -330,11 +413,12 @@ are recovered by upgrading and running `tbd doctor --fix`.
 ## References
 
 - Issues: #139 (detection/rescue), #137 (race/prevention), #135 (silent fallback).
-- `src/file/git.ts` — `remoteBranchExists` (708), `initWorktree` (1119),
+- `packages/tbd/src/file/git.ts` — `remoteBranchExists` (708), `initWorktree` (1119),
   `checkRemoteBranchHealth` (1324), `pushWithRetry` (634), preserve-branch idiom (1062),
   `repairWorktree` (1513+).
-- `src/cli/commands/sync.ts`, `src/cli/commands/doctor.ts`,
-  `src/cli/lib/data-context.ts`, `src/lib/paths.ts` (`resolveDataSyncDir`).
+- `packages/tbd/src/cli/commands/sync.ts`, `packages/tbd/src/cli/commands/doctor.ts`,
+  `packages/tbd/src/cli/lib/data-context.ts`, `packages/tbd/src/lib/paths.ts`
+  (`resolveDataSyncDir`).
 - Prior art: `plan-2026-01-28-sync-worktree-recovery-and-hardening.md`,
   `plan-2026-05-17-shared-common-dir-sync-worktree.md`.
 - Guideline: `tbd-sync-troubleshooting`.

--- a/docs/project/specs/active/plan-2026-05-29-tbd-sync-unrelated-history-hardening.md
+++ b/docs/project/specs/active/plan-2026-05-29-tbd-sync-unrelated-history-hardening.md
@@ -1,0 +1,344 @@
+# Feature: tbd-sync unrelated-history detection, prevention, and rescue
+
+**Date:** 2026-05-29 (last updated 2026-05-29)
+
+**Author:** Joshua Levy (with agent assistance)
+
+**Status:** Draft
+
+## Overview
+
+Three related reports describe ways the `tbd-sync` branch can silently end up in an
+unrecoverable or misleading state:
+
+- **#139** — Two environments each initialize `tbd-sync` as an orphan, producing
+  branches with **no common ancestor**. `tbd sync` push then fails forever, while
+  `tbd doctor` reports the remote branch as **healthy**. There is no recovery path
+  (`allow-unrelated` / unrelated-history handling appears nowhere in the codebase).
+- **#137** — The race that creates the unrelated histories in the first place:
+  independent `tbd setup --auto` runs in different environments both fall through to
+  orphan creation because the remote branch isn’t visible yet, and nothing pushes the
+  fresh orphan to close the window.
+- **#135** — When the sync worktree is missing, older versions silently read an empty
+  tracker and wrote new issues to the gitignored `.tbd/data-sync/` path.
+  This is **already largely fixed** by the v0.2.0 shared-common-dir refactor (data
+  commands resolve with `allowFallback: false` and auto-heal a missing worktree); we
+  treat it here as verification + regression coverage.
+
+This spec hardens the sync layer along three axes — **detection** (make the bad state
+visible), **prevention** (shrink the race window), and **rescue** (a safe, automatic
+recovery) — and locks each behavior in with tests.
+
+## Goals
+
+- `remoteBranchExists` distinguishes “branch absent” (clean negative) from “check
+  failed” (ls-remote errored) and never falls through to orphan creation on the latter.
+- Unrelated histories (no merge-base) are detected and reported by `tbd doctor` and
+  surfaced by `tbd sync` with an actionable message — never reported as healthy.
+- The freshly-created orphan `tbd-sync` is pushed immediately (best-effort) to make
+  “first init wins” the canonical outcome.
+- `tbd doctor --fix` recovers from unrelated histories **non-destructively** at the
+  issue-file layer: safety backup branch → adopt remote as base → replay local-only
+  issues + union-merge `ids.yml` → commit → fast-forward push.
+- Regression tests confirm #135’s missing-worktree behavior (loud heal, no silent
+  fallback writes).
+
+## Non-Goals
+
+- No change to the on-disk storage format (`f04`) or the `git-common-dir-v1` layout.
+- No general-purpose three-way git history rewriting.
+  Reconciliation happens at the issue-file layer (ULIDs guarantee no collisions), not
+  the git-history layer.
+- No interactive merge UI; rescue is automatic + non-destructive (a safety branch is
+  always created so the prior local HEAD is recoverable).
+- Not changing how genuine (shared-ancestor) divergence is merged — that path already
+  works.
+
+## Background
+
+### Current control flow (verified against current source, v0.2.0)
+
+**`initWorktree`** (`src/file/git.ts:1119`) decision tree:
+
+1. local `tbd-sync` exists → attach worktree to it.
+2. else `remoteBranchExists(remote, syncBranch)` → fetch + create tracking branch.
+3. else → `git worktree add --orphan` + seed structure + commit
+   `"Initialize tbd-sync branch"`. **No push.**
+
+**`remoteBranchExists`** (`src/file/git.ts:708`):
+
+```ts
+try {
+  await git(..., 'ls-remote', '--exit-code', remote, `refs/heads/${branch}`);
+  return true;
+} catch {
+  return false; // Fault 1: ANY error => "no remote branch" => orphan init
+}
+```
+
+`ls-remote --exit-code` exits **2** when the branch is absent but the remote was
+reachable, and exits with other non-zero codes (or throws) on auth/network/transient
+failure. Today both collapse to `false`.
+
+**`checkRemoteBranchHealth`** (`src/file/git.ts:1324`):
+
+```ts
+try {
+  const mergeBase = await git(..., 'merge-base', syncBranch, `${remote}/${syncBranch}`);
+  const localHead = await git(..., 'rev-parse', syncBranch);
+  diverged = mergeBase.trim() !== localHead.trim() && mergeBase.trim() !== remoteHead;
+} catch {
+  diverged = false; // Fault 2: merge-base exits non-zero for UNRELATED histories => "healthy"
+}
+```
+
+`git merge-base A B` exits **1** with no output when the two commits share no ancestor.
+That lands in the catch and is reported as `diverged = false` — the worst case looks
+healthy.
+
+**`pushWithRetry`** (`src/file/git.ts:634`) treats `fetch first` / `rejected` /
+`non-fast-forward` as retryable, fetches + runs the field-level merge callback, and
+after `MAX_PUSH_RETRIES` (3) returns `"Remote has conflicting changes."` For unrelated
+histories the merge callback can’t help (the git merge has no base), so it burns three
+identical attempts and falls through to the outbox.
+
+**Recovery machinery that already exists** and we build on:
+
+- Safety-backup-branch idiom (`src/file/git.ts:1062`):
+  `git branch tbd-legacy-preserve-<ts> <head>` before a destructive op.
+- `repairWorktree` / corrupted-worktree backup to `sharedBackupsDir`
+  (`src/file/git.ts:1513+`).
+- `reconcileMappings`, `mergeIdMappings`, `resolveIdMappingConflicts`
+  (`src/file/id-mapping.ts`) and the field-level `mergeIssues` (`src/file/git.ts`).
+- `attic/conflicts/` routing for issue-level conflicts.
+
+### Why a file-layer rescue is safe (storage model)
+
+- One file per issue, globally unique ULIDs: `issues/is-<ulid>.md` — no cross-history
+  collisions.
+- `mappings/ids.yml` ships with `.gitattributes: ids.yml merge=union`.
+- Issue-level conflicts already route to `attic/conflicts/`.
+
+The only real blocker is git refusing to merge histories with no common ancestor, so the
+merge must happen at the issue-file layer, not the git-history layer.
+
+### #135 status (verified)
+
+`assembleDataContext` (`src/cli/lib/data-context.ts:172`) resolves with
+`allowFallback: false`, so a missing worktree throws `WorktreeMissingError` instead of
+silently using the gitignored `.tbd/data-sync/`. `withDataSyncContext` auto-repairs a
+`missing`/`prunable` worktree via `ensureSharedDataSyncLayout` → `repairWorktree`. So
+`create`/`list` now heal-or-throw rather than silently degrade.
+Remaining work is to **prove** this with a regression test that reproduces the original
+ephemeral-clone scenario and asserts no write ever lands in `.tbd/data-sync/`.
+
+## Design
+
+### Approach
+
+Two phases.
+Phase 1 (detection + prevention + #135 regression) is independently shippable
+and stops the silent corruption and most of the race.
+Phase 2 (rescue) adds the automatic recovery that turns the “unrecoverable forever”
+state into a one-command fix.
+Each fault is driven by a failing test first (Red → Green → Refactor), per the project
+TDD guidelines.
+
+### Components
+
+| Area | File | Change |
+| --- | --- | --- |
+| Remote existence | `src/file/git.ts` `remoteBranchExists` | Return a tri-state result distinguishing absent / present / check-failed |
+| Init | `src/file/git.ts` `initWorktree` | Refuse orphan creation when remote check failed; push orphan immediately (best-effort) |
+| Detection | `src/file/git.ts` `checkRemoteBranchHealth` | Add `unrelated: boolean`; set it when `merge-base` finds no common ancestor (distinguish from “local branch absent”) |
+| Doctor report | `src/cli/commands/doctor.ts` | Report unrelated state as a hard finding (not healthy) and route to rescue, not plain `tbd sync` |
+| Sync messaging | `src/cli/commands/sync.ts` / `pushWithRetry` | Detect unrelated-history push rejection; emit dedicated message + remediation instead of 3 identical retries |
+| Rescue | `src/file/git.ts` (new `rescueUnrelatedHistory`) + `doctor.ts --fix` wiring | Non-destructive issue-file-layer reconciliation |
+| #135 | `tests/` | Regression test(s); small loud-failure tweak only if a gap is found |
+
+### Detailed design
+
+#### Fault 1 — `remoteBranchExists` fails open
+
+Introduce a tri-state so callers can act on the distinction:
+
+```ts
+export type RemoteBranchProbe = 'present' | 'absent' | 'check-failed';
+
+export async function probeRemoteBranch(
+  remote: string, branch: string, baseDir?: string,
+): Promise<RemoteBranchProbe> {
+  try {
+    await git(..., 'ls-remote', '--exit-code', remote, `refs/heads/${branch}`);
+    return 'present';
+  } catch (err) {
+    // ls-remote --exit-code exits 2 when the connection succeeded but the ref
+    // is absent; any other failure (auth/network/transient) is a check failure.
+    return exitCodeOf(err) === 2 ? 'absent' : 'check-failed';
+  }
+}
+```
+
+Keep `remoteBranchExists` as a thin `=== 'present'` wrapper for existing callers
+(`uninstall`, `init`) to avoid churn.
+In `initWorktree`, branch on the tri-state:
+
+- `present` → fetch + create tracking branch (as today).
+- `absent` → orphan creation is safe.
+- `check-failed` → **do not** create an orphan; return a clear error (`"Could not verify
+  whether origin/tbd-sync exists (remote check failed); refusing to create a divergent
+  local branch. Check connectivity/auth and retry."`).
+
+Need a reliable way to read git’s exit code: the `git()` wrapper currently throws an
+`Error` with a message.
+Extend the wrapper (or the thrown error) to carry `exitCode` so `probeRemoteBranch` can
+inspect it without string-matching.
+(Structural change, commit separately.)
+
+#### Fault 1b (#137) — push the fresh orphan immediately
+
+After the orphan is created and the initial commit is made, attempt
+`git push origin tbd-sync` best-effort with transient-retry, ignoring failure
+(restricted egress / no auth must not break setup).
+This makes “first init wins” the canonical outcome and shrinks the race window from
+“until first sync” to “until setup completes”.
+
+#### Fault 2 — detect unrelated histories
+
+Extend `RemoteBranchHealth` with `unrelated: boolean`. In `checkRemoteBranchHealth`,
+determine whether a local branch exists first (so “no local branch” stays
+`diverged=false, unrelated=false`), then run `merge-base`:
+
+- `merge-base` succeeds → compute `diverged` as today, `unrelated=false`.
+- local branch exists **and** `merge-base` exits non-zero (no common ancestor) →
+  `unrelated=true` (and `diverged=true` for callers that only check divergence).
+- local branch absent → both false.
+
+Use `git merge-base --is-ancestor` / explicit exit-code handling rather than a bare
+try/catch so transient errors don’t masquerade as “unrelated”.
+
+`tbd doctor` (`doctor.ts:~1246/1302`): when `unrelated`, emit a hard ✗ finding
+(`"Sync histories are unrelated (no common ancestor) — push cannot succeed"`) whose
+remediation is `tbd doctor --fix` (the rescue), **not** `tbd sync`.
+
+`tbd sync` (`sync.ts` push-failure block, ~line 919): when the push fails and
+`checkRemoteBranchHealth` reports `unrelated`, replace the generic “Remote has
+conflicting changes” with the dedicated message and point at `tbd doctor --fix`.
+Optionally short-circuit `pushWithRetry` so it doesn’t burn 3 identical attempts on an
+unrelated-history rejection.
+
+#### Rescue mode — `rescueUnrelatedHistory` (non-destructive)
+
+New function invoked by `tbd doctor --fix` when `unrelated` is detected:
+
+1. `git fetch origin tbd-sync`.
+2. Safety net: `git branch tbd-backup-<nowFilenameTimestamp()> <local tbd-sync HEAD>`
+   (reuse the existing preserve-branch idiom).
+   Prior local state is always recoverable.
+3. Compute the content delta keyed by ULID: issue files (and any mapping rows) present
+   on local `tbd-sync` but absent on `origin/tbd-sync`. Robust to the missing merge base
+   because it’s a file-set diff, not a git merge.
+4. Adopt remote as canonical base: reset the worktree’s `tbd-sync` to `origin/tbd-sync`
+   (preserved by step 2).
+5. Re-apply the local-only issue files; union-merge `ids.yml` via existing
+   `mergeIdMappings`; run `reconcileMappings` so every issue has a backing mapping and
+   vice-versa (closes the “62 map entries vs 57 files” inconsistency noted in #139);
+   commit `"tbd rescue: adopt remote base + reapply N local-only issue(s)"`.
+6. Return control; the normal push is now a clean fast-forward.
+
+Post-conditions asserted by tests:
+`git merge-base --is-ancestor origin/tbd-sync tbd-sync` is true (push fast-forwards);
+issue-file count equals id-map entry count; no duplicate public IDs; the backup branch
+exists and contains the pre-rescue HEAD.
+
+#### #135 — verify + regression
+
+Add a golden/e2e (tryscript) scenario reproducing: repo with issues on `tbd-sync`, fresh
+clone with the worktree absent, then `tbd list` / `tbd create` / `tbd sync`. Assert: the
+worktree is auto-materialized (or the command fails loudly), `tbd list` reflects the
+real issues, and **no file is ever written under `.tbd/data-sync/`** (the gitignored
+wrong location).
+Only add code (e.g. distinguishing “no issues” from “store unavailable”)
+if the test exposes a residual gap.
+
+### API Changes
+
+- New exported `probeRemoteBranch` + `RemoteBranchProbe` type in `src/file/git.ts`;
+  `remoteBranchExists` retained as a wrapper.
+- `RemoteBranchHealth` gains `unrelated: boolean`.
+- New exported `rescueUnrelatedHistory` (or equivalent) in `src/file/git.ts`.
+- `git()` wrapper / thrown error carries `exitCode` (internal).
+
+## Implementation Plan
+
+### Phase 1: Detection, prevention, and #135 regression
+
+- [ ] Make the `git()` error carry `exitCode` (structural; commit separately).
+- [ ] `probeRemoteBranch` tri-state + `remoteBranchExists` wrapper; unit tests for
+  absent vs check-failed (mock/stub git exit codes).
+- [ ] `initWorktree`: refuse orphan on `check-failed`; best-effort immediate push of the
+  fresh orphan. Tests cover both.
+- [ ] `checkRemoteBranchHealth`: add `unrelated`; tests for unrelated, genuinely
+  diverged, in-sync, and no-local-branch cases.
+- [ ] `tbd doctor`: report `unrelated` as a hard finding routing to `--fix`; update
+  `doctor-sync` tests / golden output.
+- [ ] `tbd sync`: dedicated unrelated-history message + remediation; avoid 3 wasted
+  retries.
+- [ ] #135 regression scenario (tryscript) — missing worktree heals/fails loudly, never
+  writes to `.tbd/data-sync/`.
+
+### Phase 2: Non-destructive rescue
+
+- [ ] `rescueUnrelatedHistory`: fetch → backup branch → file-set delta → adopt remote →
+  replay local-only issues + union ids.yml + `reconcileMappings` → commit.
+- [ ] Wire into `tbd doctor --fix`; after rescue, normal sync fast-forwards.
+- [ ] Tests: construct two unrelated `tbd-sync` roots in a temp repo, run rescue, assert
+  fast-forward-ability, file/map consistency, no duplicate IDs, backup branch present,
+  and that local-only beads survive.
+- [ ] End-to-end tryscript: race → detect → `tbd doctor --fix` → `tbd sync` → in sync.
+
+## Testing Strategy
+
+- **Unit** — `probeRemoteBranch` exit-code mapping; `checkRemoteBranchHealth` flag
+  matrix; rescue delta computation (pure where possible).
+- **Integration** — temp-repo helpers that build two unrelated orphan roots and a
+  reachable “remote”; assert detection + rescue outcomes against real `git`.
+- **Golden/tryscript** — extend the existing `tests/cli-sync-*.tryscript.md` family (and
+  worktree-scenarios) with the race, unrelated-history doctor output, the rescue flow,
+  and the #135 missing-worktree reproduction.
+  Filter unstable fields (timestamps, ULIDs/backup-branch names) per the golden-testing
+  guideline.
+- TDD: one failing test per fault before the fix; run the full (non-long) suite each
+  step; keep structural and behavioral commits separate.
+
+## Rollout Plan
+
+Lands on `claude/eager-brown-tBntt` → draft PR. Phase 1 is shippable on its own (stops
+silent corruption + the race).
+Ships in the next `get-tbd` release; existing repos already stuck in the unrelated state
+are recovered by upgrading and running `tbd doctor --fix`.
+
+## Open Questions
+
+- Should `tbd sync` short-circuit `pushWithRetry` entirely on a detected unrelated
+  rejection, or keep one attempt for the (rare) benign-race case before reporting?
+  (Lean: detect up front, skip the wasted retries.)
+- Backup-branch retention: leave `tbd-backup-<ts>` branches indefinitely, or have a
+  later `tbd doctor` offer to prune old ones?
+  (Lean: leave them; cheap and safe.)
+
+## References
+
+- Issues: #139 (detection/rescue), #137 (race/prevention), #135 (silent fallback).
+- `src/file/git.ts` — `remoteBranchExists` (708), `initWorktree` (1119),
+  `checkRemoteBranchHealth` (1324), `pushWithRetry` (634), preserve-branch idiom (1062),
+  `repairWorktree` (1513+).
+- `src/cli/commands/sync.ts`, `src/cli/commands/doctor.ts`,
+  `src/cli/lib/data-context.ts`, `src/lib/paths.ts` (`resolveDataSyncDir`).
+- Prior art: `plan-2026-01-28-sync-worktree-recovery-and-hardening.md`,
+  `plan-2026-05-17-shared-common-dir-sync-worktree.md`.
+- Guideline: `tbd-sync-troubleshooting`.
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/docs/project/specs/active/plan-2026-05-29-tbd-sync-unrelated-history-hardening.md
+++ b/docs/project/specs/active/plan-2026-05-29-tbd-sync-unrelated-history-hardening.md
@@ -4,7 +4,7 @@
 
 **Author:** Joshua Levy (with agent assistance)
 
-**Status:** Draft
+**Status:** Implemented (PR #143, epic tbd-55sk + 12 children closed)
 
 ## Overview
 
@@ -340,41 +340,58 @@ if the test exposes a residual gap.
 
 ### Phase 1: Detection, prevention, and #135 regression
 
-- [ ] Make the `git()` error carry `exitCode` (structural; commit separately).
-- [ ] `probeRemoteBranch` tri-state + `remoteBranchExists` wrapper; unit tests for
+- [x] Make the `git()` error carry `exitCode` (structural; commit separately).
+- [x] `probeRemoteBranch` tri-state + `remoteBranchExists` wrapper; unit tests for
   absent vs check-failed (mock/stub git exit codes).
-- [ ] `initWorktree`: use `probeRemoteBranch` directly (not the boolean wrapper); refuse
+- [x] `initWorktree`: use `probeRemoteBranch` directly (not the boolean wrapper); refuse
   orphan on `check-failed`; immediate orphan push that classifies success / transient /
   non-fast-forward-rejection.
   Test the **rejected-race interleaving** (A creates orphan, B pushes first, A’s push
   rejected → A adopts scaffold-only remote, or fails loudly if A already has user
   issues), plus the happy-path push and the check-failed refusal.
-- [ ] `checkRemoteBranchHealth`: add `unrelated`; tests for unrelated, genuinely
+- [x] `checkRemoteBranchHealth`: add `unrelated`; tests for unrelated, genuinely
   diverged, in-sync, and no-local-branch cases.
-- [ ] `tbd doctor`: report `unrelated` as a hard finding routing to `--fix`; update
+- [x] `tbd doctor`: report `unrelated` as a hard finding routing to `--fix`; update
   `doctor-sync` tests / golden output.
-- [ ] `tbd sync`: detect unrelated post-fetch at the merge stage (`sync.ts:865`) before
+- [x] `tbd sync`: detect unrelated post-fetch at the merge stage (`sync.ts:865`) before
   file-level conflict/retry runs; dedicated message + remediation; defense-in-depth
   check in the push-failure block; avoid 3 wasted retries.
-- [ ] #135 regression scenario (tryscript) — missing worktree heals/fails loudly, never
+- [x] #135 regression scenario (tryscript) — missing worktree heals/fails loudly, never
   writes to `.tbd/data-sync/`.
 
 ### Phase 2: Non-destructive rescue
 
-- [ ] `rescueUnrelatedHistory` under `withSharedDataSyncLock`, with clean-worktree /
+- [x] `rescueUnrelatedHistory` under `withSharedDataSyncLock`, with clean-worktree /
   no-merge-in-progress preconditions: fetch → backup branch → categorize by ULID
   (local-only / remote-only / both-identical / both-different) → adopt remote → apply
   buckets (`mergeIssues`/conflict-attic for both-different) + union ids.yml +
   `resolveIdMappingConflicts` + `reconcileMappings` → commit.
-- [ ] Wire into `tbd doctor --fix`; after rescue, normal sync fast-forwards.
-- [ ] Tests: construct two unrelated `tbd-sync` roots in a temp repo, run rescue, assert
+- [x] Wire into `tbd doctor --fix`; after rescue, normal sync fast-forwards.
+- [x] Tests: construct two unrelated `tbd-sync` roots in a temp repo, run rescue, assert
   fast-forward-ability, file/map consistency, no duplicate IDs, backup branch present,
   and that local-only beads survive.
   **Same-ULID divergence cases:** identical content (no-op), differing scalar fields,
   differing labels (field-merge), and a true conflict (preserved in `attic/conflicts/`,
   never dropped). Plus a precondition test: rescue aborts on a dirty worktree /
   merge-in-progress.
-- [ ] End-to-end tryscript: race → detect → `tbd doctor --fix` → `tbd sync` → in sync.
+- [x] End-to-end tryscript: race → detect → `tbd doctor --fix` → `tbd sync` → in sync.
+
+### Implementation notes (refinements from senior review of PR #143)
+
+- **Rescue preserves every non-winning side.** `mergeIssues(null, …)` has no trustworthy
+  base across unrelated roots (with equal `created_at` it synthesizes one from the
+  lower-version side), so the rescue preserves to `attic/conflicts/` *every*
+  substantively-different side the merge does not keep — not only when `mergeIssues`
+  reports a field conflict.
+  This guarantees no edit is dropped without an artifact even when both roots edited the
+  same field from the same version.
+- **Remote public IDs are canonical.** The ID-map union uses
+  `mergeIdMappings(remote, local)` (remote precedence), so an issue already on the
+  shared remote keeps its public ID; only colliding local-only short IDs are regenerated
+  by `reconcileMappings`.
+- **No-op rescues succeed.** After adopting the remote base, the rescue skips the commit
+  when `git status --porcelain` is clean (e.g. scaffold-only or identical roots) rather
+  than failing on “nothing to commit”.
 
 ## Testing Strategy
 

--- a/packages/tbd/src/cli/commands/doctor.ts
+++ b/packages/tbd/src/cli/commands/doctor.ts
@@ -42,6 +42,7 @@ import {
   migrateDataToWorktree,
   initWorktree,
   countRemoteIssues,
+  type RemoteBranchHealth,
 } from '../../file/git.js';
 import {
   CommonDirLayoutError,
@@ -53,6 +54,42 @@ import {
 import { isCompatibleFormat } from '../../lib/tbd-format.js';
 import { type DiagnosticResult, renderDiagnostics } from '../lib/diagnostics.js';
 import { VERSION } from '../lib/version.js';
+
+/**
+ * Map remote sync-branch health to a "Remote sync branch" diagnostic.
+ *
+ * Returns null when the remote branch does not exist (the caller then falls
+ * through to local-branch / new-repo handling). Unrelated histories are a hard
+ * ✗ finding routed to `tbd doctor --fix` (the rescue), NOT `tbd sync` — push
+ * can never fast-forward and a plain merge refuses, so `tbd sync` cannot help.
+ */
+export function classifyRemoteSyncHealth(
+  health: RemoteBranchHealth,
+  remote: string,
+  syncBranch: string,
+): DiagnosticResult | null {
+  if (!health.exists) {
+    return null;
+  }
+  if (health.unrelated) {
+    return {
+      name: 'Remote sync branch',
+      status: 'error',
+      fixable: true,
+      message: `${remote}/${syncBranch} histories are unrelated (no common ancestor) — push cannot succeed`,
+      suggestion: 'Run: tbd doctor --fix to reconcile the unrelated histories',
+    };
+  }
+  if (health.diverged) {
+    return {
+      name: 'Remote sync branch',
+      status: 'warn',
+      message: `${remote}/${syncBranch} has diverged`,
+      suggestion: 'Run: tbd sync to reconcile changes',
+    };
+  }
+  return { name: 'Remote sync branch', status: 'ok', message: `${remote}/${syncBranch}` };
+}
 import { formatHeading } from '../lib/output.js';
 import {
   renderRepositorySection,
@@ -1245,16 +1282,9 @@ class DoctorHandler extends BaseCommand {
     const remote = this.config?.sync.remote ?? 'origin';
     const remoteHealth = await checkRemoteBranchHealth(remote, syncBranch, this.cwd);
 
-    if (remoteHealth.exists) {
-      if (remoteHealth.diverged) {
-        return {
-          name: 'Remote sync branch',
-          status: 'warn',
-          message: `${remote}/${syncBranch} has diverged`,
-          suggestion: 'Run: tbd sync to reconcile changes',
-        };
-      }
-      return { name: 'Remote sync branch', status: 'ok', message: `${remote}/${syncBranch}` };
+    const diag = classifyRemoteSyncHealth(remoteHealth, remote, syncBranch);
+    if (diag) {
+      return diag;
     }
 
     // Remote branch doesn't exist

--- a/packages/tbd/src/cli/commands/doctor.ts
+++ b/packages/tbd/src/cli/commands/doctor.ts
@@ -42,6 +42,7 @@ import {
   migrateDataToWorktree,
   initWorktree,
   countRemoteIssues,
+  rescueUnrelatedHistory,
   type RemoteBranchHealth,
 } from '../../file/git.js';
 import {
@@ -209,7 +210,7 @@ class DoctorHandler extends BaseCommand {
     healthChecks.push(await this.checkLocalSyncBranch());
 
     // Check 12: Remote sync branch health
-    healthChecks.push(await this.checkRemoteSyncBranch());
+    healthChecks.push(await this.checkRemoteSyncBranch(options.fix));
 
     // Check 13: Local has data but remote empty (ai-trade-arena bug detection)
     healthChecks.push(await this.checkLocalVsRemoteData());
@@ -1277,10 +1278,37 @@ class DoctorHandler extends BaseCommand {
    * Check remote sync branch health.
    * See: plan-2026-01-28-sync-worktree-recovery-and-hardening.md §4b
    */
-  private async checkRemoteSyncBranch(): Promise<DiagnosticResult> {
+  private async checkRemoteSyncBranch(fix?: boolean): Promise<DiagnosticResult> {
     const syncBranch = this.config?.sync.branch ?? 'tbd-sync';
     const remote = this.config?.sync.remote ?? 'origin';
     const remoteHealth = await checkRemoteBranchHealth(remote, syncBranch, this.cwd);
+
+    // Unrelated histories: with --fix, run the non-destructive rescue (adopt
+    // remote base + replay local work). Serialized under the shared lock so a
+    // concurrent create/sync from a sibling worktree cannot race the
+    // reset/replay window, matching the worktree-repair fix path.
+    if (remoteHealth.unrelated && fix && !this.checkDryRun('Rescue unrelated tbd-sync histories')) {
+      try {
+        const result = await withSharedDataSyncLock(this.cwd, async () =>
+          rescueUnrelatedHistory(this.cwd, remote, syncBranch),
+        );
+        return {
+          name: 'Remote sync branch',
+          status: 'ok',
+          message:
+            `rescued: adopted ${remote}/${syncBranch} base, reconciled ` +
+            `${result.localOnly} local-only + ${result.merged} merged ` +
+            `(backup: ${result.backupBranch})`,
+        };
+      } catch (error) {
+        return {
+          name: 'Remote sync branch',
+          status: 'error',
+          message: `rescue failed: ${error instanceof Error ? error.message : String(error)}`,
+          suggestion: 'Resolve manually; the pre-rescue state is on the tbd-backup-* branch',
+        };
+      }
+    }
 
     const diag = classifyRemoteSyncHealth(remoteHealth, remote, syncBranch);
     if (diag) {

--- a/packages/tbd/src/cli/commands/sync.ts
+++ b/packages/tbd/src/cli/commands/sync.ts
@@ -7,7 +7,12 @@
 import { Command } from 'commander';
 
 import { BaseCommand } from '../lib/base-command.js';
-import { requireInit, SyncError, classifySyncError } from '../lib/errors.js';
+import {
+  requireInit,
+  SyncError,
+  UnrelatedHistoriesError,
+  classifySyncError,
+} from '../lib/errors.js';
 import { listIssues, readIssue, writeIssue } from '../../file/storage.js';
 import {
   git,
@@ -15,6 +20,7 @@ import {
   mergeIssues,
   pushWithRetry,
   ensureWorktreeAttachedToBranch,
+  checkRemoteBranchHealth,
   type ConflictEntry,
   type PushResult,
 } from '../../file/git.js';
@@ -607,6 +613,14 @@ class SyncHandler extends BaseCommand {
       // STEP 2: Fetch remote
       await git('fetch', remote, syncBranch);
 
+      // Detect unrelated histories UP FRONT (post-fetch), before any merge or
+      // conflict/retry work — so sync does no misleading work, diagnostics
+      // point at the right phase, and pushWithRetry is never run against an
+      // unrelated remote (no wasted retries). The rescue is `tbd doctor --fix`.
+      if ((await checkRemoteBranchHealth(remote, syncBranch)).unrelated) {
+        throw new UnrelatedHistoriesError(remote, syncBranch);
+      }
+
       // Get file-level changes from remote using git diff
       let behindCommits = 0;
       try {
@@ -863,6 +877,12 @@ class SyncHandler extends BaseCommand {
         }
       }
     } catch (error) {
+      // Surface real sync failures (e.g. unrelated histories) instead of
+      // masking them as "first sync". A genuine first-sync fetch failure is a
+      // GitError, not a SyncError, so it is still swallowed below.
+      if (error instanceof SyncError) {
+        throw error;
+      }
       // Remote not available - that's ok for first sync
       this.output.debug(`Fetch failed (may be first sync): ${(error as Error).message}`);
     }
@@ -917,6 +937,13 @@ class SyncHandler extends BaseCommand {
 
     // Report push failure - classify error and take appropriate action
     if (pushFailed) {
+      // Defense in depth: a push can still fail with unrelated histories if the
+      // remote became unrelated after our up-front check. Surface the dedicated
+      // remediation rather than the generic "Remote has conflicting changes".
+      if ((await checkRemoteBranchHealth(remote, syncBranch)).unrelated) {
+        throw new UnrelatedHistoriesError(remote, syncBranch);
+      }
+
       // Extract meaningful error display string
       let displayError = pushError;
       const httpMatch = /HTTP (\d+)/.exec(pushError);

--- a/packages/tbd/src/cli/lib/errors.ts
+++ b/packages/tbd/src/cli/lib/errors.ts
@@ -79,6 +79,24 @@ export class SyncError extends CLIError {
 }
 
 /**
+ * Unrelated-history error - the local and remote tbd-sync share no common
+ * ancestor, so a push can never fast-forward and a plain git merge refuses.
+ * `tbd sync` cannot resolve this; the rescue lives in `tbd doctor --fix`.
+ * See: plan-2026-05-29-tbd-sync-unrelated-history-hardening.md
+ */
+export class UnrelatedHistoriesError extends SyncError {
+  constructor(remote = 'origin', syncBranch = 'tbd-sync') {
+    super(
+      `${remote}/${syncBranch} has an unrelated history (no common ancestor) — ` +
+        `push cannot fast-forward and a merge would refuse.\n` +
+        `Run \`tbd doctor --fix\` to reconcile the unrelated histories (non-destructive; ` +
+        `a backup branch is created first).`,
+    );
+    this.name = 'UnrelatedHistoriesError';
+  }
+}
+
+/**
  * Sync branch error - issues with the tbd-sync branch.
  * This can indicate the branch is missing, orphaned, or has diverged.
  * See: tbd-design.md §2.3.6 Worktree Error Classes

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -18,6 +18,8 @@ import { writeFile } from 'atomically';
 
 import type { Issue } from '../lib/types.js';
 import { now, nowFilenameTimestamp } from '../utils/time-utils.js';
+import { parseIssue, serializeIssue } from './parser.js';
+import { listIssues, writeIssue } from './storage.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -676,6 +678,54 @@ export function mergeIssues(base: Issue | null, local: Issue, remote: Issue): Me
 }
 
 /**
+ * Issues bucketed by ULID/id across two (possibly unrelated) tbd-sync roots.
+ */
+export interface UlidBuckets {
+  /** Present only locally — must be re-applied onto the adopted remote base. */
+  localOnly: Issue[];
+  /** Present only on the remote — already on the adopted base; nothing to do. */
+  remoteOnly: Issue[];
+  /** Same id, substantively equal — no action (remote version kept). */
+  bothIdentical: Issue[];
+  /** Same id, differing content — must be field-merged, never dropped. */
+  bothDifferent: { local: Issue; remote: Issue }[];
+}
+
+/**
+ * Categorize issues from two unrelated tbd-sync roots by id (which embeds the
+ * globally unique ULID). Pure and git-free so the rescue is robust to the
+ * missing merge base. Substantive equality ignores version/updated_at so
+ * trivial bumps don't masquerade as conflicts.
+ */
+export function categorizeIssuesByUlid(local: Issue[], remote: Issue[]): UlidBuckets {
+  const localById = new Map(local.map((i) => [i.id, i]));
+  const remoteById = new Map(remote.map((i) => [i.id, i]));
+  const buckets: UlidBuckets = {
+    localOnly: [],
+    remoteOnly: [],
+    bothIdentical: [],
+    bothDifferent: [],
+  };
+
+  for (const [id, localIssue] of localById) {
+    const remoteIssue = remoteById.get(id);
+    if (!remoteIssue) {
+      buckets.localOnly.push(localIssue);
+    } else if (issuesSubstantivelyEqual(localIssue, remoteIssue)) {
+      buckets.bothIdentical.push(remoteIssue);
+    } else {
+      buckets.bothDifferent.push({ local: localIssue, remote: remoteIssue });
+    }
+  }
+  for (const [id, remoteIssue] of remoteById) {
+    if (!localById.has(id)) {
+      buckets.remoteOnly.push(remoteIssue);
+    }
+  }
+  return buckets;
+}
+
+/**
  * Maximum retry attempts for push operations.
  */
 const MAX_PUSH_RETRIES = 3;
@@ -850,6 +900,7 @@ import {
   WORKTREE_DIR_NAME,
   LEGACY_WORKTREE_DIR,
   TBD_DIR,
+  DATA_SYNC_DIR,
   DATA_SYNC_DIR_NAME,
   SYNC_BRANCH,
   resolveSharedTbdPaths,
@@ -859,8 +910,11 @@ import { DATA_SYNC_SCHEMA_VERSION } from '../lib/schemas.js';
 import {
   loadIdMapping,
   mergeIdMappings,
+  reconcileMappings,
+  parseIdMappingFromYaml,
   resolveIdMappingConflicts,
   saveIdMapping,
+  type IdMapping,
 } from './id-mapping.js';
 
 async function pathExists(path: string): Promise<boolean> {
@@ -1667,6 +1721,175 @@ export async function checkSyncConsistency(
     worktreeMatchesLocal: worktreeHead.trim() === localHead.trim(),
     localAhead,
     localBehind,
+  };
+}
+
+/**
+ * Outcome of a non-destructive unrelated-history rescue.
+ */
+export interface RescueResult {
+  /** Backup branch holding the pre-rescue local HEAD (always recoverable). */
+  backupBranch: string;
+  /** Number of local-only issues re-applied onto the adopted remote base. */
+  localOnly: number;
+  /** Number of same-id divergent issues field-merged. */
+  merged: number;
+  /** Number of those merges that preserved a losing version in attic/conflicts/. */
+  conflicts: number;
+  /** Total issue files after the rescue. */
+  totalIssues: number;
+}
+
+/** Read all issues from a git ref's data-sync tree (no checkout needed). */
+async function readBranchIssues(baseDir: string, ref: string): Promise<Issue[]> {
+  let listing: string;
+  try {
+    listing = await git(
+      '-C',
+      baseDir,
+      'ls-tree',
+      '-r',
+      '--name-only',
+      ref,
+      '--',
+      `${DATA_SYNC_DIR}/issues/`,
+    );
+  } catch {
+    return [];
+  }
+  const issues: Issue[] = [];
+  for (const path of listing.split('\n').filter((p) => /\/is-.*\.md$/.test(p))) {
+    try {
+      const content = await git('-C', baseDir, 'show', `${ref}:${path}`);
+      issues.push(parseIssue(content));
+    } catch {
+      // Skip unreadable/invalid issue files; rescue is best-effort per file.
+    }
+  }
+  return issues;
+}
+
+/** Read the ID mapping from a git ref's ids.yml (empty if absent). */
+async function readBranchMapping(baseDir: string, ref: string): Promise<IdMapping> {
+  try {
+    const content = await git('-C', baseDir, 'show', `${ref}:${DATA_SYNC_DIR}/mappings/ids.yml`);
+    return parseIdMappingFromYaml(content);
+  } catch {
+    return { shortToUlid: new Map(), ulidToShort: new Map() };
+  }
+}
+
+/** Preserve a losing issue version explicitly under attic/conflicts/. */
+async function preserveLosingVersion(dataSyncPath: string, loser: Issue): Promise<void> {
+  const conflictsDir = join(dataSyncPath, 'attic', 'conflicts');
+  await mkdir(conflictsDir, { recursive: true });
+  const filename = `${loser.id}__${nowFilenameTimestamp()}.md`;
+  await writeFile(join(conflictsDir, filename), serializeIssue(loser));
+}
+
+/**
+ * Non-destructively rescue an unrelated tbd-sync history (#139).
+ *
+ * Reconciles at the issue-file layer (ULIDs guarantee no collisions), never via
+ * a git history merge. Adopts the remote as the canonical base and replays
+ * local work onto it. The only destructive step (the reset) happens AFTER a
+ * backup branch is created, so the pre-rescue HEAD is always recoverable and
+ * the rescue is restartable.
+ *
+ * MUST be called while holding `withSharedDataSyncLock`. Aborts if the
+ * data-sync worktree is dirty or has a merge in progress.
+ */
+export async function rescueUnrelatedHistory(
+  baseDir: string,
+  remote = 'origin',
+  syncBranch: string = SYNC_BRANCH,
+): Promise<RescueResult> {
+  const { sharedWorktreePath: worktreePath, sharedDataSyncDir: dataSyncPath } =
+    await getSharedPaths(baseDir);
+
+  // Preconditions: never reset over uncommitted work or an in-progress merge.
+  const dirty = (await git('-C', worktreePath, 'status', '--porcelain')).trim();
+  if (dirty) {
+    throw new Error(
+      'Refusing to rescue: the tbd-sync worktree has uncommitted changes. ' +
+        'Commit or stash them, then retry.',
+    );
+  }
+  const mergeInProgress = await git('-C', worktreePath, 'rev-parse', '-q', '--verify', 'MERGE_HEAD')
+    .then(() => true)
+    .catch(() => false);
+  if (mergeInProgress) {
+    throw new Error(
+      'Refusing to rescue: a merge is in progress in the tbd-sync worktree. ' +
+        'Resolve or abort it, then retry.',
+    );
+  }
+
+  // 1. Fetch the remote so origin/<syncBranch> is current.
+  await gitNoPrompt('-C', baseDir, 'fetch', remote, syncBranch);
+
+  // Capture local state BEFORE the reset.
+  const localIssues = await listIssues(dataSyncPath);
+  const localMapping = await loadIdMapping(dataSyncPath);
+  const remoteIssues = await readBranchIssues(baseDir, `${remote}/${syncBranch}`);
+  const remoteMapping = await readBranchMapping(baseDir, `${remote}/${syncBranch}`);
+
+  // 2. Safety net: a backup branch at the pre-rescue local HEAD.
+  const localHead = (await git('-C', baseDir, 'rev-parse', syncBranch)).trim();
+  const backupBranch = `tbd-backup-${nowFilenameTimestamp()}`;
+  await git('-C', baseDir, 'branch', backupBranch, localHead);
+
+  // 3. Categorize by ULID (pure; robust to the missing merge base).
+  const buckets = categorizeIssuesByUlid(localIssues, remoteIssues);
+
+  // 4. Adopt the remote as the canonical base (the only destructive step, now
+  //    safely after the backup branch).
+  await git('-C', worktreePath, 'reset', '--hard', `${remote}/${syncBranch}`);
+
+  // 5. Replay local work onto the base.
+  let conflicts = 0;
+  for (const issue of buckets.localOnly) {
+    await writeIssue(dataSyncPath, issue);
+  }
+  for (const { local, remote: remoteIssue } of buckets.bothDifferent) {
+    // No common ancestor between unrelated roots -> merge with base=null.
+    const { merged, conflicts: fieldConflicts } = mergeIssues(null, local, remoteIssue);
+    await writeIssue(dataSyncPath, merged);
+    if (fieldConflicts.length > 0) {
+      // Preserve the losing version so nothing is silently dropped.
+      const loser = issuesSubstantivelyEqual(merged, local) ? remoteIssue : local;
+      await preserveLosingVersion(dataSyncPath, loser);
+      conflicts++;
+    }
+  }
+
+  // Union the ID mappings (additive) and ensure every issue has a backing
+  // mapping and vice-versa (closes the "map entries vs files" inconsistency).
+  const mergedMapping = mergeIdMappings(localMapping, remoteMapping);
+  const allIssues = await listIssues(dataSyncPath);
+  reconcileMappings(
+    allIssues.map((i) => i.id),
+    mergedMapping,
+    remoteMapping,
+  );
+  await saveIdMapping(dataSyncPath, mergedMapping);
+
+  // 6. Commit. The push is now a clean fast-forward over origin/<syncBranch>.
+  await git('-C', worktreePath, 'add', '-A');
+  await gitCommit(
+    worktreePath,
+    '--no-verify',
+    '-m',
+    `tbd rescue: adopt remote base + reconcile ${buckets.localOnly.length + buckets.bothDifferent.length} issue(s) ` +
+      `(${buckets.localOnly.length} local-only, ${buckets.bothDifferent.length} merged)`,
+  );
+
+  return {
+    backupBranch,
+    localOnly: buckets.localOnly.length,
+    merged: buckets.bothDifferent.length,
+    conflicts,
+    totalIssues: allIssues.length,
   };
 }
 

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -764,20 +764,52 @@ export async function branchExists(branch: string, baseDir?: string): Promise<bo
 }
 
 /**
- * Check if a remote branch exists.
+ * Tri-state result of probing whether a remote branch exists.
+ *
+ * - `present`      ls-remote found the ref.
+ * - `absent`       remote reachable, ref missing (ls-remote --exit-code => 2).
+ * - `check-failed` the check itself failed (auth/network/transient).
+ */
+export type RemoteBranchProbe = 'present' | 'absent' | 'check-failed';
+
+/**
+ * Probe whether a remote branch exists, distinguishing a clean "absent" from a
+ * "check failed".
+ *
+ * `git ls-remote --exit-code` exits 2 when the connection succeeded but no ref
+ * matched; any other failure (auth/network/transient, or git not found) is a
+ * check failure. Orphan-creating callers MUST branch on all three states and
+ * never treat `check-failed` as `absent` — doing so risks creating a divergent
+ * local branch when the remote is merely unreachable.
+ */
+export async function probeRemoteBranch(
+  remote: string,
+  branch: string,
+  baseDir?: string,
+): Promise<RemoteBranchProbe> {
+  const dirArgs = baseDir ? ['-C', baseDir] : [];
+  try {
+    await git(...dirArgs, 'ls-remote', '--exit-code', remote, `refs/heads/${branch}`);
+    return 'present';
+  } catch (err) {
+    return exitCodeOf(err) === 2 ? 'absent' : 'check-failed';
+  }
+}
+
+/**
+ * Check if a remote branch exists (fail-closed boolean wrapper).
+ *
+ * Returns true only for a confirmed `present`; both `absent` and `check-failed`
+ * read as false. Retained for read-only / status-style callers (e.g. uninstall)
+ * where fail-closed is acceptable. Orphan-creating paths MUST use
+ * {@link probeRemoteBranch} directly so they can refuse on `check-failed`.
  */
 export async function remoteBranchExists(
   remote: string,
   branch: string,
   baseDir?: string,
 ): Promise<boolean> {
-  try {
-    const dirArgs = baseDir ? ['-C', baseDir] : [];
-    await git(...dirArgs, 'ls-remote', '--exit-code', remote, `refs/heads/${branch}`);
-    return true;
-  } catch {
-    return false;
-  }
+  return (await probeRemoteBranch(remote, branch, baseDir)) === 'present';
 }
 
 /**

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -22,6 +22,63 @@ import { now, nowFilenameTimestamp } from '../utils/time-utils.js';
 const execFileAsync = promisify(execFile);
 
 /**
+ * Error thrown by {@link git} when a git command exits non-zero.
+ *
+ * Carries the process `exitCode` so callers can branch on git's exit status
+ * (e.g. `ls-remote --exit-code` => 2 means "ref absent", `merge-base` => 1
+ * means "no common ancestor") instead of string-matching stderr. The original
+ * message/stderr is preserved so existing message-based classifiers
+ * (classifySyncError) keep working.
+ */
+export class GitError extends Error {
+  /** Process exit code, or null for a spawn failure (e.g. git not found). */
+  readonly exitCode: number | null;
+  readonly stderr: string;
+  readonly stdout: string;
+  readonly args: string[];
+
+  constructor(
+    message: string,
+    opts: { exitCode: number | null; stderr: string; stdout: string; args: string[] },
+  ) {
+    super(message);
+    this.name = 'GitError';
+    this.exitCode = opts.exitCode;
+    this.stderr = opts.stderr;
+    this.stdout = opts.stdout;
+    this.args = opts.args;
+  }
+
+  /**
+   * Wrap a raw execFile rejection into a GitError.
+   *
+   * Node's execFile rejection carries `code` (numeric exit code for a normal
+   * exit, or a string like 'ENOENT' for a spawn failure), plus `stderr`/`stdout`.
+   */
+  static from(err: unknown, args: string[]): GitError {
+    const raw = err as {
+      message?: string;
+      code?: unknown;
+      stderr?: unknown;
+      stdout?: unknown;
+    };
+    const exitCode = typeof raw.code === 'number' ? raw.code : null;
+    const stderr = typeof raw.stderr === 'string' ? raw.stderr : '';
+    const stdout = typeof raw.stdout === 'string' ? raw.stdout : '';
+    const message = raw.message ?? `git ${args.join(' ')} failed`;
+    return new GitError(message, { exitCode, stderr, stdout, args });
+  }
+}
+
+/**
+ * Read the git exit code from a thrown value, or null if it is not a GitError
+ * (or carries no numeric code, e.g. a spawn failure).
+ */
+export function exitCodeOf(err: unknown): number | null {
+  return err instanceof GitError ? err.exitCode : null;
+}
+
+/**
  * Maximum buffer size for git command output.
  *
  * Node.js child_process.execFile() defaults to 1MB (1024 * 1024 bytes).
@@ -37,8 +94,12 @@ const GIT_MAX_BUFFER = 50 * 1024 * 1024; // 50MB
  * Uses execFile for security - prevents shell injection attacks.
  */
 export async function git(...args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync('git', args, { maxBuffer: GIT_MAX_BUFFER });
-  return stdout.trim();
+  try {
+    const { stdout } = await execFileAsync('git', args, { maxBuffer: GIT_MAX_BUFFER });
+    return stdout.trim();
+  } catch (err) {
+    throw GitError.from(err, args);
+  }
 }
 
 /**

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -1849,20 +1849,27 @@ export async function rescueUnrelatedHistory(
     await writeIssue(dataSyncPath, issue);
   }
   for (const { local, remote: remoteIssue } of buckets.bothDifferent) {
-    // No common ancestor between unrelated roots -> merge with base=null.
-    const { merged, conflicts: fieldConflicts } = mergeIssues(null, local, remoteIssue);
+    // No common ancestor between unrelated roots, so mergeIssues has no
+    // trustworthy base (with equal created_at it synthesizes one from the
+    // lower-version side). Preserve EVERY substantively-different side that the
+    // merge does not keep, so an edit is never silently dropped without an
+    // attic artifact — independent of whether mergeIssues reported a field
+    // conflict.
+    const { merged } = mergeIssues(null, local, remoteIssue);
     await writeIssue(dataSyncPath, merged);
-    if (fieldConflicts.length > 0) {
-      // Preserve the losing version so nothing is silently dropped.
-      const loser = issuesSubstantivelyEqual(merged, local) ? remoteIssue : local;
-      await preserveLosingVersion(dataSyncPath, loser);
-      conflicts++;
+    for (const side of [local, remoteIssue]) {
+      if (!issuesSubstantivelyEqual(side, merged)) {
+        await preserveLosingVersion(dataSyncPath, side);
+        conflicts++;
+      }
     }
   }
 
-  // Union the ID mappings (additive) and ensure every issue has a backing
-  // mapping and vice-versa (closes the "map entries vs files" inconsistency).
-  const mergedMapping = mergeIdMappings(localMapping, remoteMapping);
+  // Union the ID mappings (additive). The remote is the adopted canonical base,
+  // so it MUST win short-ID collisions — give remoteMapping precedence so an
+  // issue already on the shared remote keeps its public ID. reconcileMappings
+  // then regenerates only the conflicting local-only mappings.
+  const mergedMapping = mergeIdMappings(remoteMapping, localMapping);
   const allIssues = await listIssues(dataSyncPath);
   reconcileMappings(
     allIssues.map((i) => i.id),
@@ -1872,14 +1879,21 @@ export async function rescueUnrelatedHistory(
   await saveIdMapping(dataSyncPath, mergedMapping);
 
   // 6. Commit. The push is now a clean fast-forward over origin/<syncBranch>.
+  // If adopting the remote base left nothing to reconcile (e.g. two
+  // scaffold-only roots, or identical issue sets + mappings), the reset already
+  // adopted the base successfully — skip the commit rather than failing on
+  // "nothing to commit".
   await git('-C', worktreePath, 'add', '-A');
-  await gitCommit(
-    worktreePath,
-    '--no-verify',
-    '-m',
-    `tbd rescue: adopt remote base + reconcile ${buckets.localOnly.length + buckets.bothDifferent.length} issue(s) ` +
-      `(${buckets.localOnly.length} local-only, ${buckets.bothDifferent.length} merged)`,
-  );
+  const pending = (await git('-C', worktreePath, 'status', '--porcelain')).trim();
+  if (pending) {
+    await gitCommit(
+      worktreePath,
+      '--no-verify',
+      '-m',
+      `tbd rescue: adopt remote base + reconcile ${buckets.localOnly.length + buckets.bothDifferent.length} issue(s) ` +
+        `(${buckets.localOnly.length} local-only, ${buckets.bothDifferent.length} merged)`,
+    );
+  }
 
   return {
     backupBranch,

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -731,13 +731,16 @@ export function categorizeIssuesByUlid(local: Issue[], remote: Issue[]): UlidBuc
 const MAX_PUSH_RETRIES = 3;
 
 /**
- * Check if error is a non-fast-forward rejection.
+ * Check if error is a non-fast-forward rejection (also the init race signal).
  */
 function isNonFastForward(error: unknown): boolean {
-  const msg = error instanceof Error ? error.message : String(error);
-  return (
-    msg.includes('non-fast-forward') || msg.includes('fetch first') || msg.includes('rejected')
-  );
+  const msg =
+    error instanceof GitError
+      ? `${error.stderr}\n${error.message}`
+      : error instanceof Error
+        ? error.message
+        : String(error);
+  return /non-fast-forward|fetch first|rejected|updates were rejected/i.test(msg);
 }
 
 /**
@@ -1293,12 +1296,6 @@ async function worktreeHasUserIssues(dataSyncPath: string): Promise<boolean> {
   }
 }
 
-/** Whether a push failure is a non-fast-forward / rejected (the init race). */
-function isNonFastForwardRejection(err: unknown): boolean {
-  const msg = err instanceof GitError ? `${err.stderr}\n${err.message}` : String(err);
-  return /rejected|non-fast-forward|fetch first|updates were rejected/i.test(msg);
-}
-
 /**
  * Push a freshly-created orphan tbd-sync immediately so "first init wins"
  * (closes the #137 race window). Classifies the outcome:
@@ -1326,7 +1323,7 @@ export async function pushFreshOrphan(
     await gitNoPrompt('-C', worktreePath, 'push', remote, `HEAD:refs/heads/${syncBranch}`);
     return { pushed: true, adopted: false };
   } catch (err) {
-    if (!isNonFastForwardRejection(err)) {
+    if (!isNonFastForward(err)) {
       // Transient / permanent (restricted egress, no auth, network) — the push
       // is best-effort and setup must not break. The window simply shrinks to
       // "until the first reachable sync".

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -103,6 +103,23 @@ export async function git(...args: string[]): Promise<string> {
 }
 
 /**
+ * Like {@link git} but with `GIT_TERMINAL_PROMPT=0` so a network operation
+ * (e.g. a best-effort push) fails fast instead of blocking on a credential
+ * prompt in a non-interactive environment.
+ */
+async function gitNoPrompt(...args: string[]): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync('git', args, {
+      maxBuffer: GIT_MAX_BUFFER,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    });
+    return stdout.trim();
+  } catch (err) {
+    throw GitError.from(err, args);
+  }
+}
+
+/**
  * Run `git commit` in a worktree with gpg signing disabled at the command level.
  *
  * Internal tbd-sync commits are machine-generated data commits on the data branch,
@@ -1197,6 +1214,89 @@ export async function migrateLegacyWorktreesToShared(
 }
 
 /**
+ * Whether the given remote is configured (has a URL) in the repo at baseDir.
+ * A local-only repo (no remote) is safe to orphan and never pushes.
+ */
+async function remoteIsConfigured(remote: string, baseDir: string): Promise<boolean> {
+  try {
+    await git('-C', baseDir, 'config', '--get', `remote.${remote}.url`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether the data-sync worktree carries any user issue files (is-<ulid>.md),
+ * as opposed to only the initial orphan scaffold (.gitkeep / .gitattributes).
+ */
+async function worktreeHasUserIssues(dataSyncPath: string): Promise<boolean> {
+  try {
+    const entries = await readdir(join(dataSyncPath, 'issues'));
+    return entries.some((name) => /^is-.*\.md$/.test(name));
+  } catch {
+    return false;
+  }
+}
+
+/** Whether a push failure is a non-fast-forward / rejected (the init race). */
+function isNonFastForwardRejection(err: unknown): boolean {
+  const msg = err instanceof GitError ? `${err.stderr}\n${err.message}` : String(err);
+  return /rejected|non-fast-forward|fetch first|updates were rejected/i.test(msg);
+}
+
+/**
+ * Push a freshly-created orphan tbd-sync immediately so "first init wins"
+ * (closes the #137 race window). Classifies the outcome:
+ *
+ *  - success            => pushed: true ("first init wins").
+ *  - transient/permanent network/auth failure => best-effort, ignored
+ *    (branch stays local-only until the first reachable sync).
+ *  - non-fast-forward rejection => a detected init race (environment B pushed
+ *    its own orphan first). Fetch, then:
+ *      - scaffold-only local  => adopt the remote (reset local to remote).
+ *      - local has user issues => fail loudly toward `tbd doctor --fix` so the
+ *        local work is never silently discarded.
+ *
+ * MUST be called after the orphan's initial commit, while the worktree is on
+ * syncBranch.
+ */
+export async function pushFreshOrphan(
+  baseDir: string,
+  worktreePath: string,
+  remote: string,
+  syncBranch: string,
+  dataSyncPath: string,
+): Promise<{ pushed: boolean; adopted: boolean }> {
+  try {
+    await gitNoPrompt('-C', worktreePath, 'push', remote, `HEAD:refs/heads/${syncBranch}`);
+    return { pushed: true, adopted: false };
+  } catch (err) {
+    if (!isNonFastForwardRejection(err)) {
+      // Transient / permanent (restricted egress, no auth, network) — the push
+      // is best-effort and setup must not break. The window simply shrinks to
+      // "until the first reachable sync".
+      return { pushed: false, adopted: false };
+    }
+
+    // Detected init race: the remote already has a (different) branch.
+    await gitNoPrompt('-C', baseDir, 'fetch', remote, syncBranch);
+
+    if (await worktreeHasUserIssues(dataSyncPath)) {
+      throw new Error(
+        `Detected unrelated ${remote}/${syncBranch} histories during init, and the local ` +
+          `branch already contains issues. Refusing to discard local work. ` +
+          `Run \`tbd doctor --fix\` to reconcile the histories.`,
+      );
+    }
+
+    // Scaffold-only local: adopt the remote as canonical ("first init wins").
+    await git('-C', worktreePath, 'reset', '--hard', `${remote}/${syncBranch}`);
+    return { pushed: false, adopted: true };
+  }
+}
+
+/**
  * Initialize the hidden worktree for the tbd-sync branch.
  * Follows the decision tree from tbd-design.md §2.3.
  *
@@ -1248,9 +1348,24 @@ export async function initWorktree(
       return { success: true, path: worktreePath, created: true };
     }
 
-    // Check if remote branch exists
-    const remoteExists = await remoteBranchExists(remote, syncBranch, baseDir);
-    if (remoteExists) {
+    // Probe the remote. A configured-but-unreachable remote must NOT fall
+    // through to orphan creation (that is how unrelated histories are born);
+    // a local-only repo with no remote is safe to orphan and never pushes.
+    const hasRemote = await remoteIsConfigured(remote, baseDir);
+    const probe: RemoteBranchProbe = hasRemote
+      ? await probeRemoteBranch(remote, syncBranch, baseDir)
+      : 'absent';
+
+    if (probe === 'check-failed') {
+      return {
+        success: false,
+        error:
+          `Could not verify whether ${remote}/${syncBranch} exists (remote check failed); ` +
+          `refusing to create a divergent local branch. Check connectivity/auth and retry.`,
+      };
+    }
+
+    if (probe === 'present') {
       // Fetch and create worktree from remote branch with local tracking branch
       await git('-C', baseDir, 'fetch', remote, syncBranch);
       // Use -b to create local branch tracking remote, not --detach
@@ -1268,7 +1383,7 @@ export async function initWorktree(
       return { success: true, path: worktreePath, created: true };
     }
 
-    // No branch exists - create orphan worktree (requires Git 2.42+)
+    // No branch exists (probe === 'absent') - create orphan worktree (requires Git 2.42+)
     // Syntax: git worktree add --orphan -b <branch> <path>
     await requireGitVersion();
     await git('-C', baseDir, 'worktree', 'add', '--orphan', '-b', syncBranch, worktreePath);
@@ -1297,6 +1412,13 @@ export async function initWorktree(
     // Use --no-verify to bypass parent repo hooks (lefthook, husky, etc.)
     await git('-C', worktreePath, 'add', '.');
     await gitCommit(worktreePath, '--no-verify', '-m', 'Initialize tbd-sync branch');
+
+    // Push the fresh orphan immediately so "first init wins" and the #137 race
+    // window closes. Only when a remote is configured; best-effort on transient
+    // failure, adopt-or-fail-loud on a detected rejected-race.
+    if (hasRemote) {
+      await pushFreshOrphan(baseDir, worktreePath, remote, syncBranch, dataSyncPath);
+    }
 
     return { success: true, path: worktreePath, created: true };
   } catch (error) {

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -1525,6 +1525,12 @@ export async function checkLocalBranchHealth(
 export interface RemoteBranchHealth {
   exists: boolean;
   diverged: boolean;
+  /**
+   * True when a local tbd-sync exists but shares no common ancestor with the
+   * remote (merge-base finds nothing). This is the #139 worst case: push can
+   * never fast-forward and a plain merge refuses. `diverged` is also true.
+   */
+  unrelated: boolean;
   head?: string;
 }
 
@@ -1547,22 +1553,33 @@ export async function checkRemoteBranchHealth(
     const head = await git(...dirArgs, 'rev-parse', `refs/remotes/${remote}/${syncBranch}`);
     const remoteHead = head.trim();
 
-    // Check for divergence (only if local branch exists)
+    // Determine divergence / unrelated state. Distinguish "no local branch"
+    // (stays false/false) from "local exists but no common ancestor" (the
+    // unrelated worst case) — the old bare catch collapsed both to false.
     let diverged = false;
-    try {
-      const mergeBase = await git(...dirArgs, 'merge-base', syncBranch, `${remote}/${syncBranch}`);
-      const localHead = await git(...dirArgs, 'rev-parse', syncBranch);
-
-      // Diverged if merge-base is neither local nor remote HEAD
-      diverged = mergeBase.trim() !== localHead.trim() && mergeBase.trim() !== remoteHead;
-    } catch {
-      // Local branch doesn't exist - can't be diverged
-      diverged = false;
+    let unrelated = false;
+    if (await branchExists(syncBranch, baseDir)) {
+      const localHead = (await git(...dirArgs, 'rev-parse', syncBranch)).trim();
+      try {
+        const mergeBase = (
+          await git(...dirArgs, 'merge-base', syncBranch, `${remote}/${syncBranch}`)
+        ).trim();
+        // Diverged if merge-base is neither local nor remote HEAD.
+        diverged = mergeBase !== localHead && mergeBase !== remoteHead;
+      } catch (err) {
+        // merge-base exits 1 with no output when the two commits share no
+        // ancestor: unrelated histories. Any other exit is a transient/unknown
+        // failure and must NOT masquerade as "unrelated".
+        if (exitCodeOf(err) === 1) {
+          unrelated = true;
+          diverged = true;
+        }
+      }
     }
 
-    return { exists: true, diverged, head: remoteHead };
+    return { exists: true, diverged, unrelated, head: remoteHead };
   } catch {
-    return { exists: false, diverged: false };
+    return { exists: false, diverged: false, unrelated: false };
   }
 }
 

--- a/packages/tbd/tests/cli-sync-missing-worktree-135.tryscript.md
+++ b/packages/tbd/tests/cli-sync-missing-worktree-135.tryscript.md
@@ -1,0 +1,139 @@
+---
+sandbox: true
+env:
+  NO_COLOR: '1'
+  FORCE_COLOR: '0'
+path:
+  - ../dist
+timeout: 60000
+patterns:
+  ULID: '[0-9a-z]{26}'
+  SHORTID: '[0-9a-z]{4,5}'
+before: |
+  # Bare repo as local "origin". Use an isolated name (the shared ../origin.git
+  # is persistent across tryscripts and would leak other scenarios' tbd-sync
+  # issues into our sync, breaking exact counts).
+  rm -rf ../origin-135.git
+  mkdir -p ../origin-135.git
+  git init --bare ../origin-135.git
+
+  # Primary repo.
+  git init --initial-branch=main
+  git config user.email "test@example.com"
+  git config user.name "Test User"
+  git config commit.gpgsign false
+  echo "# Test repo" > README.md
+  git add README.md
+  git commit -m "Initial commit"
+  git remote add origin ../origin-135.git
+  git push -u origin main
+---
+# tbd CLI: Missing-worktree regression (#135)
+
+Reproduces the issue #135 scenario: the shared sync worktree is absent (as in a fresh
+ephemeral clone that has the `tbd-sync` branch but no materialized worktree).
+Data commands must auto-heal the worktree and read the real issues — and must **never**
+silently fall back to writing under the gitignored `.tbd/data-sync/` path in the main
+checkout.
+
+See: plan-2026-05-29-tbd-sync-unrelated-history-hardening.md (#135 verification)
+
+* * *
+
+## Setup: create and sync issues, then drop the worktree
+
+# Test: Initialize tbd
+
+```console
+$ tbd init --prefix=test 2>&1 | head -1
+✓ Initialized tbd repository (prefix: test)
+? 0
+```
+
+# Test: Create two issues
+
+```console
+$ tbd create "Issue A" --type=task >/dev/null && tbd create "Issue B" --type=task >/dev/null && echo created
+created
+? 0
+```
+
+# Test: Sync so the issues are committed on tbd-sync (as a fresh clone would have)
+
+```console
+$ tbd sync >/dev/null 2>&1; echo "synced"
+synced
+? 0
+```
+
+# Test: Two issue files are committed on the tbd-sync branch
+
+```console
+$ git ls-tree -r --name-only tbd-sync | grep -c 'issues/is-' | tr -d ' '
+2
+? 0
+```
+
+# Test: Simulate a fresh clone with no materialized worktree
+
+```console
+$ rm -rf $(git rev-parse --path-format=absolute --git-common-dir)/tbd/data-sync-worktree && rm -rf .tbd/data-sync && echo "worktree absent"
+worktree absent
+? 0
+```
+
+* * *
+
+## tbd list heals and reads the real issues (no silent fallback)
+
+# Test: tbd list reflects the real issues (does not silently report empty)
+
+```console
+$ tbd list 2>&1 | tail -1
+2 issue(s)
+? 0
+```
+
+# Test: Worktree was auto-materialized
+
+```console
+$ test -d $(git rev-parse --path-format=absolute --git-common-dir)/tbd/data-sync-worktree && echo "materialized"
+materialized
+? 0
+```
+
+# Test: NOTHING was written under the gitignored .tbd/data-sync/ wrong location
+
+```console
+$ ls .tbd/data-sync/issues/*.md 2>/dev/null | wc -l | tr -d ' '
+0
+? 0
+```
+
+* * *
+
+## tbd create after heal writes to the worktree, never to .tbd/data-sync/
+
+# Test: Create another issue after the heal
+
+```console
+$ tbd create "Issue C" --type=task 2>&1 | head -1
+✓ Created [..]
+? 0
+```
+
+# Test: Still nothing under .tbd/data-sync/ in the main checkout
+
+```console
+$ ls .tbd/data-sync/issues/*.md 2>/dev/null | wc -l | tr -d ' '
+0
+? 0
+```
+
+# Test: The new issue lives in the shared worktree
+
+```console
+$ ls $(git rev-parse --path-format=absolute --git-common-dir)/tbd/data-sync-worktree/.tbd/data-sync/issues/*.md 2>/dev/null | wc -l | tr -d ' ' | awk '$1 >= 3 {print "ok"}'
+ok
+? 0
+```

--- a/packages/tbd/tests/cli-sync-unrelated-rescue.tryscript.md
+++ b/packages/tbd/tests/cli-sync-unrelated-rescue.tryscript.md
@@ -1,0 +1,158 @@
+---
+sandbox: true
+env:
+  NO_COLOR: '1'
+  FORCE_COLOR: '0'
+path:
+  - ../dist
+timeout: 60000
+patterns:
+  ULID: '[0-9a-z]{26}'
+  SHORTID: '[0-9a-z]{4,5}'
+  TIMESTAMP: "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z"
+before: |
+  # Isolated bare repo as "origin" (avoid the shared ../origin.git).
+  rm -rf ../origin-rescue.git ../seed-rescue
+  mkdir -p ../origin-rescue.git
+  git init --bare ../origin-rescue.git
+
+  # Seed the remote with an UNRELATED orphan tbd-sync (as if environment B
+  # initialized independently): one remote-only issue, no common ancestor with
+  # whatever this repo creates locally.
+  mkdir -p ../seed-rescue/.tbd/data-sync/issues
+  ( cd ../seed-rescue
+    git init --initial-branch=tbd-sync
+    git config user.email "b@example.com"
+    git config user.name "Env B"
+    git config commit.gpgsign false
+    printf '%s\n' '---' 'type: is' 'id: is-01envbrescue0000000remote1' 'title: Remote only issue' \
+      'status: open' 'kind: task' 'priority: 2' 'version: 1' \
+      'created_at: 2026-01-01T00:00:00.000Z' 'updated_at: 2026-01-01T00:00:00.000Z' '---' 'env B body' \
+      > .tbd/data-sync/issues/is-01envbrescue0000000remote1.md
+    git add -A
+    git commit -m "env B orphan"
+    git push ../origin-rescue.git tbd-sync:refs/heads/tbd-sync )
+
+  # Primary repo with NO remote yet (so the local tbd-sync is an independent
+  # orphan, unrelated to env B's).
+  git init --initial-branch=main
+  git config user.email "test@example.com"
+  git config user.name "Test User"
+  git config commit.gpgsign false
+  echo "# Test repo" > README.md
+  git add README.md
+  git commit -m "Initial commit"
+---
+# tbd CLI: Unrelated-history detect → rescue → sync (end to end)
+
+Reproduces the #139 race end to end: two environments create independent orphan
+`tbd-sync` branches with no common ancestor.
+`tbd doctor` must flag this as a hard finding (never healthy), `tbd doctor --fix` must
+rescue non-destructively, and the following `tbd sync` must fast-forward with both
+sides’ issues preserved.
+
+See: plan-2026-05-29-tbd-sync-unrelated-history-hardening.md
+
+* * *
+
+## Build an unrelated local tbd-sync, then attach the remote
+
+# Test: Initialize tbd and create a local-only issue
+
+```console
+$ tbd init --prefix=test >/dev/null && tbd create "Local only issue" --type=task >/dev/null && echo ok
+ok
+? 0
+```
+
+# Test: Commit the local orphan tbd-sync (no remote configured yet)
+
+```console
+$ tbd sync >/dev/null 2>&1; echo "synced"
+synced
+? 0
+```
+
+# Test: Attach the remote whose tbd-sync is unrelated to ours
+
+```console
+$ git remote add origin ../origin-rescue.git && echo "attached"
+attached
+? 0
+```
+
+* * *
+
+## Detection: doctor reports a hard finding routed to --fix
+
+# Test: tbd doctor flags the unrelated history (not healthy)
+
+```console
+$ tbd doctor 2>&1 | grep -i "Remote sync branch"
+[..]Remote sync branch - [..]unrelated[..]
+? 0
+```
+
+# Test: The remediation points at tbd doctor --fix
+
+```console
+$ tbd doctor 2>&1 | grep -iA1 "histories are unrelated" | grep -i "doctor --fix" | head -1
+[..]tbd doctor --fix[..]
+? 0
+```
+
+* * *
+
+## Rescue: doctor --fix reconciles non-destructively
+
+# Test: tbd doctor --fix runs the rescue and adopts the remote base
+
+```console
+$ tbd doctor --fix 2>&1 | grep -i "Remote sync branch"
+[..]Remote sync branch - rescued: adopted origin/tbd-sync base[..]
+? 0
+```
+
+# Test: A backup branch preserves the pre-rescue state
+
+```console
+$ git branch | grep -c "tbd-backup-" | tr -d ' ' | awk '$1 >= 1 {print "ok"}'
+ok
+? 0
+```
+
+# Test: origin/tbd-sync is now an ancestor of local tbd-sync (push fast-forwards)
+
+```console
+$ git merge-base --is-ancestor origin/tbd-sync tbd-sync && echo "fast-forwardable"
+fast-forwardable
+? 0
+```
+
+* * *
+
+## Sync: fast-forwards, both issues preserved on the remote
+
+# Test: tbd sync succeeds after the rescue
+
+```console
+$ tbd sync >/dev/null 2>&1; echo "exit=$?"
+exit=0
+? 0
+```
+
+# Test: The remote tbd-sync now carries BOTH issues (local-only + remote-only)
+
+```console
+$ git fetch -q origin tbd-sync && git ls-tree -r --name-only origin/tbd-sync | grep -c 'issues/is-' | tr -d ' '
+2
+? 0
+```
+
+# Test: tbd list shows both issues locally
+
+```console
+$ tbd list 2>&1 | tail -1
+2 issue(s)
+? 0
+```

--- a/packages/tbd/tests/doctor-unrelated.test.ts
+++ b/packages/tbd/tests/doctor-unrelated.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Unit tests for classifyRemoteSyncHealth (tbd doctor unrelated finding).
+ *
+ * Unrelated histories must surface as a hard ✗ finding routed to
+ * `tbd doctor --fix`, never as healthy and never toward `tbd sync`.
+ *
+ * See: tbd-fg5a (plan-2026-05-29-tbd-sync-unrelated-history-hardening.md)
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { classifyRemoteSyncHealth } from '../src/cli/commands/doctor.js';
+import type { RemoteBranchHealth } from '../src/file/git.js';
+
+const base: RemoteBranchHealth = { exists: true, diverged: false, unrelated: false };
+
+describe('classifyRemoteSyncHealth', () => {
+  it('reports unrelated histories as a hard error routed to doctor --fix', () => {
+    const diag = classifyRemoteSyncHealth(
+      { ...base, diverged: true, unrelated: true },
+      'origin',
+      'tbd-sync',
+    );
+    expect(diag?.status).toBe('error');
+    expect(diag?.fixable).toBe(true);
+    expect(diag?.message).toMatch(/unrelated|no common ancestor/i);
+    expect(diag?.suggestion).toMatch(/doctor --fix/);
+    expect(diag?.suggestion).not.toMatch(/tbd sync/);
+  });
+
+  it('reports a plain divergence as a warning toward tbd sync', () => {
+    const diag = classifyRemoteSyncHealth({ ...base, diverged: true }, 'origin', 'tbd-sync');
+    expect(diag?.status).toBe('warn');
+    expect(diag?.suggestion).toMatch(/tbd sync/);
+  });
+
+  it('reports an in-sync remote as ok', () => {
+    const diag = classifyRemoteSyncHealth(base, 'origin', 'tbd-sync');
+    expect(diag?.status).toBe('ok');
+  });
+
+  it('returns null when the remote branch does not exist (caller falls through)', () => {
+    const diag = classifyRemoteSyncHealth(
+      { exists: false, diverged: false, unrelated: false },
+      'origin',
+      'tbd-sync',
+    );
+    expect(diag).toBeNull();
+  });
+});

--- a/packages/tbd/tests/git-exit-code.test.ts
+++ b/packages/tbd/tests/git-exit-code.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for the git() wrapper carrying a structured exit code.
+ *
+ * Callers that must distinguish git exit statuses (e.g. probeRemoteBranch
+ * telling "branch absent" (ls-remote --exit-code => 2) from a connection
+ * failure, or checkRemoteBranchHealth telling "unrelated histories"
+ * (merge-base => 1) from a transient error) need the exit code without
+ * string-matching stderr.
+ *
+ * See: tbd-as47 (plan-2026-05-29-tbd-sync-unrelated-history-hardening.md)
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { git, GitError, exitCodeOf } from '../src/file/git.js';
+
+describe('git() exit code propagation', () => {
+  it('throws a GitError carrying a numeric exitCode when a command fails', async () => {
+    // `git rev-parse --verify <bogus>` exits 128 with no resolvable ref.
+    await expect(git('rev-parse', '--verify', 'refs/heads/tbd-bogus-ref-xyz')).rejects.toThrow(
+      GitError,
+    );
+
+    let captured: unknown;
+    try {
+      await git('rev-parse', '--verify', 'refs/heads/tbd-bogus-ref-xyz');
+    } catch (err) {
+      captured = err;
+    }
+
+    expect(captured).toBeInstanceOf(GitError);
+    const gitErr = captured as GitError;
+    expect(typeof gitErr.exitCode).toBe('number');
+    expect(gitErr.exitCode).toBeGreaterThan(0);
+    // The original stderr/message is preserved so message-based classifiers
+    // (classifySyncError) keep working.
+    expect(gitErr.message.length).toBeGreaterThan(0);
+    expect(gitErr.args).toContain('rev-parse');
+  });
+
+  it('exitCodeOf reads the exit code from a GitError', async () => {
+    let captured: unknown;
+    try {
+      await git('rev-parse', '--verify', 'refs/heads/tbd-bogus-ref-xyz');
+    } catch (err) {
+      captured = err;
+    }
+    expect(exitCodeOf(captured)).toBe((captured as GitError).exitCode);
+    expect(typeof exitCodeOf(captured)).toBe('number');
+  });
+
+  it('exitCodeOf returns null for a plain Error', () => {
+    expect(exitCodeOf(new Error('not a git error'))).toBeNull();
+    expect(exitCodeOf(undefined)).toBeNull();
+    expect(exitCodeOf('string error')).toBeNull();
+  });
+
+  it('git() still returns trimmed stdout on success', async () => {
+    const out = await git('rev-parse', '--is-inside-work-tree');
+    expect(out).toBe('true');
+  });
+});

--- a/packages/tbd/tests/git-init-orphan.test.ts
+++ b/packages/tbd/tests/git-init-orphan.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for initWorktree orphan hardening (#137 / Fault 1b).
+ *
+ *  - check-failed: a configured-but-unreachable remote must NOT fall through to
+ *    orphan creation (no divergent local branch).
+ *  - happy path: a fresh orphan is pushed immediately ("first init wins").
+ *  - rejected race: if the remote already has a branch (environment B won), the
+ *    push is rejected; a scaffold-only local adopts the remote, while a local
+ *    that already carries user issues fails loudly toward `tbd doctor --fix`.
+ *
+ * See: tbd-xkyh (plan-2026-05-29-tbd-sync-unrelated-history-hardening.md)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, writeFile as fsWriteFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir, platform } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import {
+  initWorktree,
+  pushFreshOrphan,
+  branchExists,
+  remoteBranchExists,
+  worktreeExists,
+} from '../src/file/git.js';
+import { SYNC_BRANCH, TBD_DIR, DATA_SYNC_DIR_NAME } from '../src/lib/paths.js';
+
+const execFileAsync = promisify(execFile);
+const isWindows = platform() === 'win32';
+const describeUnlessWindows = isWindows ? describe.skip : describe;
+
+async function gitInDir(dir: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, {
+    cwd: dir,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+  });
+  return stdout.trim();
+}
+
+async function createBareRepo(path: string): Promise<void> {
+  await mkdir(path, { recursive: true });
+  await gitInDir(path, 'init', '--bare');
+}
+
+async function initRepoWithRemote(repoPath: string, remotePath: string): Promise<void> {
+  await mkdir(repoPath, { recursive: true });
+  await gitInDir(repoPath, 'init', '-b', 'main');
+  await gitInDir(repoPath, 'config', 'user.email', 'test@test.com');
+  await gitInDir(repoPath, 'config', 'user.name', 'Test User');
+  await gitInDir(repoPath, 'config', 'commit.gpgsign', 'false');
+  await gitInDir(repoPath, 'remote', 'add', 'origin', remotePath);
+  await fsWriteFile(join(repoPath, 'README.md'), '# t\n');
+  await gitInDir(repoPath, 'add', 'README.md');
+  await gitInDir(repoPath, 'commit', '-m', 'init');
+}
+
+/** Seed a bare remote with an unrelated (orphan) tbd-sync built in a scratch repo. */
+async function seedRemoteOrphanSync(testDir: string, barePath: string): Promise<void> {
+  const seed = join(testDir, `seed-${randomBytes(3).toString('hex')}`);
+  await mkdir(seed, { recursive: true });
+  await gitInDir(seed, 'init', '-b', SYNC_BRANCH);
+  await gitInDir(seed, 'config', 'user.email', 'b@b.com');
+  await gitInDir(seed, 'config', 'user.name', 'Env B');
+  await gitInDir(seed, 'config', 'commit.gpgsign', 'false');
+  await fsWriteFile(join(seed, 'remote-marker.txt'), 'env-B\n');
+  await gitInDir(seed, 'add', '.');
+  await gitInDir(seed, 'commit', '-m', 'env B orphan');
+  await gitInDir(seed, 'push', barePath, `${SYNC_BRANCH}:refs/heads/${SYNC_BRANCH}`);
+}
+
+describeUnlessWindows('initWorktree orphan hardening', () => {
+  let testDir: string;
+  let barePath: string;
+  let workPath: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `tbd-initorphan-${randomBytes(4).toString('hex')}`);
+    barePath = join(testDir, 'remote.git');
+    workPath = join(testDir, 'work');
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  it('refuses to create an orphan when the remote check fails', async () => {
+    await initRepoWithRemote(workPath, join(testDir, 'unreachable-does-not-exist.git'));
+    const result = await initWorktree(workPath);
+
+    expect(result.success).toBe(false);
+    expect(result.error ?? '').toMatch(/remote check failed|could not verify/i);
+    // No divergent local branch and no worktree were created.
+    expect(await branchExists(SYNC_BRANCH, workPath)).toBe(false);
+    expect(await worktreeExists(workPath)).toBe(false);
+  });
+
+  it('pushes the fresh orphan immediately (first init wins)', async () => {
+    await createBareRepo(barePath);
+    await initRepoWithRemote(workPath, barePath);
+
+    const result = await initWorktree(workPath);
+    expect(result.success).toBe(true);
+    expect(result.created).toBe(true);
+    expect(await remoteBranchExists('origin', SYNC_BRANCH, workPath)).toBe(true);
+  });
+
+  it('still succeeds locally when there is no remote configured', async () => {
+    await mkdir(workPath, { recursive: true });
+    await gitInDir(workPath, 'init', '-b', 'main');
+    await gitInDir(workPath, 'config', 'user.email', 'a@a.com');
+    await gitInDir(workPath, 'config', 'user.name', 'A');
+    await gitInDir(workPath, 'config', 'commit.gpgsign', 'false');
+    await fsWriteFile(join(workPath, 'README.md'), '# t\n');
+    await gitInDir(workPath, 'add', '.');
+    await gitInDir(workPath, 'commit', '-m', 'init');
+
+    const result = await initWorktree(workPath);
+    expect(result.success).toBe(true);
+    expect(await branchExists(SYNC_BRANCH, workPath)).toBe(true);
+  });
+
+  describe('pushFreshOrphan rejected-race handling', () => {
+    it('adopts a scaffold-only remote when the push is rejected', async () => {
+      await createBareRepo(barePath);
+      await seedRemoteOrphanSync(testDir, barePath);
+      await initRepoWithRemote(workPath, barePath);
+
+      // Build a local scaffold-only orphan tbd-sync (no user issues).
+      const worktreePath = join(workPath, '.git', 'tbd', 'data-sync-worktree');
+      await gitInDir(workPath, 'worktree', 'add', '--orphan', '-b', SYNC_BRANCH, worktreePath);
+      const dataSyncPath = join(worktreePath, TBD_DIR, DATA_SYNC_DIR_NAME);
+      await mkdir(join(dataSyncPath, 'issues'), { recursive: true });
+      await fsWriteFile(join(dataSyncPath, 'issues', '.gitkeep'), '');
+      await gitInDir(worktreePath, 'add', '.');
+      await gitInDir(worktreePath, '-c', 'commit.gpgsign=false', 'commit', '-m', 'local orphan');
+
+      const res = await pushFreshOrphan(
+        workPath,
+        worktreePath,
+        'origin',
+        SYNC_BRANCH,
+        dataSyncPath,
+      );
+      expect(res.adopted).toBe(true);
+      expect(res.pushed).toBe(false);
+
+      // Local tbd-sync now equals the remote (env B) — push will fast-forward.
+      const localHead = await gitInDir(workPath, 'rev-parse', SYNC_BRANCH);
+      const remoteHead = await gitInDir(workPath, 'rev-parse', `origin/${SYNC_BRANCH}`);
+      expect(localHead).toBe(remoteHead);
+    });
+
+    it('fails loudly toward doctor --fix when the local already has user issues', async () => {
+      await createBareRepo(barePath);
+      await seedRemoteOrphanSync(testDir, barePath);
+      await initRepoWithRemote(workPath, barePath);
+
+      const worktreePath = join(workPath, '.git', 'tbd', 'data-sync-worktree');
+      await gitInDir(workPath, 'worktree', 'add', '--orphan', '-b', SYNC_BRANCH, worktreePath);
+      const dataSyncPath = join(worktreePath, TBD_DIR, DATA_SYNC_DIR_NAME);
+      await mkdir(join(dataSyncPath, 'issues'), { recursive: true });
+      // A real user issue lives locally and must NOT be silently discarded.
+      await fsWriteFile(
+        join(dataSyncPath, 'issues', 'is-01localuserissue00000000aa.md'),
+        '---\ntype: is\ntitle: local work\n---\n',
+      );
+      await gitInDir(worktreePath, 'add', '.');
+      await gitInDir(worktreePath, '-c', 'commit.gpgsign=false', 'commit', '-m', 'local issue');
+
+      await expect(
+        pushFreshOrphan(workPath, worktreePath, 'origin', SYNC_BRANCH, dataSyncPath),
+      ).rejects.toThrow(/doctor --fix/i);
+    });
+  });
+});

--- a/packages/tbd/tests/git-probe-remote.test.ts
+++ b/packages/tbd/tests/git-probe-remote.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit/integration tests for probeRemoteBranch tri-state.
+ *
+ * Distinguishes:
+ *  - 'present'      ls-remote finds the ref
+ *  - 'absent'       remote reachable, ref missing (ls-remote --exit-code => 2)
+ *  - 'check-failed' remote unreachable / auth / transient (any other failure)
+ *
+ * The 'check-failed' case MUST NOT collapse to 'absent', so orphan-creating
+ * callers never create a divergent local branch on a flaky check.
+ *
+ * See: tbd-ptj3 (plan-2026-05-29-tbd-sync-unrelated-history-hardening.md)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, writeFile as fsWriteFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir, platform } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { probeRemoteBranch, remoteBranchExists } from '../src/file/git.js';
+
+const execFileAsync = promisify(execFile);
+const isWindows = platform() === 'win32';
+const describeUnlessWindows = isWindows ? describe.skip : describe;
+
+async function gitInDir(dir: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, { cwd: dir });
+  return stdout.trim();
+}
+
+describeUnlessWindows('probeRemoteBranch', () => {
+  let testDir: string;
+  let barePath: string;
+  let workPath: string;
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `tbd-probe-test-${randomBytes(4).toString('hex')}`);
+    barePath = join(testDir, 'remote.git');
+    workPath = join(testDir, 'work');
+    await mkdir(barePath, { recursive: true });
+    await execFileAsync('git', ['init', '--bare', barePath]);
+    await mkdir(workPath, { recursive: true });
+    await gitInDir(workPath, 'init', '-b', 'main');
+    await gitInDir(workPath, 'config', 'user.email', 'test@test.com');
+    await gitInDir(workPath, 'config', 'user.name', 'Test User');
+    await gitInDir(workPath, 'config', 'commit.gpgsign', 'false');
+    await gitInDir(workPath, 'remote', 'add', 'origin', barePath);
+    await fsWriteFile(join(workPath, 'README.md'), '# t\n');
+    await gitInDir(workPath, 'add', 'README.md');
+    await gitInDir(workPath, 'commit', '-m', 'init');
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  it("returns 'absent' when the remote is reachable but the branch is missing", async () => {
+    const probe = await probeRemoteBranch('origin', 'tbd-sync', workPath);
+    expect(probe).toBe('absent');
+  });
+
+  it("returns 'present' when the branch exists on the remote", async () => {
+    await gitInDir(workPath, 'push', 'origin', 'HEAD:refs/heads/tbd-sync');
+    const probe = await probeRemoteBranch('origin', 'tbd-sync', workPath);
+    expect(probe).toBe('present');
+  });
+
+  it("returns 'check-failed' when the remote is unreachable (not 'absent')", async () => {
+    const bogus = join(testDir, 'does-not-exist.git');
+    const probe = await probeRemoteBranch(bogus, 'tbd-sync', workPath);
+    expect(probe).toBe('check-failed');
+  });
+
+  it('remoteBranchExists wrapper stays fail-closed (present => true, else false)', async () => {
+    expect(await remoteBranchExists('origin', 'tbd-sync', workPath)).toBe(false);
+    await gitInDir(workPath, 'push', 'origin', 'HEAD:refs/heads/tbd-sync');
+    expect(await remoteBranchExists('origin', 'tbd-sync', workPath)).toBe(true);
+    // Unreachable remote must NOT read as "exists".
+    const bogus = join(testDir, 'nope.git');
+    expect(await remoteBranchExists(bogus, 'tbd-sync', workPath)).toBe(false);
+  });
+});

--- a/packages/tbd/tests/git-unrelated-health.test.ts
+++ b/packages/tbd/tests/git-unrelated-health.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for checkRemoteBranchHealth unrelated-history detection (Fault 2).
+ *
+ * The old code lumped "no local branch" and "no common ancestor" together as
+ * diverged=false, so unrelated histories (the #139 worst case) reported as
+ * healthy. The flag matrix:
+ *   in-sync          -> diverged false, unrelated false
+ *   diverged (shared)-> diverged true,  unrelated false
+ *   unrelated        -> diverged true,  unrelated true
+ *   no local branch  -> diverged false, unrelated false
+ *
+ * See: tbd-nzqt (plan-2026-05-29-tbd-sync-unrelated-history-hardening.md)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, writeFile as fsWriteFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir, platform } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { checkRemoteBranchHealth } from '../src/file/git.js';
+import { SYNC_BRANCH } from '../src/lib/paths.js';
+
+const execFileAsync = promisify(execFile);
+const isWindows = platform() === 'win32';
+const describeUnlessWindows = isWindows ? describe.skip : describe;
+
+async function g(dir: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, {
+    cwd: dir,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+  });
+  return stdout.trim();
+}
+
+async function configRepo(dir: string): Promise<void> {
+  await g(dir, 'config', 'user.email', 't@t.com');
+  await g(dir, 'config', 'user.name', 'T');
+  await g(dir, 'config', 'commit.gpgsign', 'false');
+}
+
+describeUnlessWindows('checkRemoteBranchHealth unrelated detection', () => {
+  let testDir: string;
+  let barePath: string;
+  let workPath: string;
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `tbd-unrel-${randomBytes(4).toString('hex')}`);
+    barePath = join(testDir, 'remote.git');
+    workPath = join(testDir, 'work');
+    await mkdir(barePath, { recursive: true });
+    await g(barePath, 'init', '--bare');
+    await mkdir(workPath, { recursive: true });
+    await g(workPath, 'init', '-b', 'main');
+    await configRepo(workPath);
+    await g(workPath, 'remote', 'add', 'origin', barePath);
+    await fsWriteFile(join(workPath, 'README.md'), '# t\n');
+    await g(workPath, 'add', '.');
+    await g(workPath, 'commit', '-m', 'init main');
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  /** Create an orphan tbd-sync in workPath with one commit, return to main. */
+  async function localOrphanSync(marker: string): Promise<void> {
+    await g(workPath, 'checkout', '--orphan', SYNC_BRANCH);
+    await g(workPath, 'rm', '-rf', '--cached', '.').catch(() => undefined);
+    await rm(join(workPath, 'README.md'), { force: true }).catch(() => undefined);
+    await fsWriteFile(join(workPath, 'sync-marker.txt'), `${marker}\n`);
+    await g(workPath, 'add', '.');
+    await g(workPath, 'commit', '-m', `sync ${marker}`);
+    await g(workPath, 'checkout', 'main');
+  }
+
+  it('reports unrelated when local and remote tbd-sync are independent orphans', async () => {
+    // Remote tbd-sync = env B's orphan.
+    const seed = join(testDir, 'seedB');
+    await mkdir(seed, { recursive: true });
+    await g(seed, 'init', '-b', SYNC_BRANCH);
+    await configRepo(seed);
+    await fsWriteFile(join(seed, 'b.txt'), 'b\n');
+    await g(seed, 'add', '.');
+    await g(seed, 'commit', '-m', 'env B');
+    await g(seed, 'push', barePath, `${SYNC_BRANCH}:refs/heads/${SYNC_BRANCH}`);
+
+    // Local tbd-sync = our own orphan (no common ancestor with env B).
+    await localOrphanSync('A');
+
+    const health = await checkRemoteBranchHealth('origin', SYNC_BRANCH, workPath);
+    expect(health.exists).toBe(true);
+    expect(health.unrelated).toBe(true);
+    expect(health.diverged).toBe(true);
+  });
+
+  it('reports in-sync (not diverged, not unrelated) when local equals remote', async () => {
+    await localOrphanSync('A');
+    await g(workPath, 'push', 'origin', `${SYNC_BRANCH}:refs/heads/${SYNC_BRANCH}`);
+
+    const health = await checkRemoteBranchHealth('origin', SYNC_BRANCH, workPath);
+    expect(health.exists).toBe(true);
+    expect(health.diverged).toBe(false);
+    expect(health.unrelated).toBe(false);
+  });
+
+  it('reports diverged-but-related when both advance from a shared base', async () => {
+    await localOrphanSync('A');
+    await g(workPath, 'push', 'origin', `${SYNC_BRANCH}:refs/heads/${SYNC_BRANCH}`);
+
+    // Second clone advances the remote tbd-sync from the shared base.
+    const repo2 = join(testDir, 'repo2');
+    await g(testDir, 'clone', '-b', SYNC_BRANCH, barePath, repo2);
+    await configRepo(repo2);
+    await fsWriteFile(join(repo2, 'remote-advance.txt'), 'y\n');
+    await g(repo2, 'add', '.');
+    await g(repo2, 'commit', '-m', 'remote advance');
+    await g(repo2, 'push', 'origin', SYNC_BRANCH);
+
+    // Local advances independently from the same base (no pull).
+    await g(workPath, 'checkout', SYNC_BRANCH);
+    await fsWriteFile(join(workPath, 'local-advance.txt'), 'x\n');
+    await g(workPath, 'add', '.');
+    await g(workPath, 'commit', '-m', 'local advance');
+    await g(workPath, 'checkout', 'main');
+
+    const health = await checkRemoteBranchHealth('origin', SYNC_BRANCH, workPath);
+    expect(health.exists).toBe(true);
+    expect(health.diverged).toBe(true);
+    expect(health.unrelated).toBe(false);
+  });
+
+  it('reports not-diverged/not-unrelated when there is no local tbd-sync branch', async () => {
+    const seed = join(testDir, 'seedOnly');
+    await mkdir(seed, { recursive: true });
+    await g(seed, 'init', '-b', SYNC_BRANCH);
+    await configRepo(seed);
+    await fsWriteFile(join(seed, 'r.txt'), 'r\n');
+    await g(seed, 'add', '.');
+    await g(seed, 'commit', '-m', 'remote only');
+    await g(seed, 'push', barePath, `${SYNC_BRANCH}:refs/heads/${SYNC_BRANCH}`);
+
+    // workPath has NO local tbd-sync branch.
+    const health = await checkRemoteBranchHealth('origin', SYNC_BRANCH, workPath);
+    expect(health.exists).toBe(true);
+    expect(health.diverged).toBe(false);
+    expect(health.unrelated).toBe(false);
+  });
+});

--- a/packages/tbd/tests/rescue-categorize.test.ts
+++ b/packages/tbd/tests/rescue-categorize.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for categorizeIssuesByUlid (the pure core of the unrelated-history
+ * rescue). Buckets issues across two unrelated roots by ULID/id so the rescue
+ * never relies on a git merge base.
+ *
+ * See: tbd-6l8r (plan-2026-05-29-tbd-sync-unrelated-history-hardening.md)
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { categorizeIssuesByUlid } from '../src/file/git.js';
+import { createTestIssue } from './test-helpers.js';
+
+const A = '01rescuecat00000000000000a1';
+const B = '01rescuecat00000000000000b2';
+const C = '01rescuecat00000000000000c3';
+const D = '01rescuecat00000000000000d4';
+
+describe('categorizeIssuesByUlid', () => {
+  it('buckets issues into local-only / remote-only / identical / different', () => {
+    const local = [
+      createTestIssue({ id: `is-${A}`, title: 'shared identical' }),
+      createTestIssue({ id: `is-${B}`, title: 'local title' }),
+      createTestIssue({ id: `is-${C}`, title: 'local only' }),
+    ];
+    const remote = [
+      createTestIssue({ id: `is-${A}`, title: 'shared identical' }),
+      createTestIssue({ id: `is-${B}`, title: 'remote title' }),
+      createTestIssue({ id: `is-${D}`, title: 'remote only' }),
+    ];
+
+    const buckets = categorizeIssuesByUlid(local, remote);
+
+    expect(buckets.localOnly.map((i) => i.id)).toEqual([`is-${C}`]);
+    expect(buckets.remoteOnly.map((i) => i.id)).toEqual([`is-${D}`]);
+    expect(buckets.bothIdentical.map((i) => i.id)).toEqual([`is-${A}`]);
+    expect(buckets.bothDifferent.map((p) => p.local.id)).toEqual([`is-${B}`]);
+    expect(buckets.bothDifferent[0]?.local.title).toBe('local title');
+    expect(buckets.bothDifferent[0]?.remote.title).toBe('remote title');
+  });
+
+  it('treats version/timestamp-only differences as identical (substantive equality)', () => {
+    const local = [
+      createTestIssue({
+        id: `is-${A}`,
+        title: 'same',
+        version: 9,
+        updated_at: '2026-05-01T00:00:00Z',
+      }),
+    ];
+    const remote = [
+      createTestIssue({
+        id: `is-${A}`,
+        title: 'same',
+        version: 2,
+        updated_at: '2026-01-01T00:00:00Z',
+      }),
+    ];
+    const buckets = categorizeIssuesByUlid(local, remote);
+    expect(buckets.bothIdentical).toHaveLength(1);
+    expect(buckets.bothDifferent).toHaveLength(0);
+  });
+
+  it('handles empty inputs', () => {
+    const buckets = categorizeIssuesByUlid([], []);
+    expect(buckets.localOnly).toHaveLength(0);
+    expect(buckets.remoteOnly).toHaveLength(0);
+    expect(buckets.bothIdentical).toHaveLength(0);
+    expect(buckets.bothDifferent).toHaveLength(0);
+  });
+});

--- a/packages/tbd/tests/rescue-divergence.test.ts
+++ b/packages/tbd/tests/rescue-divergence.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdir, rm, readdir, writeFile as fsWriteFile } from 'node:fs/promises';
+import { mkdir, rm, readdir, readFile, writeFile as fsWriteFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir, platform } from 'node:os';
 import { randomBytes } from 'node:crypto';
@@ -21,6 +21,7 @@ import { promisify } from 'node:util';
 
 import { initWorktree, rescueUnrelatedHistory } from '../src/file/git.js';
 import { writeIssue, readIssue } from '../src/file/storage.js';
+import { loadIdMapping, saveIdMapping, type IdMapping } from '../src/file/id-mapping.js';
 import { SYNC_BRANCH, TBD_DIR, DATA_SYNC_DIR_NAME } from '../src/lib/paths.js';
 import type { Issue } from '../src/lib/types.js';
 import { createTestIssue } from './test-helpers.js';
@@ -112,10 +113,10 @@ describeUnlessWindows('rescue divergence matrix + preconditions', () => {
     expect(await atticConflictFiles()).toHaveLength(0);
   });
 
-  it('field-merges a same-origin divergence without dropping the issue (no attic)', async () => {
+  it('preserves the dropped side in attic when a same-origin field diverges', async () => {
     // Equal created_at -> field-by-field merge against a synthetic base (the
-    // lower-version side). The higher-version side's field changes are applied;
-    // no data is discarded, so no attic artifact is created.
+    // lower-version side). The higher-version side's change is applied, but the
+    // other side's value is NOT silently dropped — it is preserved in attic.
     const created = '2026-01-01T00:00:00Z';
     await buildUnrelated(
       createTestIssue({
@@ -136,12 +137,45 @@ describeUnlessWindows('rescue divergence matrix + preconditions', () => {
 
     const result = await rescueUnrelatedHistory(workPath, 'origin', SYNC_BRANCH);
     expect(result.merged).toBe(1);
-    expect(result.conflicts).toBe(0);
-    expect(await atticConflictFiles()).toHaveLength(0);
+    // The local labels are not kept by the merge, so they are preserved.
+    expect(result.conflicts).toBeGreaterThanOrEqual(1);
 
-    // The issue survives and carries the higher-version side's labels.
     const merged = await readIssue(dataSyncPath, `is-${SHARED}`);
     expect(merged.labels).toEqual(['remote']);
+    expect(await atticConflictFiles()).toContainEqual(expect.stringContaining(`is-${SHARED}__`));
+  });
+
+  it('drops neither side when both edit the same field from the same version (issue #1)', async () => {
+    // Same id, same created_at, same version, both sides edited the same scalar.
+    // mergeIssues has no trustworthy base; the rescue must still preserve the
+    // side the merge does not keep, so neither edit is lost.
+    const created = '2026-01-01T00:00:00Z';
+    await buildUnrelated(
+      createTestIssue({ id: `is-${SHARED}`, title: 'local edit', created_at: created, version: 1 }),
+      createTestIssue({
+        id: `is-${SHARED}`,
+        title: 'remote edit',
+        created_at: created,
+        version: 1,
+      }),
+    );
+
+    const result = await rescueUnrelatedHistory(workPath, 'origin', SYNC_BRANCH);
+    expect(result.merged).toBe(1);
+    expect(result.conflicts).toBeGreaterThanOrEqual(1);
+
+    // The merged file carries one side's title; the other side is preserved.
+    const merged = await readIssue(dataSyncPath, `is-${SHARED}`);
+    const attic = await atticConflictFiles();
+    expect(attic.some((f) => f.startsWith(`is-${SHARED}__`))).toBe(true);
+
+    // Neither title is lost: one is the merged value, the other lives in attic.
+    const atticBodies = await Promise.all(
+      attic.map((f) => readFile(join(dataSyncPath, 'attic', 'conflicts', f), 'utf-8')),
+    );
+    const allTitles = [merged.title, ...atticBodies.map((b) => /title: (.*)/.exec(b)?.[1] ?? '')];
+    expect(allTitles).toContain('local edit');
+    expect(allTitles).toContain('remote edit');
   });
 
   it('preserves the losing version in attic/conflicts/ on a true conflict', async () => {
@@ -170,6 +204,85 @@ describeUnlessWindows('rescue divergence matrix + preconditions', () => {
     // The losing (remote) version is preserved as an explicit artifact.
     const attic = await atticConflictFiles();
     expect(attic.some((f) => f.startsWith(`is-${SHARED}__`))).toBe(true);
+  });
+
+  function idMap(pairs: [string, string][]): IdMapping {
+    const shortToUlid = new Map(pairs);
+    const ulidToShort = new Map(pairs.map(([s, u]) => [u, s] as [string, string]));
+    return { shortToUlid, ulidToShort };
+  }
+
+  /** Commit the given issues (+ optional ids.yml) onto the local tbd-sync. */
+  async function commitLocal(issues: Issue[], mapping?: IdMapping): Promise<void> {
+    for (const issue of issues) await writeIssue(dataSyncPath, issue);
+    if (mapping) await saveIdMapping(dataSyncPath, mapping);
+    await g(worktreePath, 'add', '-A');
+    await g(worktreePath, '-c', 'commit.gpgsign=false', 'commit', '-m', 'local');
+  }
+
+  /** Push an unrelated orphan tbd-sync (+ optional ids.yml) to the bare remote. */
+  async function pushRemoteSeed(issues: Issue[], mapping?: IdMapping): Promise<void> {
+    const seed = join(testDir, `seed-${randomBytes(3).toString('hex')}`);
+    const seedData = join(seed, TBD_DIR, DATA_SYNC_DIR_NAME);
+    await mkdir(join(seedData, 'issues'), { recursive: true });
+    await g(seed, 'init', '-b', SYNC_BRANCH);
+    await g(seed, 'config', 'user.email', 'b@b.com');
+    await g(seed, 'config', 'user.name', 'B');
+    await g(seed, 'config', 'commit.gpgsign', 'false');
+    for (const issue of issues) await writeIssue(seedData, issue);
+    if (mapping) await saveIdMapping(seedData, mapping);
+    await g(seed, 'add', '-A');
+    await g(seed, 'commit', '-m', 'env B');
+    await g(seed, 'push', barePath, `${SYNC_BRANCH}:refs/heads/${SYNC_BRANCH}`);
+    await g(workPath, 'remote', 'add', 'origin', barePath);
+  }
+
+  it('keeps the remote public ID when local and remote use the same short ID (issue #2)', async () => {
+    const localUlid = '01collidelocal000000000000';
+    const remoteUlid = '01collideremote00000000000';
+    // Both roots independently assigned the short ID "ab12" to different ULIDs.
+    await commitLocal(
+      [createTestIssue({ id: `is-${localUlid}`, title: 'local only' })],
+      idMap([['ab12', localUlid]]),
+    );
+    await pushRemoteSeed(
+      [createTestIssue({ id: `is-${remoteUlid}`, title: 'remote only' })],
+      idMap([['ab12', remoteUlid]]),
+    );
+
+    await rescueUnrelatedHistory(workPath, 'origin', SYNC_BRANCH);
+
+    const mapping = await loadIdMapping(dataSyncPath);
+    // Remote (the adopted canonical base) keeps its original public ID.
+    expect(mapping.ulidToShort.get(remoteUlid)).toBe('ab12');
+    // The colliding local-only issue is regenerated to a different short ID.
+    expect(mapping.ulidToShort.get(localUlid)).toBeDefined();
+    expect(mapping.ulidToShort.get(localUlid)).not.toBe('ab12');
+  });
+
+  it('reports success (no failure) for a no-op rescue with nothing to commit (issue #3)', async () => {
+    // Identical single issue + identical canonical ids.yml on both unrelated
+    // roots: after adopting the remote base there is nothing to reconcile or
+    // commit, but rescue must still succeed rather than fail on "nothing to commit".
+    const ulid = '01noopidentical00000000000';
+    const issue = createTestIssue({
+      id: `is-${ulid}`,
+      title: 'same',
+      created_at: '2026-01-01T00:00:00Z',
+    });
+    const mapping = idMap([['ab12', ulid]]);
+    await commitLocal([{ ...issue }], mapping);
+    await pushRemoteSeed([{ ...issue }], mapping);
+
+    const result = await rescueUnrelatedHistory(workPath, 'origin', SYNC_BRANCH);
+    expect(result.merged).toBe(0);
+    expect(result.localOnly).toBe(0);
+    expect(result.backupBranch).toMatch(/^tbd-backup-/);
+
+    // No empty commit was created: local tbd-sync equals the adopted remote base.
+    const localHead = await g(workPath, 'rev-parse', SYNC_BRANCH);
+    const remoteHead = await g(workPath, 'rev-parse', `origin/${SYNC_BRANCH}`);
+    expect(localHead).toBe(remoteHead);
   });
 
   it('aborts on a dirty worktree without resetting or creating a backup branch', async () => {

--- a/packages/tbd/tests/rescue-divergence.test.ts
+++ b/packages/tbd/tests/rescue-divergence.test.ts
@@ -2,9 +2,9 @@
  * Rescue divergence matrix + precondition tests (tbd-e550).
  *
  * Same-ULID divergence across two unrelated roots must never be dropped:
- *   identical      -> no-op
- *   scalar differ  -> field-merge (lww); losing version preserved in attic/conflicts/
- *   labels differ  -> union (clean, no attic)
+ *   identical             -> no-op
+ *   same-origin field diff -> field-merge (no data discarded, no attic)
+ *   true conflict          -> losing version preserved in attic/conflicts/
  * Plus preconditions: rescue aborts on a dirty worktree or a merge in progress
  * (never resets over uncommitted work).
  *

--- a/packages/tbd/tests/rescue-divergence.test.ts
+++ b/packages/tbd/tests/rescue-divergence.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Rescue divergence matrix + precondition tests (tbd-e550).
+ *
+ * Same-ULID divergence across two unrelated roots must never be dropped:
+ *   identical      -> no-op
+ *   scalar differ  -> field-merge (lww); losing version preserved in attic/conflicts/
+ *   labels differ  -> union (clean, no attic)
+ * Plus preconditions: rescue aborts on a dirty worktree or a merge in progress
+ * (never resets over uncommitted work).
+ *
+ * See: plan-2026-05-29-tbd-sync-unrelated-history-hardening.md (Phase 2 tests)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, readdir, writeFile as fsWriteFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir, platform } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { initWorktree, rescueUnrelatedHistory } from '../src/file/git.js';
+import { writeIssue, readIssue } from '../src/file/storage.js';
+import { SYNC_BRANCH, TBD_DIR, DATA_SYNC_DIR_NAME } from '../src/lib/paths.js';
+import type { Issue } from '../src/lib/types.js';
+import { createTestIssue } from './test-helpers.js';
+
+const execFileAsync = promisify(execFile);
+const isWindows = platform() === 'win32';
+const describeUnlessWindows = isWindows ? describe.skip : describe;
+
+async function g(dir: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, {
+    cwd: dir,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+  });
+  return stdout.trim();
+}
+
+const SHARED = '01rescuediverg00000000shar';
+
+describeUnlessWindows('rescue divergence matrix + preconditions', () => {
+  let testDir: string;
+  let barePath: string;
+  let workPath: string;
+  let worktreePath: string;
+  let dataSyncPath: string;
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `tbd-rescuediv-${randomBytes(4).toString('hex')}`);
+    barePath = join(testDir, 'remote.git');
+    workPath = join(testDir, 'work');
+    await mkdir(barePath, { recursive: true });
+    await g(barePath, 'init', '--bare');
+    await mkdir(workPath, { recursive: true });
+    await g(workPath, 'init', '-b', 'main');
+    await g(workPath, 'config', 'user.email', 't@t.com');
+    await g(workPath, 'config', 'user.name', 'T');
+    await g(workPath, 'config', 'commit.gpgsign', 'false');
+    await fsWriteFile(join(workPath, 'README.md'), '# t\n');
+    await g(workPath, 'add', '.');
+    await g(workPath, 'commit', '-m', 'init');
+
+    const init = await initWorktree(workPath);
+    expect(init.success).toBe(true);
+    worktreePath = join(workPath, '.git', 'tbd', 'data-sync-worktree');
+    dataSyncPath = join(worktreePath, TBD_DIR, DATA_SYNC_DIR_NAME);
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  /**
+   * Build the unrelated state: local tbd-sync carries `localShared`, the remote
+   * orphan tbd-sync carries `remoteShared` (same id, possibly divergent).
+   */
+  async function buildUnrelated(localShared: Issue, remoteShared: Issue): Promise<void> {
+    await writeIssue(dataSyncPath, localShared);
+    await g(worktreePath, 'add', '-A');
+    await g(worktreePath, '-c', 'commit.gpgsign=false', 'commit', '-m', 'local');
+
+    const seed = join(testDir, `seed-${randomBytes(3).toString('hex')}`);
+    await mkdir(join(seed, TBD_DIR, DATA_SYNC_DIR_NAME, 'issues'), { recursive: true });
+    await g(seed, 'init', '-b', SYNC_BRANCH);
+    await g(seed, 'config', 'user.email', 'b@b.com');
+    await g(seed, 'config', 'user.name', 'B');
+    await g(seed, 'config', 'commit.gpgsign', 'false');
+    await writeIssue(join(seed, TBD_DIR, DATA_SYNC_DIR_NAME), remoteShared);
+    await g(seed, 'add', '-A');
+    await g(seed, 'commit', '-m', 'env B');
+    await g(seed, 'push', barePath, `${SYNC_BRANCH}:refs/heads/${SYNC_BRANCH}`);
+
+    await g(workPath, 'remote', 'add', 'origin', barePath);
+  }
+
+  async function atticConflictFiles(): Promise<string[]> {
+    return readdir(join(dataSyncPath, 'attic', 'conflicts')).catch(() => [] as string[]);
+  }
+
+  it('identical same-ULID is a no-op (no merge, no attic artifact)', async () => {
+    const issue = createTestIssue({
+      id: `is-${SHARED}`,
+      title: 'same',
+      created_at: '2026-01-01T00:00:00Z',
+    });
+    await buildUnrelated({ ...issue }, { ...issue });
+
+    const result = await rescueUnrelatedHistory(workPath, 'origin', SYNC_BRANCH);
+    expect(result.merged).toBe(0);
+    expect(result.conflicts).toBe(0);
+    expect(await atticConflictFiles()).toHaveLength(0);
+  });
+
+  it('field-merges a same-origin divergence without dropping the issue (no attic)', async () => {
+    // Equal created_at -> field-by-field merge against a synthetic base (the
+    // lower-version side). The higher-version side's field changes are applied;
+    // no data is discarded, so no attic artifact is created.
+    const created = '2026-01-01T00:00:00Z';
+    await buildUnrelated(
+      createTestIssue({
+        id: `is-${SHARED}`,
+        title: 'same',
+        labels: ['local'],
+        created_at: created,
+        version: 1,
+      }),
+      createTestIssue({
+        id: `is-${SHARED}`,
+        title: 'same',
+        labels: ['remote'],
+        created_at: created,
+        version: 2,
+      }),
+    );
+
+    const result = await rescueUnrelatedHistory(workPath, 'origin', SYNC_BRANCH);
+    expect(result.merged).toBe(1);
+    expect(result.conflicts).toBe(0);
+    expect(await atticConflictFiles()).toHaveLength(0);
+
+    // The issue survives and carries the higher-version side's labels.
+    const merged = await readIssue(dataSyncPath, `is-${SHARED}`);
+    expect(merged.labels).toEqual(['remote']);
+  });
+
+  it('preserves the losing version in attic/conflicts/ on a true conflict', async () => {
+    // Different created_at + different content -> whole-issue LWW: the
+    // earlier-created side wins and the loser is preserved, never dropped.
+    await buildUnrelated(
+      createTestIssue({
+        id: `is-${SHARED}`,
+        title: 'local title',
+        created_at: '2026-01-01T00:00:00Z',
+      }),
+      createTestIssue({
+        id: `is-${SHARED}`,
+        title: 'remote title',
+        created_at: '2026-02-01T00:00:00Z',
+      }),
+    );
+
+    const result = await rescueUnrelatedHistory(workPath, 'origin', SYNC_BRANCH);
+    expect(result.merged).toBe(1);
+    expect(result.conflicts).toBe(1);
+
+    const merged = await readIssue(dataSyncPath, `is-${SHARED}`);
+    expect(merged.title).toBe('local title'); // earlier-created wins
+
+    // The losing (remote) version is preserved as an explicit artifact.
+    const attic = await atticConflictFiles();
+    expect(attic.some((f) => f.startsWith(`is-${SHARED}__`))).toBe(true);
+  });
+
+  it('aborts on a dirty worktree without resetting or creating a backup branch', async () => {
+    const created = '2026-01-01T00:00:00Z';
+    await buildUnrelated(
+      createTestIssue({ id: `is-${SHARED}`, title: 'local', created_at: created }),
+      createTestIssue({ id: `is-${SHARED}`, title: 'remote', created_at: created }),
+    );
+    // Uncommitted change in the worktree.
+    await fsWriteFile(join(dataSyncPath, 'issues', 'is-01dirtyuncommitted00000000.md'), 'junk\n');
+
+    const headBefore = await g(workPath, 'rev-parse', SYNC_BRANCH);
+    await expect(rescueUnrelatedHistory(workPath, 'origin', SYNC_BRANCH)).rejects.toThrow(
+      /uncommitted changes/i,
+    );
+    // No reset happened and no backup branch was created.
+    expect(await g(workPath, 'rev-parse', SYNC_BRANCH)).toBe(headBefore);
+    const backups = (await g(workPath, 'branch', '--list', 'tbd-backup-*')).trim();
+    expect(backups).toBe('');
+  });
+
+  it('aborts when a merge is in progress in the worktree', async () => {
+    const created = '2026-01-01T00:00:00Z';
+    await buildUnrelated(
+      createTestIssue({ id: `is-${SHARED}`, title: 'local', created_at: created }),
+      createTestIssue({ id: `is-${SHARED}`, title: 'remote', created_at: created }),
+    );
+    // Simulate an in-progress merge: a MERGE_HEAD in the worktree's git dir
+    // (clean working tree, so this exercises the merge-in-progress guard, not
+    // the dirty-worktree guard).
+    const gitDir = await g(worktreePath, 'rev-parse', '--absolute-git-dir');
+    const head = await g(worktreePath, 'rev-parse', 'HEAD');
+    await fsWriteFile(join(gitDir, 'MERGE_HEAD'), `${head}\n`);
+
+    await expect(rescueUnrelatedHistory(workPath, 'origin', SYNC_BRANCH)).rejects.toThrow(
+      /merge is in progress/i,
+    );
+  });
+});

--- a/packages/tbd/tests/rescue-unrelated.test.ts
+++ b/packages/tbd/tests/rescue-unrelated.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Integration tests for rescueUnrelatedHistory (#139, core happy path).
+ *
+ * The same-ULID divergence matrix and dirty-worktree precondition live in the
+ * dedicated test bead (tbd-e550). This proves the core contract: adopt the
+ * remote base, replay local-only work, merge both-different, end up
+ * fast-forward-able with a recoverable backup branch.
+ *
+ * See: tbd-6l8r (plan-2026-05-29-tbd-sync-unrelated-history-hardening.md)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, writeFile as fsWriteFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir, platform } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { initWorktree, rescueUnrelatedHistory, branchExists } from '../src/file/git.js';
+import { writeIssue, listIssues } from '../src/file/storage.js';
+import { loadIdMapping } from '../src/file/id-mapping.js';
+import { SYNC_BRANCH, TBD_DIR, DATA_SYNC_DIR_NAME } from '../src/lib/paths.js';
+import { createTestIssue } from './test-helpers.js';
+
+const execFileAsync = promisify(execFile);
+const isWindows = platform() === 'win32';
+const describeUnlessWindows = isWindows ? describe.skip : describe;
+
+async function g(dir: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, {
+    cwd: dir,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+  });
+  return stdout.trim();
+}
+
+// ULIDs: shared (both roots), local-only, remote-only.
+const SHARED = '01rescueintg00000000shared';
+const LOCAL_ONLY = '01rescueintg00000localonly';
+const REMOTE_ONLY = '01rescueintg0000remoteonly';
+
+describeUnlessWindows('rescueUnrelatedHistory (core)', () => {
+  let testDir: string;
+  let barePath: string;
+  let workPath: string;
+  let dataSyncPath: string;
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `tbd-rescue-${randomBytes(4).toString('hex')}`);
+    barePath = join(testDir, 'remote.git');
+    workPath = join(testDir, 'work');
+    await mkdir(barePath, { recursive: true });
+    await g(barePath, 'init', '--bare');
+
+    // Work repo, NO remote yet (so initWorktree makes a local orphan tbd-sync).
+    await mkdir(workPath, { recursive: true });
+    await g(workPath, 'init', '-b', 'main');
+    await g(workPath, 'config', 'user.email', 't@t.com');
+    await g(workPath, 'config', 'user.name', 'T');
+    await g(workPath, 'config', 'commit.gpgsign', 'false');
+    await fsWriteFile(join(workPath, 'README.md'), '# t\n');
+    await g(workPath, 'add', '.');
+    await g(workPath, 'commit', '-m', 'init');
+
+    const init = await initWorktree(workPath);
+    expect(init.success).toBe(true);
+    const worktreePath = join(workPath, '.git', 'tbd', 'data-sync-worktree');
+    dataSyncPath = join(worktreePath, TBD_DIR, DATA_SYNC_DIR_NAME);
+
+    // Local issues: a local-only issue + a shared-id issue (local content).
+    await writeIssue(
+      dataSyncPath,
+      createTestIssue({ id: `is-${LOCAL_ONLY}`, title: 'local only' }),
+    );
+    await writeIssue(
+      dataSyncPath,
+      createTestIssue({ id: `is-${SHARED}`, title: 'shared — local edit' }),
+    );
+    await g(worktreePath, 'add', '-A');
+    await g(worktreePath, '-c', 'commit.gpgsign=false', 'commit', '-m', 'local work');
+
+    // Seed the bare remote with an UNRELATED orphan tbd-sync (env B): a
+    // remote-only issue + the shared-id issue with different content.
+    const seed = join(testDir, 'seedB');
+    await mkdir(join(seed, TBD_DIR, DATA_SYNC_DIR_NAME, 'issues'), { recursive: true });
+    await g(seed, 'init', '-b', SYNC_BRANCH);
+    await g(seed, 'config', 'user.email', 'b@b.com');
+    await g(seed, 'config', 'user.name', 'B');
+    await g(seed, 'config', 'commit.gpgsign', 'false');
+    const seedData = join(seed, TBD_DIR, DATA_SYNC_DIR_NAME);
+    await writeIssue(seedData, createTestIssue({ id: `is-${REMOTE_ONLY}`, title: 'remote only' }));
+    await writeIssue(
+      seedData,
+      createTestIssue({ id: `is-${SHARED}`, title: 'shared — remote edit' }),
+    );
+    await g(seed, 'add', '-A');
+    await g(seed, 'commit', '-m', 'env B');
+    await g(seed, 'push', barePath, `${SYNC_BRANCH}:refs/heads/${SYNC_BRANCH}`);
+
+    // Now attach the remote — local and origin tbd-sync are unrelated.
+    await g(workPath, 'remote', 'add', 'origin', barePath);
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  it('adopts the remote base, replays local work, and ends up fast-forward-able', async () => {
+    const result = await rescueUnrelatedHistory(workPath, 'origin', SYNC_BRANCH);
+
+    // A backup branch holds the pre-rescue HEAD.
+    expect(result.backupBranch).toMatch(/^tbd-backup-/);
+    expect(await branchExists(result.backupBranch, workPath)).toBe(true);
+
+    // Push will now fast-forward: origin/tbd-sync is an ancestor of tbd-sync.
+    await expect(
+      g(workPath, 'merge-base', '--is-ancestor', `origin/${SYNC_BRANCH}`, SYNC_BRANCH),
+    ).resolves.toBe('');
+
+    // All three issues survive (local-only, remote-only, shared/merged).
+    const issues = await listIssues(dataSyncPath);
+    const ids = issues.map((i) => i.id).sort();
+    expect(ids).toEqual([`is-${LOCAL_ONLY}`, `is-${REMOTE_ONLY}`, `is-${SHARED}`].sort());
+    expect(result.localOnly).toBe(1);
+    expect(result.merged).toBe(1);
+
+    // Every issue has a backing mapping and there are no duplicate public IDs.
+    const mapping = await loadIdMapping(dataSyncPath);
+    expect(mapping.ulidToShort.size).toBe(issues.length);
+    const shortIds = [...mapping.shortToUlid.keys()];
+    expect(new Set(shortIds).size).toBe(shortIds.length);
+  });
+
+  it('preserves the pre-rescue HEAD on the backup branch', async () => {
+    const preHead = await g(workPath, 'rev-parse', SYNC_BRANCH);
+    const result = await rescueUnrelatedHistory(workPath, 'origin', SYNC_BRANCH);
+    const backupHead = await g(workPath, 'rev-parse', result.backupBranch);
+    expect(backupHead).toBe(preHead);
+  });
+});

--- a/packages/tbd/tests/unrelated-histories-error.test.ts
+++ b/packages/tbd/tests/unrelated-histories-error.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Unit tests for UnrelatedHistoriesError (tbd sync dedicated message).
+ *
+ * See: tbd-xsb4 (plan-2026-05-29-tbd-sync-unrelated-history-hardening.md)
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { UnrelatedHistoriesError, SyncError } from '../src/cli/lib/errors.js';
+
+describe('UnrelatedHistoriesError', () => {
+  it('is a SyncError so the sync command surfaces it (not swallowed as first-sync)', () => {
+    const err = new UnrelatedHistoriesError('origin', 'tbd-sync');
+    expect(err).toBeInstanceOf(SyncError);
+    expect(err.name).toBe('UnrelatedHistoriesError');
+  });
+
+  it('names the remote/branch and routes to tbd doctor --fix, not tbd sync', () => {
+    const err = new UnrelatedHistoriesError('upstream', 'tbd-sync');
+    expect(err.message).toMatch(/upstream\/tbd-sync/);
+    expect(err.message).toMatch(/unrelated|no common ancestor/i);
+    expect(err.message).toMatch(/tbd doctor --fix/);
+  });
+
+  it('defaults to origin/tbd-sync', () => {
+    expect(new UnrelatedHistoriesError().message).toMatch(/origin\/tbd-sync/);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the full plan spec `docs/project/specs/active/plan-2026-05-29-tbd-sync-unrelated-history-hardening.md`, hardening the `tbd-sync` layer along three axes — **detection**, **prevention**, **rescue** — so the branch can no longer silently end up unrecoverable or misreported as healthy.

- **#139** — unrelated `tbd-sync` histories (no common ancestor) were undetected (`doctor` said "healthy") and unrecoverable (push failed forever).
- **#137** — the init race that creates those histories (nothing pushed the fresh orphan to close the window).
- **#135** — silent fallback when the sync worktree is missing (already fixed in v0.2.0; here verified + locked with a regression test).

This is the **implementation** PR. The planning PR (#141, spec only) tracked the same work; this branch carries the spec plus the full implementation. Tracked by epic **`tbd-55sk`** + 11 children (all closed).

## What changed

**Phase 1 — detection + prevention + #135 regression**
- `git()` throws a structured `GitError` carrying `exitCode` (+ `exitCodeOf`), so callers branch on git's exit status instead of string-matching stderr. _(structural, tbd-as47)_
- `probeRemoteBranch` tri-state `present` / `absent` / `check-failed` (keyed on `ls-remote --exit-code` → 2); `remoteBranchExists` becomes a fail-closed wrapper. Fixes Fault 1's fail-open catch. _(tbd-ptj3)_
- `initWorktree` refuses to orphan on `check-failed` (no divergent local branch), still orphans local-only repos, and pushes the fresh orphan immediately (`pushFreshOrphan`) so "first init wins"; on a rejected race it adopts a scaffold-only remote or fails loudly toward `tbd doctor --fix`. _(#137, tbd-xkyh)_
- `checkRemoteBranchHealth` gains `unrelated` — distinguishing "no local branch" from "no common ancestor" via `merge-base` exit 1. _(Fault 2, tbd-nzqt)_
- `tbd doctor` reports unrelated histories as a hard ✗ routed to `--fix` (never `tbd sync`). _(tbd-fg5a)_
- `tbd sync` detects the unrelated state up front (post-fetch) and raises `UnrelatedHistoriesError` before any merge/retry — so `pushWithRetry` never burns attempts against an unrelated remote; push-failure block has defense-in-depth. _(tbd-xsb4)_
- #135 regression tryscript: missing worktree heals and reflects real issues, never writing under the gitignored `.tbd/data-sync/`. _(tbd-b6vi)_

**Phase 2 — non-destructive rescue**
- `rescueUnrelatedHistory`: preconditions (clean worktree, no merge in progress) → fetch → backup branch `tbd-backup-<ts>` → ULID-bucket categorization (`categorizeIssuesByUlid`, pure) → adopt `origin/tbd-sync` base → replay local-only, field-merge both-different (losing version preserved under `attic/conflicts/`), union + reconcile `ids.yml` → commit. Reconciliation is at the issue-file layer (ULIDs), never a git history merge; leaves a clean fast-forward push. _(#139, tbd-6l8r)_
- Wired into `tbd doctor --fix` under `withSharedDataSyncLock`. _(tbd-7eyl)_
- Tests: rescue divergence matrix + dirty/merge-in-progress preconditions _(tbd-e550)_, and an end-to-end tryscript `race → detect → doctor --fix → sync` _(tbd-xxk5)_.

## Test plan

- [x] `pnpm typecheck`, `lint`, `format` clean (pre-commit hooks on every commit)
- [x] `pnpm test` — **1126 vitest tests pass** (68 files; +new git-exit-code, probe-remote, init-orphan, unrelated-health, doctor-unrelated, unrelated-histories-error, rescue-categorize, rescue-unrelated, rescue-divergence)
- [x] `tryscript run 'tests/**/*.tryscript.md'` — **817 golden tests pass** (+new missing-worktree-135 and unrelated-rescue scenarios)
- [x] pre-push hook (build + full test + package-age) passed on push
- [x] Manual end-to-end: `doctor` flags unrelated → `doctor --fix` rescues (backup branch, both sides' issues survive) → `sync` fast-forwards

Developed TDD throughout (failing test per fault), structural and behavioral commits kept separate.

🤖 Generated with [Claude Code](https://claude.ai/code/session_016dQiPcejjsZXjPJgKtL78o)

---
_Generated by [Claude Code](https://claude.ai/code/session_016dQiPcejjsZXjPJgKtL78o)_