### PR TITLE
docs: complete v0.2.1 release notes + make release process cover shipped content

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -77,7 +77,13 @@ git status  # Must be clean
 Review changes since last release:
 
 ```bash
-git log $(git describe --tags --abbrev=0 2>/dev/null || echo "HEAD~20")..HEAD --oneline
+PREV=$(git describe --tags --abbrev=0)
+git log $PREV..HEAD --oneline
+
+# Releases are not code-only: also review shipped content that users invoke
+# (bundled guidelines, skills, shortcuts, templates) — its changes belong in the notes.
+git diff --stat $PREV..HEAD -- 'packages/tbd/docs/guidelines/**' \
+  'packages/tbd/docs/shortcuts/**'
 ```
 
 Choose version bump:

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -34,6 +34,30 @@ drifted into unrelated git histories.
   carries a `format=fNN` stamp, and `tbd setup` refuses to overwrite a skill written by
   a newer tbd (telling you to upgrade) instead of silently rolling it back.
 
+### Guidelines & skills
+
+These ship inside the package and are read by agents via `tbd guidelines …` and
+`tbd skill`:
+
+- **`cli-agent-skill-patterns` guideline — new guidance for authoring CLI-backed skills
+  and handling their upgrades:**
+  - **Route, don’t restate**: when a skill is backed by a CLI, that CLI’s own `--help`
+    and informational subcommands are the authoritative reference layer.
+    The skill should point to them rather than copying flags, types, and output formats
+    that then drift (the type-enum drift fixed above is exactly this failure mode).
+  - **When to bump the `fNN` format**: reserve a format bump for changes big enough to
+    need an explicit migration.
+    Routine content updates ship by regenerating the surface on the next `setup` — no
+    bump, no migration — so the format code does not churn on every edit.
+  - **Upgrades are opt-in, never silent**: a tool only rewrites a user’s committed files
+    on an explicit `setup`; a `SessionStart` hook should run the read-only `prime`, not
+    `setup`.
+  - **Overwritten surfaces must be guarded**: stamp and guard each generated surface (or
+    run the format check before writing anything) so an older tool cannot
+    partial-downgrade a newer committed skill.
+- The bundled **skill baseline** stops over-documenting CLI-backed commands and leans on
+  `--help` for the authoritative flag/type reference.
+
 ### Security
 
 - Lockfile is byte-identical to v0.2.0 — no manifest changes and no new advisories

--- a/packages/tbd/docs/guidelines/release-notes-guidelines.md
+++ b/packages/tbd/docs/guidelines/release-notes-guidelines.md
@@ -20,6 +20,9 @@ Use these sections in order (omit empty sections):
 ### Fixes
 - Bug fixes and corrections
 
+### Guidelines & content
+- Changes to shipped guidelines, skills, shortcuts, or templates that users invoke
+
 ### Refactoring
 - Internal improvements (only if user-visible impact)
 
@@ -28,6 +31,13 @@ Use these sections in order (omit empty sections):
 
 **Full commit history**: [link to compare]
 ```
+
+**Releases are not code-only.** If the project ships content — bundled guidelines,
+skills, shortcuts, prompts, or templates that users invoke — changes to that content are
+product changes. Review those diffs (not just code commits) and give them their own
+`### Guidelines & content` section.
+Reserve `### Documentation` for docs *about* the project (README, dev/internal docs);
+shipped content a user can invoke is never an “internal doc” to skip.
 
 ## Core Principle: Describe the Delta
 
@@ -105,7 +115,11 @@ Don’t include:
 - Test-only changes (unless they fix flaky tests users noticed)
 - Pure refactoring with no user impact
 - CI/tooling changes
-- Minor doc typo fixes
+- Minor typo fixes in docs *about* the project (README, dev/internal docs)
+
+Do **not** treat shipped content as internal.
+Changes to guidelines, skills, shortcuts, or templates that users invoke are product
+changes — include them under `Guidelines & content` (see Structure).
 
 ## Review Checklist
 
@@ -116,6 +130,8 @@ Before finalizing release notes:
 - [ ] Would a user understand what’s different after upgrading?
 - [ ] Are feature names/commands in consistent format?
 - [ ] Are internal-only changes excluded?
+- [ ] Did you review shipped-content diffs (guidelines, skills, shortcuts, templates),
+  not just code commits, and give them a section?
 
 ## Example
 


### PR DESCRIPTION
## Why

The v0.2.1 release notes omitted the shipped guideline/skill changes (the `cli-agent-skill-patterns` additions from #142/#144), because they were treated as "internal docs" and skipped. They are **product surface** — users invoke them via `tbd guidelines …` and `tbd skill` — so they belong in the notes alongside code.

The live GitHub Release for v0.2.1 has already been updated with the corrected notes; this PR lands the corresponding repo changes.

## What

- **`CHANGELOG.md`**: add a `### Guidelines & skills` section to `## 0.2.1` covering the new skill-authoring guidance (route-don't-restate, when to bump the `fNN` format vs. regenerate, opt-in upgrades, guarding overwritten surfaces).
- **Process fix so it can't recur:**
  - `release-notes-guidelines.md` (itself shipped): add a `Guidelines & content` section to the structure, a "releases are not code-only" note, a clarification that shipped content is not an "internal doc" to skip, and a review-checklist item.
  - `publishing.md` Step 2: review shipped-content diffs (`docs/guidelines/**`, `docs/shortcuts/**`), not just `git log` of code commits.

## Note

The npm tarball for 0.2.1 is immutable and keeps the original CHANGELOG; the repo CHANGELOG and the GitHub Release (already updated) are the canonical, complete notes.

https://claude.ai/code/session_01HLxiGe8HrUkPUFQTQk9yHz