### PR TITLE
docs: apply common-doc-guidelines to main tbd docs (tbd-b2zm)

### DIFF
--- a/docs/tbd-format-versioning.md
+++ b/docs/tbd-format-versioning.md
@@ -24,7 +24,7 @@ SINGLE SOURCE OF TRUTH: `CURRENT_FORMAT`, `FORMAT_HISTORY`, the per-step migrati
 `formatUpgradeMessage` all live there.
 When bumping `fNN` → `fNN+1` follow the rules below.
 
-## Old client in a newer repo: fail closed, never silently downgrade
+## Old Client in a Newer Repo: Fail Closed, Never Silently Downgrade
 
 An older `tbd` (built with a smaller `CURRENT_FORMAT`) that encounters either marker
 with a future `tbd_format` MUST:
@@ -47,7 +47,7 @@ it behind a generic “invalid config” or “worktree corrupted” error.
 `checkConfig` and `checkCommonDirLayout` in `packages/tbd/src/cli/commands/doctor.ts`
 distinguish these errors and report the actionable upgrade text.
 
-## New client in an older repo: migrate gracefully and idempotently
+## New Client in an Older Repo: Migrate Gracefully and Idempotently
 
 When a new client loads an older repo migration runs automatically.
 It MUST:
@@ -84,7 +84,7 @@ It MUST:
    usable key a failed sign leaves migration unfinished and surfaces as a “worktree
    corrupted” failure on the next command.
 
-## Mismatch recovery: route through `tbd doctor --fix`
+## Mismatch Recovery: Route Through `tbd doctor --fix`
 
 If the two markers disagree (partial migration, manual edit, half-applied upgrade),
 normal mutating commands fail closed and point the user at `tbd doctor --fix`. The
@@ -98,7 +98,7 @@ contract:
   remediation; the manual `rm "$(git rev-parse --git-common-dir)/tbd/layout.yml"` hint
   is a secondary fallback.
 
-## Required pieces when adding a new format
+## Required Pieces When Adding a New Format
 
 When bumping from `fNN` to `fNN+1`:
 
@@ -115,7 +115,7 @@ When bumping from `fNN` to `fNN+1`:
    release time from commits): “every machine that touches this repo must upgrade tbd to
    the new version, older clients will fail closed.”
 
-## Reference design
+## Reference Design
 
 Implementation reference: the `f03` → `f04` migration that introduced the shared
 common-dir sync worktree

--- a/packages/tbd/docs/tbd-design.md
+++ b/packages/tbd/docs/tbd-design.md
@@ -4674,7 +4674,7 @@ Options:
 - `tbd list --status=in_progress` - Your active work
 - `tbd show <id>` - Detailed issue view with dependencies
 
-### Creating & Updating
+### Creating and Updating
 - `tbd create "title" --type=task|bug|feature --priority=P2` - New issue
   - Priority: P0-P4 (P0=critical, P2=medium, P4=backlog)
 - `tbd update <id> --status=in_progress` - Claim work
@@ -4682,12 +4682,12 @@ Options:
 - `tbd close <id>` - Mark complete
 - `tbd close <id> --reason "explanation"` - Close with reason
 
-### Dependencies & Blocking
+### Dependencies and Blocking
 - `tbd dep add <issue> <depends-on>` - Add dependency
 - `tbd blocked` - Show all blocked issues
 - `tbd show <id>` - See what's blocking/blocked by this issue
 
-### Sync & Collaboration
+### Sync and Collaboration
 - `tbd sync` - Sync with git remote (run at session end)
 - `tbd sync --status` - Check sync status without syncing
 

--- a/packages/tbd/docs/tbd-docs.md
+++ b/packages/tbd/docs/tbd-docs.md
@@ -30,7 +30,7 @@ Why a separate branch?
 - No conflicts across main or feature branches
 - Issues shared across all branches
 
-## File format
+## File Format
 
 You usually don’t need to worry about where issues are stored, but it may be comforting
 to know that internally it’s very simple and transparent.

--- a/packages/tbd/docs/tbd-prime.md
+++ b/packages/tbd/docs/tbd-prime.md
@@ -52,7 +52,7 @@ Every session must end with tbd in a clean state:
 - `tbd show <id>` - Detailed issue view with dependencies
   - Auto-displays parent context for child issues (use `--no-parent` to suppress)
 
-### Creating & Updating
+### Creating and Updating
 
 - `tbd create "title" --type task|bug|feature --priority 2` - New issue
   - Priority: 0-4 (0=critical, 2=medium, 4=backlog).
@@ -63,13 +63,13 @@ Every session must end with tbd in a clean state:
 - `tbd close <id> --reason "explanation"` - Close with reason
 - **Tip**: When creating multiple issues, use parallel subagents for efficiency
 
-### Dependencies & Blocking
+### Dependencies and Blocking
 
 - `tbd dep add <issue> <depends-on>` - Add dependency (issue depends on depends-on)
 - `tbd blocked` - Show all blocked issues
 - `tbd show <id>` - See what’s blocking/blocked by this issue
 
-### Sync & Collaboration
+### Sync and Collaboration
 
 - `tbd sync` - Sync with git remote (run at session end)
 - `tbd sync --status` - Check sync status without syncing

--- a/packages/tbd/tests/cli-help-all.tryscript.md
+++ b/packages/tbd/tests/cli-help-all.tryscript.md
@@ -277,7 +277,7 @@ $ tbd docs --list --json
     "slug": "key-design-features"
   },
   {
-    "title": "File format",
+    "title": "File Format",
     "slug": "file-format"
   },
   {


### PR DESCRIPTION
## Summary

Mechanical application of `common-doc-guidelines.md` to the main (non-guideline) documentation files.

### Changes by category

**"and" not "&" in prose headings (6 occurrences):**
- `packages/tbd/docs/tbd-prime.md`: "Creating & Updating" -> "Creating and Updating", "Dependencies & Blocking" -> "Dependencies and Blocking", "Sync & Collaboration" -> "Sync and Collaboration"
- `packages/tbd/docs/tbd-design.md`: Same 3 headings (duplicated content in §6.4.3)

**H2 Title Case (6 occurrences):**
- `docs/tbd-format-versioning.md`: All 5 H2 headings converted to Title Case (e.g. "## Old client in a newer repo: fail closed, never silently downgrade" -> "## Old Client in a Newer Repo: Fail Closed, Never Silently Downgrade")
- `packages/tbd/docs/tbd-docs.md`: "## File format" -> "## File Format"

### Items reviewed with no changes needed

- **Banned hype words**: None found in scoped files
- **Stray history notations**: None found
- **`Markdown + YAML`**: Left as-is throughout — treated as a canonical technical compound term (per the "proper names/identifiers" exception)
- **Em dashes**: Left as-is per instructions
- **Footer**: All scoped docs already have the guideline footer
- **README.md**, `docs/development.md`, `docs/docs-overview.md`, `packages/tbd/docs/tbd-closing.md`, `packages/tbd/docs/install/claude-header.md`, `packages/tbd/docs/templates/*.md`: Reviewed, no violations found

### Verification

- `pnpm exec vitest run tests/doc-references.test.ts` — passes (no broken anchor links)
- `pnpm format:md` and `pnpm format:check` — pass

Resolves tbd-b2zm (under epic tbd-kzab).

https://claude.ai/code/session_01WwnpPJpRoh7arB5gvYuLcq

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwnpPJpRoh7arB5gvYuLcq)_