### PR TITLE
fix(setup): make --dry-run read-only in legacy cleanup; docs: supply-chain safe-override patterns (closes #126, #127)

### DIFF
--- a/packages/tbd/docs/guidelines/supply-chain-hardening.md
+++ b/packages/tbd/docs/guidelines/supply-chain-hardening.md
@@ -100,6 +100,63 @@ No exception is “trivial” — the rule exists because we don’t trust ourse
 which fresh versions are safe.
 **Agents never self-approve an exception**: prepare the record and a human signs off.
 
+### Safe-override patterns (verify, then install surgically)
+
+A release-age gate applies at **version resolution**, so `pkg@latest` (or a bare range)
+silently resolves to the newest version *outside* the window — which can mean you get a
+**stale** version without noticing.
+(This is the dogfood case: an `~/.npmrc` `minimum-release-age` resolved
+`npm i -g get-tbd@latest` to an older release because the newer one was still inside the
+window.) When you genuinely need the fresh version, do not weaken the global policy —
+override **surgically** for the one install, and **verify first**. The pattern is always
+*verify the publisher, timestamp, and integrity → install by an exact,
+resolution-bypassing reference → confirm afterwards.*
+
+**1. Verify before fetching** (publisher identity, publish time, integrity hash):
+
+| Ecosystem | Verify command |
+| --- | --- |
+| npm | `npm view <pkg>@<ver> _npmUser maintainers time.<ver> dist.integrity dist.tarball` |
+| PyPI | `uv pip index versions <pkg>` and inspect the file hashes on `https://pypi.org/project/<pkg>/<ver>/#files` (or `pip download --no-deps --no-binary :all:` then check the hash) |
+| Cargo | `cargo info <pkg>@<ver>` (owners, published-at); crates.io is immutable + checksummed in `Cargo.lock` |
+| Go | `go list -m -json <module>@<ver>` (the proxy returns the checksum DB entry) |
+
+For a package **you maintain** (the dogfood case), the strongest check is that the
+published artifact matches the git tag — confirm the commit/tag and, where the registry
+supports provenance/attestations (npm `--provenance`), that it was built from that
+source.
+
+**2. Install by an exact reference that bypasses version resolution**, so the gate does
+not silently re-resolve:
+
+```bash
+# npm — direct tarball URL (verified in step 1); skips before/min-release-age resolution
+npm install -g https://registry.npmjs.org/<pkg>/-/<pkg>-X.Y.Z.tgz
+
+# npm — git ref (strongest for packages you maintain: the source is auditable)
+npm install -g git+https://github.com/<org>/<repo>#vX.Y.Z
+
+# uv / pip — pin exact, with the hash recorded; --exclude-newer override is per-invocation
+uv pip install "<pkg>==X.Y.Z" --exclude-newer "$(date -u +%Y-%m-%d)"   # one-shot, not global
+
+# cargo / go — pin exact in the manifest; the committed lockfile/sum carries the checksum
+cargo add <pkg>@=X.Y.Z       # then `cargo build --locked`
+go get <module>@vX.Y.Z       # then `go mod verify`
+```
+
+A tarball-URL or git-ref install is the cleanest npm override because it never consults
+`before` / `minimum-release-age` at all (those apply only to range resolution), so you
+do not touch global config or env.
+The uv/cargo/go forms pin an exact version rather than bypassing a gate, since those
+ecosystems gate at the lockfile rather than at resolution.
+
+**3. Keep it surgical and on the record.** The override must affect **one install**, not
+global `~/.npmrc` / env / CI config; carry the same commit/PR record as any exception
+(reason, exact `pkg@version`, the verification output); and **confirm afterwards** that
+the version was not subsequently yanked.
+Never relax the global cool-off to get one fresh package — that re-exposes every
+install.
+
 ## Node / TypeScript Enforcement (npm, pnpm, Bun)
 
 The hands-on controls for the rules above in the Node ecosystem.

--- a/packages/tbd/src/cli/commands/setup.ts
+++ b/packages/tbd/src/cli/commands/setup.ts
@@ -1765,6 +1765,11 @@ class SetupAutoHandler extends BaseCommand {
           const filename = entry.name;
           // Check against known legacy script names
           if (LEGACY_TBD_SCRIPTS.includes(filename)) {
+            // In dry-run mode, report what would be removed but don't touch disk.
+            if (this.ctx.dryRun) {
+              scriptsRemoved.push(filename);
+              continue;
+            }
             try {
               await rm(join(scriptsDir, filename));
               scriptsRemoved.push(filename);
@@ -1828,7 +1833,9 @@ class SetupAutoHandler extends BaseCommand {
           }
         }
 
-        if (modified) {
+        // In dry-run mode, return the count of hooks that would be removed but
+        // never write the mutated settings back to disk.
+        if (modified && !this.ctx.dryRun) {
           if (Object.keys(hooks).length === 0) {
             delete settings.hooks;
           }
@@ -1856,7 +1863,12 @@ class SetupAutoHandler extends BaseCommand {
       const parts = [];
       if (scriptsRemoved.length > 0) parts.push(`${scriptsRemoved.length} script(s)`);
       if (hooksRemoved > 0) parts.push(`${hooksRemoved} hook(s)`);
-      console.log(colors.dim(`Cleaned up legacy ${parts.join(' and ')}`));
+      // Past tense only when we actually wrote; otherwise make clear it's hypothetical.
+      if (this.ctx.dryRun) {
+        this.output.dryRun(`Would clean up legacy ${parts.join(' and ')}`);
+      } else {
+        console.log(colors.dim(`Cleaned up legacy ${parts.join(' and ')}`));
+      }
     }
 
     // Sync docs using DocSync

--- a/packages/tbd/tests/setup-hooks.test.ts
+++ b/packages/tbd/tests/setup-hooks.test.ts
@@ -385,6 +385,76 @@ describeUnix('setup hooks (project-local)', { timeout: 15000 }, () => {
     });
   });
 
+  describe('dry-run does not mutate state (issue #126)', () => {
+    it('setup --auto --dry-run leaves .claude/settings.json byte-for-byte unchanged', async () => {
+      const projectDir = join(tempDir, 'project');
+      await mkdir(projectDir, { recursive: true });
+      initGitRepo(projectDir);
+
+      // First do a real setup so there are installed tbd hooks present. The
+      // legacy-cleanup path historically rewrote settings.json even under
+      // --dry-run, which is exactly the regression this guards.
+      const first = runTbd(['setup', '--auto', '--prefix=test'], projectDir);
+      expect(first.status).toBe(0);
+
+      const settingsPath = join(projectDir, '.claude', 'settings.json');
+      const before = await readFile(settingsPath, 'utf-8');
+
+      // Now a dry-run. It must not touch the file at all.
+      const dry = runTbd(['setup', '--auto', '--dry-run'], projectDir);
+      expect(dry.status).toBe(0);
+
+      const after = await readFile(settingsPath, 'utf-8');
+      expect(after).toBe(before);
+    });
+
+    it('setup --auto --dry-run does not remove legacy scripts/hooks from disk', async () => {
+      const projectDir = join(tempDir, 'project');
+      await mkdir(projectDir, { recursive: true });
+      initGitRepo(projectDir);
+
+      // Plant a legacy script and a legacy-pattern hook that real setup would clean up.
+      const scriptsDir = join(projectDir, '.claude', 'scripts');
+      await mkdir(scriptsDir, { recursive: true });
+      const legacyScriptPath = join(scriptsDir, 'ensure-tbd-cli.sh');
+      await writeFile(legacyScriptPath, '#!/bin/bash\necho legacy\n');
+
+      const settingsPath = join(projectDir, '.claude', 'settings.json');
+      await writeFile(
+        settingsPath,
+        JSON.stringify(
+          {
+            hooks: {
+              SessionStart: [
+                {
+                  matcher: '',
+                  hooks: [{ type: 'command', command: 'bash .claude/scripts/ensure-tbd-cli.sh' }],
+                },
+              ],
+            },
+          },
+          null,
+          2,
+        ) + '\n',
+      );
+
+      const settingsBefore = await readFile(settingsPath, 'utf-8');
+
+      const dry = runTbd(['setup', '--auto', '--dry-run', '--prefix=test'], projectDir);
+      expect(dry.status).toBe(0);
+
+      // The legacy script must still exist and settings must be unchanged.
+      await expect(access(legacyScriptPath)).resolves.not.toThrow();
+      const settingsAfter = await readFile(settingsPath, 'utf-8');
+      expect(settingsAfter).toBe(settingsBefore);
+
+      // And the output should phrase the cleanup as hypothetical, not done.
+      const out = dry.stdout + dry.stderr;
+      expect(out).not.toContain('Cleaned up legacy');
+      expect(out).toMatch(/\[DRY-RUN\].*[Ww]ould clean up legacy/);
+    });
+  });
+
   describe('script refresh on setup', () => {
     it('tbd setup --auto refreshes tbd-session.sh with latest content', async () => {
       const projectDir = join(tempDir, 'project');


### PR DESCRIPTION
## Summary

Two fixes found during an open-issue status review, bundled together. Makes `tbd setup --auto --dry-run` truly read-only (it was silently rewriting `.claude/settings.json`), and adds safe-override guidance to the supply-chain guideline for fetching a fresh package version without weakening the global cool-off.

## Changes

**`fix` — `tbd setup --auto --dry-run` no longer mutates state (closes #126)**
- `SetupAutoHandler.run()` ran legacy script/hook cleanup at the very top, *before* any dry-run gating, and `cleanupLegacyProjectHooks`/`cleanupLegacyProjectScripts` wrote to disk (`writeFile`/`rm`) unconditionally. A user running `--dry-run` to inspect changes had `.claude/settings.json` rewritten and the tbd hooks from a prior real run torn out.
- Both cleanup helpers now compute what *would* change but skip all disk writes when `ctx.dryRun` is set.
- `run()` now prints `[DRY-RUN] Would clean up legacy N ...` instead of the misleading past-tense `Cleaned up legacy ...`.
- The `install*` paths were already correctly gated via `checkDryRun`; only the cleanup path leaked.

**`docs` — supply-chain safe-override patterns (closes #127)**
- New "Safe-override patterns (verify, then install surgically)" subsection in `supply-chain-hardening.md`, after the Exception Process.
- Documents the footgun where a release-age gate resolves `@latest` to a **stale** version; a per-ecosystem **verify** table (npm/PyPI/Cargo/Go); **surgical install** commands that bypass version resolution (npm tarball-URL and git-ref; exact pins for uv/cargo/go); and keeping the override surgical + on the record.

**`test` — regression coverage**
- Two new tests in `setup-hooks.test.ts`: `.claude/settings.json` is byte-identical across a dry-run; a planted legacy script + legacy-pattern hook survive a dry-run and the output reads "Would clean up", not "Cleaned up".

Files: `packages/tbd/src/cli/commands/setup.ts` (+16/-2), `packages/tbd/tests/setup-hooks.test.ts` (+70), `packages/tbd/docs/guidelines/supply-chain-hardening.md` (+57).

## Test Plan

- [x] **Unit/integration tests pass** — `pnpm test`: **69 files, 1145 tests passed** locally, and again via the pre-push hook (70.95s). Re-confirmed by CI on this PR.
- [x] **Build succeeds** — `pnpm build` clean (tsdown, 18 files).
- [x] **Typecheck + lint** — `pnpm typecheck` and `pnpm lint` clean; pre-commit hooks (prettier, flowmark, eslint, typecheck) green.
- [x] **New regression tests** target the exact bug:
  - `setup --auto --dry-run leaves .claude/settings.json byte-for-byte unchanged` — does a real setup, snapshots the file, runs a dry-run, asserts the content is identical.
  - `setup --auto --dry-run does not remove legacy scripts/hooks from disk` — plants `ensure-tbd-cli.sh` + a legacy-pattern SessionStart hook, runs a dry-run, asserts both survive and output matches `/\[DRY-RUN\].*[Ww]ould clean up legacy/` and not `Cleaned up legacy`.
- [x] **Manual end-to-end** (#126): in a fresh git repo with a fake `$HOME`, ran a real `tbd setup --auto --prefix=test`, captured `shasum .claude/settings.json`, ran `tbd setup --auto --dry-run`, and confirmed the shasum is **identical** and the output reads `[DRY-RUN] Would clean up legacy 2 hook(s)`.
- [x] **Edge cases considered:**
  - No `.claude/settings.json` present (cleanup is a no-op; unchanged).
  - Legacy hooks present but no real install yet (planted-hook test covers this).
  - `--json` dry-run: `output.dryRun` already emits structured `{dryRun:true, action}` JSON, so the new "Would clean up" message is consistent in JSON mode.
  - Non-dry-run path is byte-for-byte unchanged from before (same `writeFile`/`rm` behavior; only gated by the new `!ctx.dryRun` guard), preserving existing idempotency tests.
- [x] **Out of scope, by design (documented on #126):** the portable Agent Skill (`.agents/skills/tbd/SKILL.md`) still installs unconditionally as the cross-agent surface — "Not detected (skipped)" refers only to the Codex `AGENTS.md`+hooks surface. Not changed here.

## Related Beads

No open beads directly track these two issues; they came from a GitHub-issue status review. GitHub: closes #126, closes #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
