### PR TITLE
docs: apply common-doc-guidelines to remaining guideline docs (tbd-33uv)

### DIFF
--- a/packages/tbd/docs/guidelines/bun-monorepo-patterns.md
+++ b/packages/tbd/docs/guidelines/bun-monorepo-patterns.md
@@ -123,7 +123,7 @@ research stock.
 
 ## Research Findings
 
-### 1. Package Manager & Workspace Structure
+### 1. Package Manager and Workspace Structure
 
 #### Bun Workspaces
 
@@ -634,7 +634,7 @@ has platform-specific issues.
 
 * * *
 
-### 4. Package Exports & Dual Module Support
+### 4. Package Exports and Dual Module Support
 
 #### Subpath Exports
 
@@ -784,7 +784,7 @@ publint is runtime-agnostic.
 
 * * *
 
-### 7. Versioning & Release Automation
+### 7. Versioning and Release Automation
 
 #### Changesets (with Bun Workarounds)
 
@@ -1062,7 +1062,7 @@ maintain.
 
 * * *
 
-### 9. Code Formatting & Linting
+### 9. Code Formatting and Linting
 
 #### Biome
 
@@ -1514,7 +1514,7 @@ timing. The Changesets Action remains simpler for projects that prefer full auto
 
 * * *
 
-### 11. Git Hooks & Local Validation
+### 11. Git Hooks and Local Validation
 
 #### Lefthook with Biome
 
@@ -2112,7 +2112,7 @@ testing features.
 
 - [publint Documentation](https://publint.dev/docs/)
 
-### Guides & Articles
+### Guides and Articles
 
 - [Building a TypeScript Library in 2026 with Bunup](https://dev.to/arshadyaseen/building-a-typescript-library-in-2026-with-bunup-3bmg)
 

--- a/packages/tbd/docs/guidelines/electron-app-development-patterns.md
+++ b/packages/tbd/docs/guidelines/electron-app-development-patterns.md
@@ -605,7 +605,7 @@ Building a desktop app involves three separate decisions:
 
 1. **Framework/runtime**: Electron vs Electrobun (vs Tauri, etc.)
 2. **Package manager**: npm vs pnpm vs Bun (as a toolchain)
-3. **Packaging & updates**: electron-builder vs electron-forge vs Electrobun’s built-in
+3. **Packaging and updates**: electron-builder vs electron-forge vs Electrobun’s built-in
    pipeline
 
 The sections below address these decisions, starting with package manager choice for

--- a/packages/tbd/docs/guidelines/pnpm-monorepo-patterns.md
+++ b/packages/tbd/docs/guidelines/pnpm-monorepo-patterns.md
@@ -137,7 +137,7 @@ recommendations from the TypeScript and JavaScript ecosystem maintainers.
 
 ## Research Findings
 
-### 1. Package Manager & Workspace Structure
+### 1. Package Manager and Workspace Structure
 
 #### pnpm Workspaces
 
@@ -469,7 +469,7 @@ Only provide dual ESM/CJS if you have confirmed CJS consumer requirements.
 
 * * *
 
-### 4. Package Exports & Dual Module Support
+### 4. Package Exports and Dual Module Support
 
 #### Subpath Exports
 
@@ -668,7 +668,7 @@ package. Essential for any published package.
 
 * * *
 
-### 7. Versioning & Release Automation
+### 7. Versioning and Release Automation
 
 #### Changesets
 
@@ -1572,7 +1572,7 @@ CI) provides the best developer experience while ensuring CI catches issues.
 
 * * *
 
-### 11. Git Hooks & Local Validation
+### 11. Git Hooks and Local Validation
 
 #### Lefthook
 
@@ -2831,7 +2831,7 @@ ready for public release.
 
 - [Node.js Releases](https://nodejs.org/en/about/previous-releases)
 
-### Guides & Articles
+### Guides and Articles
 
 - [Complete Monorepo Guide 2025](https://jsdev.space/complete-monorepo-guide/)
 

--- a/packages/tbd/docs/guidelines/python-cli-patterns.md
+++ b/packages/tbd/docs/guidelines/python-cli-patterns.md
@@ -31,7 +31,7 @@ src/myproject/
     └── options.py          # TypedDict for command options
 ```
 
-### Agent & CI Compatibility
+### Agent and CI Compatibility
 
 Support automation with explicit flags:
 - `--format text|json|jsonl`: Output format


### PR DESCRIPTION
## Summary

Bead `tbd-33uv` under epic `tbd-kzab`. Applies `common-doc-guidelines.md` to the remaining guideline docs in `packages/tbd/docs/guidelines/` (the four unreleased docs are handled in #150).

## Changes

Write "and" rather than "&" in headings, reserving `&`/`+` for code and proper names:

- **H3 section headings** — `python-cli-patterns.md` (1), `bun-monorepo-patterns.md` (6), `pnpm-monorepo-patterns.md` (5).
- **Bold heading** — `electron-app-development-patterns.md`: "Packaging and updates".

Ampersands inside external article-title links (citations), YAML/CI job names (`name: Lint & Typecheck`), and code examples (`slugify_snake("… & …")`) are intentionally left as-is per the guideline's code/proper-name exception. No internal anchor links referenced the changed headings.

## Note on history

The first automated pass on this branch ran in a corrupted worktree git state and produced a destructive diff (hundreds of files deleted, CI never validated). This branch was **rebuilt cleanly from `main`** and now contains only the four intended doc edits.

## Deferred (tracked, not in this PR)

To keep this reviewable and avoid a sprawling diff:
- Subjective **H1/H2 Title-Case** normalization (e.g. `convex-rules.md`).
- Repo-wide **em-dash spacing** normalization (spaced ` — ` → unspaced), best done as one scripted pass.

https://claude.ai/code/session_01WwnpPJpRoh7arB5gvYuLcq