### PR TITLE
Rescope multi-agent setup to a --surfaces selector (design lock)

### DIFF
--- a/docs/project/specs/active/plan-2026-05-24-multi-agent-skills-hooks-setup.md
+++ b/docs/project/specs/active/plan-2026-05-24-multi-agent-skills-hooks-setup.md
@@ -427,7 +427,7 @@ Update `packages/tbd/docs/guidelines/cli-agent-skill-patterns.md` to match the p
 
 ### Phase 2: Setup and Integration Model
 
-- [ ] Refactor integration path constants.
+- [x] Refactor integration path constants.
 - [ ] Add canonical `.agents/skills/tbd/SKILL.md` setup.
 - [ ] Keep `.claude/skills/tbd/SKILL.md` as a mirror.
 - [ ] Add `skills/tbd/SKILL.md` distribution source.
@@ -471,7 +471,7 @@ criteria live in each bead):
 | Bead | Priority | Status | Scope |
 | --- | --- | --- | --- |
 | `tbd-t5q1` | P1 | closed | Write implementation spec for multi-agent skills setup |
-| `tbd-0fhy` | P1 | open | Refactor agent integration path model (`integration-paths.ts`) |
+| `tbd-0fhy` | P1 | closed | Refactor agent integration path model (`integration-paths.ts`) |
 | `tbd-1h9x` | P1 | open | Adopt `.agents/skills` as primary skill path with Claude mirror |
 | `tbd-qgpl` | P1 | open | Add `skills/tbd` distribution source and drift test |
 | `tbd-mjxt` | P1 | open | Define AGENTS.md scope, marker and format policy |
@@ -487,7 +487,8 @@ criteria live in each bead):
 | `tbd-m6f3` | P1 | open | Self-apply tbd setup to this repository |
 | `tbd-wha7` | P2 | open | Validate ecosystem compatibility and release metadata |
 
-Dependency outline (blocker edges; `tbd-0fhy` is the foundational unblocked task):
+Dependency outline (blocker edges; `tbd-0fhy` was the foundational path-model task and
+is now closed):
 
 - `tbd-0fhy` depends on `tbd-t5q1`.
 - `tbd-1h9x` depends on `tbd-0fhy`.

--- a/docs/project/specs/active/plan-2026-05-24-multi-agent-skills-hooks-setup.md
+++ b/docs/project/specs/active/plan-2026-05-24-multi-agent-skills-hooks-setup.md
@@ -5,12 +5,22 @@ author: Joshua Levy (github.com/jlevy) with LLM assistance
 ---
 # Feature: Modernize multi-agent skills and hooks setup
 
-**Date:** 2026-05-24 (last updated 2026-05-24)
+**Date:** 2026-05-24 (last updated 2026-06-02)
 
 **Author:** Joshua Levy (github.com/jlevy) with LLM assistance
 
-**Status:** Implemented (all beads under epic `tbd-g9x7` closed, 2026-05-26).
-Self-applied to this repo; `tbd doctor` reports all four surfaces green.
+**Status:** In progress (epic `tbd-g9x7` open).
+Partially landed: the path-model refactor (`tbd-0fhy`, closed) and an initial
+Codex/`AGENTS.md` surface.
+Still open: agent-targeting flags (`tbd-zd4h`), Codex and gh-CLI shared-script parity
+(`tbd-orup`), and pinned-runner fallbacks (`tbd-shsb`). The neutral `scripts/agent/`
+shared-script constants exist in `integration-paths.ts` but are **not yet wired up** —
+hooks still reference per-agent copies under `.claude/scripts/` and `.codex/`.
+
+**Revised 2026-06-02:** the agent-targeting design changed from per-agent flags
+(`--claude`/`--codex`/`--cursor`/`--agents-md`/`--all`) to a single
+`--surfaces=<comma-list>` selector that installs **all** surfaces by default.
+See “Setup Behavior” below and the 2026-06-02 entry under “Resolved Decisions.”
 
 ## Overview
 
@@ -121,9 +131,10 @@ or document:
 - **Codex hooks need their own path policy.** If tbd adds `.codex/hooks.json` or another
   Codex-native hook file, those hooks should reference shared or Codex-native scripts,
   not `.claude/scripts/tbd-session.sh`.
-- **Agent-targeting flags should be explicit.** pprose exposes optional AGENTS.md
-  patching; tbd should design a clearer flag taxonomy such as `--claude`, `--codex`,
-  `--cursor`, `--agents-md`, and `--all`, while preserving safe `--auto` behavior.
+- **Agent-targeting should be explicit.** pprose exposes optional AGENTS.md patching;
+  tbd needs an explicit way to choose surfaces.
+  **Resolved (2026-06-02):** a single `--surfaces=<comma-list>` selector (default = all
+  surfaces) rather than a per-agent flag taxonomy — see “Setup Behavior.”
 - **Existing unmarked AGENTS.md needs a playbook.** Status/doctor should tell users what
   it means when `AGENTS.md` exists but lacks the tbd marker block, and setup should
   preserve user content outside markers.
@@ -166,15 +177,40 @@ separate product decision.
 8. Detect old generated integration artifacts and upgrade them in place, preserving
    user-owned content and reporting every changed surface.
 
-Setup should also expose an explicit targeting model:
+Setup exposes a single explicit targeting flag, `--surfaces=<comma-list>` (revised
+2026-06-02):
 
-- `--auto` keeps the current default behavior: detect available surfaces and refresh
-  project-local integrations.
-- Future explicit flags should let users request or suppress individual surfaces, for
-  example `--claude`, `--codex`, `--cursor`, `--agents-md`, `--all`, or matching
-  `--no-*` flags.
-- The design must define how explicit flags interact with config defaults and existing
-  files before implementation.
+- **Default (flag omitted) installs every surface.** Project-local integration files are
+  cheap and harmless, and writing all of them is what makes the portable model actually
+  portable. There is no detection-based gating: `tbd setup --auto` writes all surfaces
+  unless `--surfaces` restricts the set.
+
+- `--surfaces` takes a comma-separated list of surface IDs, with `all` as an alias for
+  the full set. Surface IDs:
+  - `portable` — `.agents/skills/tbd/SKILL.md` (canonical Agent Skill, read natively by
+    Codex, Gemini, Cursor, Copilot, Amp, OpenCode, pi)
+  - `agents-md` — the `AGENTS.md` tbd-managed block (read by Codex, Cursor, Factory,
+    Amp, OpenCode, Aider, …)
+  - `claude` — `.claude/skills/tbd/SKILL.md` mirror + `.claude/settings.json` hooks
+  - `codex` — `.codex/hooks.json` + `.codex/` lifecycle scripts
+
+  Example: `tbd setup --surfaces=portable,agents-md` installs only those two.
+  `agents-md` is now its own surface, split out of the former bundled `codex` surface,
+  so the `AGENTS.md` block can be installed without Codex hooks and vice versa.
+
+- This **replaces** the earlier per-agent flag taxonomy (`--claude`, `--codex`,
+  `--cursor`, `--agents-md`, `--all`, `--skip-*`). One selector keeps the interface flat
+  and trivially extensible: a new agent is one entry in the surface registry, not a new
+  flag pair. A one-time break in the install-flag shape is acceptable — agents are always
+  instructed to read `tbd setup --help` before installing.
+
+- Orthogonal flags are unchanged: `--no-gh-cli`, `--prefix`, `--force`, `--auto`,
+  `--interactive`, `--from-beads`. The gh-CLI hook stays gated by `--no-gh-cli` /
+  `settings.use_gh_cli`, independent of surface selection.
+
+- The committed distribution copy `skills/tbd/SKILL.md` is a tbd-repo publication
+  artifact (guarded by a drift test), **not** a user-selectable `--surfaces` value: it
+  is not written into consumer repos by `tbd setup`.
 
 ### Existing Install Upgrade Model
 
@@ -289,6 +325,18 @@ fallback appropriate to the package manager:
    - `go run module/path@<version> <args>` for Go CLIs.
 3. If neither local nor pinned fallback works, stop and tell the user what install step
    is required.
+
+**Pin to the running version, not `@latest` (revised 2026-06-02).** Every version
+stamped into a generated artifact or printed as an agent-facing install hint must be the
+currently running tbd version (`PINNED_NPM_VERSION`, the clean published semver from
+`version.ts`), not `@latest`. The generated session script already does this; the
+remaining `@latest` install hints in `output.ts`, `setup.ts`, and `doctor.ts` should
+switch to `get-tbd@${PINNED_NPM_VERSION}` so a team and its agents all reinstall the
+same version they are currently using.
+The **sole** intentional exception is the forward-compatibility upgrade error in
+`tbd-format.ts`: when an artifact’s format is newer than the running tbd understands, it
+tells the user to `npm install -g get-tbd@latest` because the whole point there is to
+fetch a newer release.
 
 Never recommend an unpinned network runner from generated agent instructions unless the
 user explicitly opts into that behavior.
@@ -430,7 +478,7 @@ criteria live in each bead):
 | `tbd-jrir` | P1 | open | Shrink generated AGENTS.md block to compact bootstrap |
 | `tbd-orup` | P1 | open | Add Codex hook and gh CLI parity via shared scripts |
 | `tbd-shsb` | P1 | open | Document and emit pinned CLI runner fallbacks |
-| `tbd-zd4h` | P2 | open | Add agent-targeted setup flags |
+| `tbd-zd4h` | P2 | open | Add `--surfaces=<list>` selector (default all); replace per-agent flags |
 | `tbd-fcam` | P1 | open | Existing-install upgrade, migration and format guard |
 | `tbd-0q8h` | P1 | open | Audit gitignore policy for agent integration files |
 | `tbd-l2ym` | P1 | open | Update setup check/remove, status and doctor diagnostics |
@@ -509,6 +557,32 @@ These were open questions; resolved 2026-05-25 so the beads are unambiguous:
 - **Integration format starts at `2`**: today’s unversioned full `AGENTS.md` block is
   treated as legacy format 1, and the new compact block is format 2. (`tbd-slsp`,
   `tbd-y84j`)
+
+Revised 2026-06-02:
+
+- **Single `--surfaces=<comma-list>` selector, default all** — replaces the per-agent
+  flag taxonomy (`--claude`/`--codex`/`--cursor`/`--agents-md`/`--all`/`--skip-*`). With
+  the flag omitted, setup installs every surface; `--surfaces` restricts to a list, with
+  `all` as an alias. One flat, extensible interface beats N flag pairs; a one-time
+  install-flag break is acceptable because agents read `tbd setup --help` first.
+  (`tbd-zd4h`)
+- **`agents-md` is its own surface**, split out of the previously bundled `codex`
+  surface, so the `AGENTS.md` block and the Codex hooks install independently.
+  Surface registry IDs: `portable`, `agents-md`, `claude`, `codex`. The
+  `skills/tbd/SKILL.md` distribution copy is a tbd-repo publication artifact, not a
+  `--surfaces` value. (`tbd-zd4h`)
+- **Internals use a surface registry** — replace the fixed `{ claude, codex }` targeting
+  and the bespoke `setupClaudeIfDetected`/`setupCodexIfDetected` methods with a
+  `Surface[]` registry the run loop iterates; adding an agent becomes one descriptor.
+  (`tbd-zd4h`, `tbd-0fhy`)
+- **Wire up the neutral shared scripts** — the `scripts/agent/` constants in
+  `integration-paths.ts` are currently dead; complete `tbd-orup` by referencing them
+  from both `.claude/settings.json` and `.codex/hooks.json` (or drop them if per-agent
+  copies are kept deliberately).
+  Either way, Codex hooks must never reference `.claude/`. (`tbd-orup`)
+- **Pin agent-facing install hints to the running version** (`PINNED_NPM_VERSION`), not
+  `@latest`, except the forward-compatibility upgrade error.
+  (`tbd-shsb`)
 
 ## Self-Upgrade and Forward-Compatibility (Tier-2 behavior)
 

--- a/docs/project/specs/active/plan-2026-05-24-multi-agent-skills-hooks-setup.md
+++ b/docs/project/specs/active/plan-2026-05-24-multi-agent-skills-hooks-setup.md
@@ -10,12 +10,15 @@ author: Joshua Levy (github.com/jlevy) with LLM assistance
 **Author:** Joshua Levy (github.com/jlevy) with LLM assistance
 
 **Status:** In progress (epic `tbd-g9x7` open).
-Partially landed: the path-model refactor (`tbd-0fhy`, closed) and an initial
-Codex/`AGENTS.md` surface.
-Still open: agent-targeting flags (`tbd-zd4h`), Codex and gh-CLI shared-script parity
-(`tbd-orup`), and pinned-runner fallbacks (`tbd-shsb`). The neutral `scripts/agent/`
-shared-script constants exist in `integration-paths.ts` but are **not yet wired up** —
-hooks still reference per-agent copies under `.claude/scripts/` and `.codex/`.
+Landed via PR #156 (2026-06-02): the `--surfaces=<comma-list>` selector and surface
+registry (`tbd-zd4h`); the `agents-md`/`codex` surface split; Codex/gh-CLI decoupling
+(`tbd-orup`); and `status`/`doctor` surface labels (`tbd-l2ym`). Earlier: the path-model
+refactor (`tbd-0fhy`). On `tbd-orup`, tbd uses **per-agent script copies**
+(`.claude/scripts/` for Claude, `.codex/` for Codex) rather than a shared
+`scripts/agent/` copy; the unused `scripts/agent/` constants were removed.
+This keeps each surface self-contained — Codex hooks never reference `.claude/` — which
+is the load-bearing requirement (the guideline treats per-agent copies as a valid
+alternative to a shared neutral script).
 
 **Revised 2026-06-02:** the agent-targeting design changed from per-agent flags
 (`--claude`/`--codex`/`--cursor`/`--agents-md`/`--all`) to a single
@@ -326,17 +329,18 @@ fallback appropriate to the package manager:
 3. If neither local nor pinned fallback works, stop and tell the user what install step
    is required.
 
-**Pin to the running version, not `@latest` (revised 2026-06-02).** Every version
-stamped into a generated artifact or printed as an agent-facing install hint must be the
-currently running tbd version (`PINNED_NPM_VERSION`, the clean published semver from
-`version.ts`), not `@latest`. The generated session script already does this; the
-remaining `@latest` install hints in `output.ts`, `setup.ts`, and `doctor.ts` should
-switch to `get-tbd@${PINNED_NPM_VERSION}` so a team and its agents all reinstall the
-same version they are currently using.
-The **sole** intentional exception is the forward-compatibility upgrade error in
-`tbd-format.ts`: when an artifact’s format is newer than the running tbd understands, it
-tells the user to `npm install -g get-tbd@latest` because the whole point there is to
-fetch a newer release.
+**Pin reproducing invocations to the running version; keep upgrade/bootstrap hints on
+`@latest` (revised 2026-06-02).** A version printed so the tool re-runs *itself* must be
+the currently running tbd version (`PINNED_NPM_VERSION`, the clean published semver from
+`version.ts`), so a team and its agents all reproduce the same version.
+The generated session script (`.codex/tbd-session.sh`, `.claude/scripts/tbd-session.sh`)
+already does this via `npx --yes get-tbd@${PINNED_NPM_VERSION}`. An audit (2026-06-02,
+`tbd-shsb`) confirmed the remaining `@latest` usages are **all correct as-is** and must
+**not** be pinned: the forward-compatibility “requires a newer tbd” errors in
+`doctor.ts`, `setup.ts`, and `tbd-format.ts` exist precisely to fetch a newer release,
+and the first-install bootstrap one-liner in `output.ts` (Getting Started) is for a user
+who has no tbd yet. Pinning any of these to the running version would be a bug.
+So no code change is needed here beyond the already-pinned session script.
 
 Never recommend an unpinned network runner from generated agent instructions unless the
 user explicitly opts into that behavior.
@@ -576,13 +580,16 @@ Revised 2026-06-02:
   and the bespoke `setupClaudeIfDetected`/`setupCodexIfDetected` methods with a
   `Surface[]` registry the run loop iterates; adding an agent becomes one descriptor.
   (`tbd-zd4h`, `tbd-0fhy`)
-- **Wire up the neutral shared scripts** — the `scripts/agent/` constants in
-  `integration-paths.ts` are currently dead; complete `tbd-orup` by referencing them
-  from both `.claude/settings.json` and `.codex/hooks.json` (or drop them if per-agent
-  copies are kept deliberately).
-  Either way, Codex hooks must never reference `.claude/`. (`tbd-orup`)
-- **Pin agent-facing install hints to the running version** (`PINNED_NPM_VERSION`), not
-  `@latest`, except the forward-compatibility upgrade error.
+- **Per-agent script copies, not a shared neutral copy** — the `scripts/agent/`
+  constants in `integration-paths.ts` were dead code and have been **removed**. tbd
+  keeps per-agent copies (`.claude/scripts/` for Claude, `.codex/` for Codex); each
+  surface is self-contained and Codex hooks never reference `.claude/`. The guideline
+  treats this as a valid alternative to a shared neutral script.
+  (`tbd-orup`)
+- **Version pinning is already correct; no change needed** — the session script pins to
+  `PINNED_NPM_VERSION`; the remaining `@latest` usages are forward-compatibility upgrade
+  errors or the first-install bootstrap, all of which legitimately want the newest
+  release and must not be pinned.
   (`tbd-shsb`)
 
 ## Self-Upgrade and Forward-Compatibility (Tier-2 behavior)

--- a/packages/tbd/src/cli/commands/doctor.ts
+++ b/packages/tbd/src/cli/commands/doctor.ts
@@ -910,10 +910,10 @@ class DoctorHandler extends BaseCommand {
       await access(agentsPath);
       const content = await readFile(agentsPath, 'utf-8');
       if (content.includes('BEGIN TBD INTEGRATION')) {
-        return { name: 'Codex AGENTS.md', status: 'ok', path: AGENTS_MD_REL };
+        return { name: 'AGENTS.md', status: 'ok', path: AGENTS_MD_REL };
       }
       return {
-        name: 'Codex AGENTS.md',
+        name: 'AGENTS.md',
         status: 'warn',
         message: 'exists but missing tbd integration',
         path: AGENTS_MD_REL,
@@ -921,7 +921,7 @@ class DoctorHandler extends BaseCommand {
       };
     } catch {
       return {
-        name: 'Codex AGENTS.md',
+        name: 'AGENTS.md',
         status: 'warn',
         message: 'not installed',
         path: AGENTS_MD_REL,

--- a/packages/tbd/src/cli/commands/setup.ts
+++ b/packages/tbd/src/cli/commands/setup.ts
@@ -59,7 +59,6 @@ import {
   getCodexPaths,
   AGENTS_SKILL_DISPLAY,
   AGENT_INTEGRATION_FORMAT,
-  GLOBAL_CLAUDE_DIR,
 } from '../../lib/integration-paths.js';
 import { initWorktree, isInGitRepo, findGitRoot, checkWorktreeHealth } from '../../file/git.js';
 import { DocCache, generateShortcutDirectory } from '../../file/doc-cache.js';
@@ -952,6 +951,18 @@ class SetupCodexHandler extends BaseCommand {
     await this.installCodexHooks(cwd);
   }
 
+  /** Install only the AGENTS.md managed block (the `agents-md` surface). */
+  async runAgentsMdOnly(): Promise<void> {
+    const cwd = this.projectDir ?? process.cwd();
+    await this.installCodexSection(join(cwd, 'AGENTS.md'));
+  }
+
+  /** Install only the Codex lifecycle hooks (the `codex` surface). */
+  async runCodexHooksOnly(): Promise<void> {
+    const cwd = this.projectDir ?? process.cwd();
+    await this.installCodexHooks(cwd);
+  }
+
   /**
    * Read the use_gh_cli setting; defaults to true (so fresh setup installs it).
    */
@@ -1734,10 +1745,19 @@ interface AutoSetupResult {
 }
 
 /**
- * How a given agent surface should be handled by setup: forced on, forced off,
- * or detection-based (the default when no targeting flag is given).
+ * Agent integration surfaces that `tbd setup` can install, in install/report
+ * order. Each is selectable via `--surfaces=<comma-list>`; with the flag omitted,
+ * all are installed. Adding an agent is one entry here plus a case in
+ * `installSurface` — there is no per-agent flag to add.
  */
-type SurfaceMode = 'on' | 'off' | 'auto';
+const SETUP_SURFACE_IDS = ['portable', 'agents-md', 'claude', 'codex'] as const;
+type SurfaceId = (typeof SETUP_SURFACE_IDS)[number];
+const SURFACE_DISPLAY_NAME: Record<SurfaceId, string> = {
+  portable: 'Portable Agent Skill',
+  'agents-md': 'AGENTS.md',
+  claude: 'Claude Code',
+  codex: 'Codex hooks',
+};
 
 class SetupAutoHandler extends BaseCommand {
   private cmd: Command;
@@ -1874,25 +1894,23 @@ class SetupAutoHandler extends BaseCommand {
     // Sync docs using DocSync
     await this.syncDocs(cwd);
 
-    const targeting = this.resolveTargeting();
-
-    // Install the portable Agent Skill unconditionally. It is project-local and
-    // harmless, and is what makes the skill discoverable by Codex, Gemini CLI,
-    // Cursor, and other Agent Skills clients regardless of which agent is detected.
-    await this.installPortableSkill(cwd);
-
-    // Set up Claude Code (forced/skipped/auto per targeting)
-    const claudeResult = await this.setupClaudeIfDetected(cwd, targeting.claude);
-    results.push(claudeResult);
-
-    // Set up Codex/AGENTS.md (also used by Cursor since v1.6)
-    const codexResult = await this.setupCodexIfDetected(cwd, targeting.codex);
-    results.push(codexResult);
+    // Install the selected surfaces. With no --surfaces flag, all are installed;
+    // there is no detection gating — project-local integration files are cheap
+    // and harmless, and installing them all is what makes the skill portable.
+    const selected = this.resolveSurfaces();
+    const skippedSurfaces: string[] = [];
+    for (const id of SETUP_SURFACE_IDS) {
+      if (!selected.has(id)) {
+        skippedSurfaces.push(SURFACE_DISPLAY_NAME[id]);
+        continue;
+      }
+      results.push(await this.installSurface(id, cwd));
+    }
 
     // Report results
     const installed = results.filter((r) => r.installed && !r.alreadyInstalled);
     const alreadyInstalled = results.filter((r) => r.alreadyInstalled);
-    const skipped = results.filter((r) => !r.detected);
+    const failed = results.filter((r) => r.error);
 
     if (installed.length > 0) {
       console.log(colors.bold('Configured integrations:'));
@@ -1908,20 +1926,17 @@ class SetupAutoHandler extends BaseCommand {
       }
     }
 
-    if (skipped.length > 0 && (installed.length > 0 || alreadyInstalled.length > 0)) {
-      console.log(colors.dim('Not detected (skipped):'));
-      for (const r of skipped) {
-        console.log(`  ${colors.dim('-')} ${r.name}`);
+    if (skippedSurfaces.length > 0) {
+      console.log(colors.dim('Skipped (not in --surfaces):'));
+      for (const name of skippedSurfaces) {
+        console.log(`  ${colors.dim('-')} ${name}`);
       }
     }
 
-    if (installed.length === 0 && alreadyInstalled.length === 0) {
-      console.log(colors.dim('No coding agents detected.'));
-      console.log('');
-      console.log(
-        'Install a coding agent (Claude Code, Codex, or any AGENTS.md-compatible tool) and re-run:',
-      );
-      console.log('  tbd setup --auto');
+    if (failed.length > 0) {
+      for (const r of failed) {
+        console.log(colors.warn(`  ! ${r.name}: ${r.error}`));
+      }
     }
   }
 
@@ -1970,75 +1985,90 @@ class SetupAutoHandler extends BaseCommand {
   }
 
   /**
-   * Write the canonical portable Agent Skill to .agents/skills/tbd/SKILL.md.
-   * Runs for every initialized repo, independent of agent detection, so the
-   * skill is portable across Codex, Gemini CLI, Cursor, and other clients.
+   * Resolve the set of surfaces to install from `--surfaces=<comma-list>`. With
+   * the flag omitted, every surface is installed. `all` is an alias for the full
+   * set; an unknown surface ID is a hard error.
    */
-  private async installPortableSkill(cwd: string): Promise<void> {
-    const colors = this.output.getColors();
-    if (this.checkDryRun('Would install portable Agent Skill', { path: AGENTS_SKILL_DISPLAY })) {
-      return;
+  private resolveSurfaces(): Set<SurfaceId> {
+    const opts: { surfaces?: string } = this.cmd.optsWithGlobals();
+    if (opts.surfaces === undefined) {
+      return new Set(SETUP_SURFACE_IDS);
     }
-    const { portable } = getAgentSkillPaths(cwd);
-    const payload = await buildSkillPayload(this.ctx.quiet);
-    await writeSkillFile(portable, payload);
-    console.log(`  ${colors.success('✓')} Portable Agent Skill (${AGENTS_SKILL_DISPLAY})`);
+    const valid = new Set<string>(SETUP_SURFACE_IDS);
+    const requested = opts.surfaces
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    const selected = new Set<SurfaceId>();
+    for (const name of requested) {
+      if (name === 'all') {
+        for (const id of SETUP_SURFACE_IDS) selected.add(id);
+        continue;
+      }
+      if (valid.has(name)) {
+        selected.add(name as SurfaceId);
+        continue;
+      }
+      throw new CLIError(
+        `Unknown surface "${name}". Valid surfaces: ${SETUP_SURFACE_IDS.join(', ')}, all.`,
+      );
+    }
+    return selected;
+  }
+
+  /** Dispatch the install for a single surface by ID. */
+  private async installSurface(id: SurfaceId, cwd: string): Promise<AutoSetupResult> {
+    switch (id) {
+      case 'portable':
+        return this.installPortableSurface(cwd);
+      case 'agents-md':
+        return this.installAgentsMdSurface(cwd);
+      case 'claude':
+        return this.installClaudeSurface(cwd);
+      case 'codex':
+        return this.installCodexSurface(cwd);
+    }
   }
 
   /**
-   * Resolve which agent surfaces to install from the explicit targeting flags.
-   * `--all`/`--claude`/`--codex` force surfaces on (and suppress auto-detection
-   * of untargeted surfaces); `--skip-claude`/`--skip-codex` force them off; with
-   * no targeting flag each surface falls back to detection-based auto behavior.
+   * Write the canonical portable Agent Skill to .agents/skills/tbd/SKILL.md.
+   * Read natively by Codex, Gemini CLI, Cursor, and other Agent Skills clients.
    */
-  private resolveTargeting(): { claude: SurfaceMode; codex: SurfaceMode } {
-    const opts: {
-      all?: boolean;
-      claude?: boolean;
-      codex?: boolean;
-      skipClaude?: boolean;
-      skipCodex?: boolean;
-    } = this.cmd.optsWithGlobals();
-    const all = opts.all === true;
-    const anyPositive = all || opts.claude === true || opts.codex === true;
-    const resolve = (on: boolean | undefined, skip: boolean | undefined): SurfaceMode => {
-      if (skip === true) return 'off';
-      if (on === true || all) return 'on';
-      return anyPositive ? 'off' : 'auto';
+  private async installPortableSurface(cwd: string): Promise<AutoSetupResult> {
+    const result: AutoSetupResult = {
+      name: SURFACE_DISPLAY_NAME.portable,
+      detected: true,
+      installed: false,
+      alreadyInstalled: false,
     };
-    return {
-      claude: resolve(opts.claude, opts.skipClaude),
-      codex: resolve(opts.codex, opts.skipCodex),
-    };
+    if (this.checkDryRun('Would install portable Agent Skill', { path: AGENTS_SKILL_DISPLAY })) {
+      return result;
+    }
+    try {
+      const { portable } = getAgentSkillPaths(cwd);
+      const payload = await buildSkillPayload(this.ctx.quiet);
+      await writeSkillFile(portable, payload);
+      result.installed = true;
+    } catch (error) {
+      // The format guard is a hard stop — surface it instead of swallowing.
+      if (error instanceof CLIError) {
+        throw error;
+      }
+      result.error = (error as Error).message;
+    }
+    return result;
   }
 
-  private async setupClaudeIfDetected(cwd: string, mode: SurfaceMode): Promise<AutoSetupResult> {
+  /** Install the Claude Code surface: skill mirror + .claude/settings.json hooks. */
+  private async installClaudeSurface(cwd: string): Promise<AutoSetupResult> {
     const result: AutoSetupResult = {
-      name: 'Claude Code',
-      detected: false,
+      name: SURFACE_DISPLAY_NAME.claude,
+      detected: true,
       installed: false,
       alreadyInstalled: false,
     };
 
-    if (mode === 'off') {
-      return result;
-    }
-
-    if (mode === 'auto') {
-      // Detect Claude Code: check for ~/.claude/ directory or CLAUDE_* env vars.
-      // We check the global dir for DETECTION only, not for installation.
-      const hasClaudeDir = await pathExists(GLOBAL_CLAUDE_DIR);
-      const hasClaudeEnv = Object.keys(process.env).some((k) => k.startsWith('CLAUDE_'));
-      if (!hasClaudeDir && !hasClaudeEnv) {
-        return result;
-      }
-    }
-
-    result.detected = true;
-
-    // Check if already installed (project-local settings - all installs are project-local)
     const claudePaths = getClaudePaths(cwd);
-
     try {
       if (await pathExists(claudePaths.settings)) {
         const content = await readFile(claudePaths.settings, 'utf-8');
@@ -2055,69 +2085,80 @@ class SetupAutoHandler extends BaseCommand {
           );
           if (hasTbdHook && (await pathExists(claudePaths.skill))) {
             result.alreadyInstalled = true;
-            // Note: We still run the handler to update the skill file content
-            // even if hooks are already installed. This ensures users get the
-            // latest skill file when running `tbd setup --auto`.
+            // Still run the handler to refresh the skill file content.
           }
         }
       }
 
-      // Install/update Claude Code setup (always runs to update skill file)
       const handler = new SetupClaudeHandler(this.cmd);
       handler.setProjectDir(cwd);
       await handler.run({});
       result.installed = true;
     } catch (error) {
+      // The format guard is a hard stop — surface it instead of swallowing.
+      if (error instanceof CLIError) {
+        throw error;
+      }
       result.error = (error as Error).message;
     }
 
     return result;
   }
 
-  private async setupCodexIfDetected(cwd: string, mode: SurfaceMode): Promise<AutoSetupResult> {
+  /** Install the AGENTS.md surface: the tbd managed block only (no Codex hooks). */
+  private async installAgentsMdSurface(cwd: string): Promise<AutoSetupResult> {
     const result: AutoSetupResult = {
-      name: 'Codex/AGENTS.md',
-      detected: false,
+      name: SURFACE_DISPLAY_NAME['agents-md'],
+      detected: true,
       installed: false,
       alreadyInstalled: false,
     };
 
-    if (mode === 'off') {
-      return result;
-    }
-
-    const agentsPath = getAgentsMdPath(cwd);
-    const hasAgentsMd = await pathExists(agentsPath);
-
-    if (mode === 'auto') {
-      // Detect Codex: check for existing AGENTS.md or CODEX_* env vars
-      const hasCodexEnv = Object.keys(process.env).some((k) => k.startsWith('CODEX_'));
-      if (!hasAgentsMd && !hasCodexEnv) {
-        return result;
-      }
-    }
-
-    result.detected = true;
-
-    // Check if already has tbd section
-    if (hasAgentsMd) {
-      const content = await readFile(agentsPath, 'utf-8');
-      if (content.includes('BEGIN TBD INTEGRATION')) {
-        result.alreadyInstalled = true;
-        // Note: We still run the handler to update the AGENTS.md content
-        // even if tbd section exists. This ensures users get the latest
-        // content when running `tbd setup --auto`.
-      }
-    }
-
     try {
-      // Install/update Codex AGENTS.md (always runs to update content)
+      const agentsPath = getAgentsMdPath(cwd);
+      if (await pathExists(agentsPath)) {
+        const content = await readFile(agentsPath, 'utf-8');
+        if (content.includes('BEGIN TBD INTEGRATION')) {
+          result.alreadyInstalled = true;
+          // Still run the handler to refresh the managed block.
+        }
+      }
+
       const handler = new SetupCodexHandler(this.cmd);
       handler.setProjectDir(cwd);
-      await handler.run({});
+      await handler.runAgentsMdOnly();
       result.installed = true;
     } catch (error) {
       // The format guard is a hard stop — surface it instead of swallowing.
+      if (error instanceof CLIError) {
+        throw error;
+      }
+      result.error = (error as Error).message;
+    }
+
+    return result;
+  }
+
+  /** Install the Codex surface: .codex/hooks.json + .codex/ lifecycle scripts. */
+  private async installCodexSurface(cwd: string): Promise<AutoSetupResult> {
+    const result: AutoSetupResult = {
+      name: SURFACE_DISPLAY_NAME.codex,
+      detected: true,
+      installed: false,
+      alreadyInstalled: false,
+    };
+
+    try {
+      if (await pathExists(getCodexPaths(cwd).hooks)) {
+        result.alreadyInstalled = true;
+        // Still run the handler to refresh the hooks and scripts.
+      }
+
+      const handler = new SetupCodexHandler(this.cmd);
+      handler.setProjectDir(cwd);
+      await handler.runCodexHooksOnly();
+      result.installed = true;
+    } catch (error) {
       if (error instanceof CLIError) {
         throw error;
       }
@@ -2137,11 +2178,10 @@ export const setupCommand = new Command('setup')
   .option('--prefix <name>', 'Project prefix for issue IDs (required for fresh setup)')
   .option('--force', 'Allow non-recommended prefix format (not 2-8 alphabetic)')
   .option('--no-gh-cli', 'Disable automatic GitHub CLI installation hook')
-  .option('--all', 'Install every supported agent surface (Claude + Codex)')
-  .option('--claude', 'Install the Claude Code surface (skill mirror + hooks)')
-  .option('--codex', 'Install the Codex surface (AGENTS.md block + .codex hooks)')
-  .option('--skip-claude', 'Skip the Claude Code surface even if detected')
-  .option('--skip-codex', 'Skip the Codex surface even if detected')
+  .option(
+    '--surfaces <list>',
+    'Comma-separated agent surfaces to install: portable, agents-md, claude, codex (or "all"). Default: all',
+  )
   .action(async (options: SetupDefaultOptions, command) => {
     // If --auto or --interactive flag is set, run the default handler
     if (options.auto || options.interactive) {
@@ -2175,6 +2215,9 @@ export const setupCommand = new Command('setup')
     console.log('  --prefix <name>     Project prefix for issue IDs (2-8 alphabetic recommended)');
     console.log('  --force             Allow non-recommended prefix format');
     console.log('  --no-gh-cli         Disable automatic GitHub CLI installation hook');
+    console.log(
+      '  --surfaces <list>   Agent surfaces to install: portable,agents-md,claude,codex,all (default: all)',
+    );
     console.log('');
     console.log('Examples:');
     console.log('  tbd setup --auto --prefix=tbd   # Full automatic setup with prefix');

--- a/packages/tbd/src/cli/commands/status.ts
+++ b/packages/tbd/src/cli/commands/status.ts
@@ -341,7 +341,7 @@ class StatusHandler extends BaseCommand {
         path: data.integrations.claude_code_path,
       },
       {
-        name: 'Codex AGENTS.md',
+        name: 'AGENTS.md',
         installed: data.integrations.codex,
         path: data.integrations.codex_path,
       },

--- a/packages/tbd/src/lib/integration-paths.ts
+++ b/packages/tbd/src/lib/integration-paths.ts
@@ -116,30 +116,13 @@ export const CODEX_HOOKS_REL = '.codex/hooks.json';
  */
 export const CODEX_CONFIG_REL = '.codex/config.toml';
 
-// =============================================================================
-// Shared Agent Scripts (neutral location, referenced by every agent's hooks)
-// =============================================================================
-
-/**
- * Neutral directory for hook scripts shared across agents. Kept out of
- * `.claude/` so Codex hooks never depend on Claude Code setup.
- */
-export const AGENT_SCRIPTS_DIR_REL = 'scripts/agent';
-
-/**
- * Shared session bootstrap script (runs `tbd prime`).
- */
-export const SHARED_SESSION_SCRIPT_REL = 'scripts/agent/tbd-session.sh';
-
-/**
- * Shared close-protocol reminder script.
- */
-export const SHARED_CLOSING_REMINDER_REL = 'scripts/agent/tbd-closing-reminder.sh';
-
-/**
- * Shared gh CLI ensure script.
- */
-export const SHARED_GH_CLI_SCRIPT_REL = 'scripts/agent/ensure-gh-cli.sh';
+// Note on hook scripts: each agent surface writes its own copy of the hook
+// scripts under its own directory — Claude Code under `.claude/scripts/` and
+// Codex under `.codex/` — rather than sharing a single neutral `scripts/agent/`
+// copy. Per-agent copies keep each surface self-contained: Codex hooks never
+// reference `.claude/`, so Codex setup does not depend on Claude Code setup.
+// (See cli-agent-skill-patterns §6.6: per-agent copies are a valid alternative
+// to a shared neutral script.)
 
 // =============================================================================
 // Global Paths (for detection only - NOT for installation)
@@ -223,24 +206,6 @@ export function getCodexPaths(projectRoot: string) {
     hooks: join(projectRoot, CODEX_HOOKS_REL),
     /** .codex/config.toml */
     config: join(projectRoot, CODEX_CONFIG_REL),
-  };
-}
-
-/**
- * Get shared agent script paths (neutral location used by every agent's hooks).
- *
- * @param projectRoot - The project root directory
- */
-export function getSharedScriptPaths(projectRoot: string) {
-  return {
-    /** scripts/agent/ directory */
-    dir: join(projectRoot, AGENT_SCRIPTS_DIR_REL),
-    /** scripts/agent/tbd-session.sh */
-    sessionScript: join(projectRoot, SHARED_SESSION_SCRIPT_REL),
-    /** scripts/agent/tbd-closing-reminder.sh */
-    closingReminder: join(projectRoot, SHARED_CLOSING_REMINDER_REL),
-    /** scripts/agent/ensure-gh-cli.sh */
-    ghCliScript: join(projectRoot, SHARED_GH_CLI_SCRIPT_REL),
   };
 }
 

--- a/packages/tbd/tests/cli-beads.tryscript.md
+++ b/packages/tbd/tests/cli-beads.tryscript.md
@@ -46,7 +46,7 @@ Tests for `tbd setup --from-beads` which migrates from Beads to tbd.
 
 ```console
 $ tbd setup --help | grep -E "(--from-beads|Migrate)"
-  --from-beads     Migrate from Beads to tbd
+  --from-beads       Migrate from Beads to tbd
 ? 0
 ```
 

--- a/packages/tbd/tests/cli-orientation-golden.tryscript.md
+++ b/packages/tbd/tests/cli-orientation-golden.tryscript.md
@@ -55,7 +55,7 @@ ID prefix: go-
 INTEGRATIONS
   ✗ Portable Agent Skill (./.agents/skills/tbd/SKILL.md)
   ✗ Claude Code hooks (./.claude/settings.json)
-  ✗ Codex AGENTS.md (./AGENTS.md)
+  ✗ AGENTS.md (./AGENTS.md)
   ✗ Codex hooks (./.codex/hooks.json)
 
 Run tbd setup auto to configure detected agents
@@ -98,7 +98,7 @@ INTEGRATIONS
     Run: tbd setup --auto
 ⚠ Claude Code skill - not installed (.claude/skills/tbd/SKILL.md)
     Run: tbd setup --auto
-⚠ Codex AGENTS.md - not installed (AGENTS.md)
+⚠ AGENTS.md - not installed (AGENTS.md)
     Run: tbd setup --auto
 ⚠ Codex hooks - not installed (.codex/hooks.json)
     Run: tbd setup --auto

--- a/packages/tbd/tests/cli-setup-commands.tryscript.md
+++ b/packages/tbd/tests/cli-setup-commands.tryscript.md
@@ -37,28 +37,26 @@ Usage: tbd setup [options]
 Configure tbd integration with editors and tools
 
 Options:
-  --auto           Non-interactive mode with smart defaults (for agents/scripts)
-  --interactive    Interactive mode with prompts (for humans)
-  --from-beads     Migrate from Beads to tbd
-  --prefix <name>  Project prefix for issue IDs (required for fresh setup)
-  --force          Allow non-recommended prefix format (not 2-8 alphabetic)
-  --no-gh-cli      Disable automatic GitHub CLI installation hook
-  --all            Install every supported agent surface (Claude + Codex)
-  --claude         Install the Claude Code surface (skill mirror + hooks)
-  --codex          Install the Codex surface (AGENTS.md block + .codex hooks)
-  --skip-claude    Skip the Claude Code surface even if detected
-  --skip-codex     Skip the Codex surface even if detected
-  -h, --help       display help for command
+  --auto             Non-interactive mode with smart defaults (for
+                     agents/scripts)
+  --interactive      Interactive mode with prompts (for humans)
+  --from-beads       Migrate from Beads to tbd
+  --prefix <name>    Project prefix for issue IDs (required for fresh setup)
+  --force            Allow non-recommended prefix format (not 2-8 alphabetic)
+  --no-gh-cli        Disable automatic GitHub CLI installation hook
+  --surfaces <list>  Comma-separated agent surfaces to install: portable,
+                     agents-md, claude, codex (or "all"). Default: all
+  -h, --help         display help for command
 
 Global Options:
-  --version        Show version number
-  --dry-run        Show what would be done without making changes
-  --verbose        Enable verbose output
-  --quiet          Suppress non-essential output
-  --json           Output as JSON
-  --color <when>   Colorize output: auto, always, never (default: "auto")
-  --no-sync        Skip automatic sync after write operations
-  --debug          Show internal IDs alongside public IDs for debugging
+  --version          Show version number
+  --dry-run          Show what would be done without making changes
+  --verbose          Enable verbose output
+  --quiet            Suppress non-essential output
+  --json             Output as JSON
+  --color <when>     Colorize output: auto, always, never (default: "auto")
+  --no-sync          Skip automatic sync after write operations
+  --debug            Show internal IDs alongside public IDs for debugging
 
 IMPORTANT:
   Agents unfamiliar with tbd should run `tbd prime` for full workflow context.

--- a/packages/tbd/tests/gitignore-policy.test.ts
+++ b/packages/tbd/tests/gitignore-policy.test.ts
@@ -2,10 +2,10 @@
  * Guards the gitignore policy for agent integration files.
  *
  * Generated integration artifacts that travel with the repository (the portable
- * Agent Skill, the Claude mirror, AGENTS.md, Codex hooks, shared scripts, and
- * the distribution skill) must NOT be gitignored, or `tbd setup`'s dogfooded
- * output would silently fail to be committed. Only regenerable caches may be
- * ignored.
+ * Agent Skill, the Claude mirror, AGENTS.md, Codex hooks and their per-agent
+ * scripts, and the distribution skill) must NOT be gitignored, or `tbd setup`'s
+ * dogfooded output would silently fail to be committed. Only regenerable caches
+ * may be ignored.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -29,7 +29,6 @@ describe('gitignore policy for agent integration files', () => {
       'AGENTS.md',
       '.codex/hooks.json',
       '.codex/tbd-session.sh',
-      'scripts/agent/tbd-session.sh',
       'skills/tbd/SKILL.md',
     ];
     for (const path of mustBeTracked) {

--- a/packages/tbd/tests/setup-flows.test.ts
+++ b/packages/tbd/tests/setup-flows.test.ts
@@ -287,50 +287,51 @@ describe('setup flows', { timeout: isWindows ? 60000 : 15000 }, () => {
     });
   });
 
-  describe('agent-targeting flags', () => {
-    it('--codex installs only the Codex surface and skips Claude', async () => {
+  describe('--surfaces selector', () => {
+    it('default (no --surfaces) installs all four surfaces', async () => {
       initGitRepo();
 
-      // Harness sets CLAUDE_CODE=1, but --codex targets Codex explicitly, so the
-      // Claude surface must be suppressed.
-      const result = runTbd(['setup', '--auto', '--prefix=test', '--codex']);
+      const result = runTbd(['setup', '--auto', '--prefix=test']);
       expect(result.status).toBe(0);
 
-      // Codex surface present.
-      await access(join(tempDir, 'AGENTS.md'));
-      await access(join(tempDir, '.codex/hooks.json'));
-      // Portable skill is always installed.
       await access(join(tempDir, '.agents/skills/tbd/SKILL.md'));
-      // Claude surface suppressed.
+      await access(join(tempDir, 'AGENTS.md'));
+      await access(join(tempDir, '.claude/settings.json'));
+      await access(join(tempDir, '.codex/hooks.json'));
+    });
+
+    it('--surfaces=codex installs only the Codex hooks surface', async () => {
+      initGitRepo();
+
+      const result = runTbd(['setup', '--auto', '--prefix=test', '--surfaces=codex']);
+      expect(result.status).toBe(0);
+
+      // Codex hooks present; every other surface suppressed.
+      await access(join(tempDir, '.codex/hooks.json'));
+      await expect(access(join(tempDir, 'AGENTS.md'))).rejects.toThrow();
+      await expect(access(join(tempDir, '.claude/settings.json'))).rejects.toThrow();
+      await expect(access(join(tempDir, '.agents/skills/tbd/SKILL.md'))).rejects.toThrow();
+    });
+
+    it('--surfaces=agents-md,portable installs only those two (codex hooks split off)', async () => {
+      initGitRepo();
+
+      const result = runTbd(['setup', '--auto', '--prefix=test', '--surfaces=agents-md,portable']);
+      expect(result.status).toBe(0);
+
+      await access(join(tempDir, 'AGENTS.md'));
+      await access(join(tempDir, '.agents/skills/tbd/SKILL.md'));
+      // agents-md is independent of the codex hooks surface.
+      await expect(access(join(tempDir, '.codex/hooks.json'))).rejects.toThrow();
       await expect(access(join(tempDir, '.claude/settings.json'))).rejects.toThrow();
     });
 
-    it('--skip-codex suppresses Codex even when CODEX_HOME is set', async () => {
+    it('rejects an unknown surface id', () => {
       initGitRepo();
 
-      const result = runTbd(['setup', '--auto', '--prefix=test', '--skip-codex'], tempDir, {
-        CODEX_HOME: tempDir,
-      });
-      expect(result.status).toBe(0);
-
-      await expect(access(join(tempDir, '.codex/hooks.json'))).rejects.toThrow();
-    });
-  });
-
-  describe('portable skill without Claude detection', () => {
-    it('writes .agents/skills even when no Claude signals are present', async () => {
-      initGitRepo();
-
-      // Clear Claude/Codex detection signals so only the unconditional portable
-      // skill install runs.
-      const result = runTbd(['setup', '--auto', '--prefix=test'], tempDir, {
-        CLAUDE_CODE: '',
-        HOME: tempDir,
-        USERPROFILE: tempDir,
-      });
-      expect(result.status).toBe(0);
-
-      await access(join(tempDir, '.agents/skills/tbd/SKILL.md'));
+      const result = runTbd(['setup', '--auto', '--prefix=test', '--surfaces=bogus']);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr + result.stdout).toContain('Unknown surface');
     });
   });
 


### PR DESCRIPTION
## Summary

Rescopes tbd's multi-agent setup to a single, extensible `--surfaces` selector, and
implements it. Started as a design-lock (spec) and now includes the full implementation
on this branch.

### The interface change

- **One flag replaces five.** `--surfaces=<comma-list>` replaces
  `--all` / `--claude` / `--codex` / `--skip-claude` / `--skip-codex`. Default (flag
  omitted) installs **all** surfaces; `--surfaces` restricts to a list, with `all` as an
  alias; an unknown id is a hard error. A one-time install-flag break is acceptable —
  agents read `tbd setup --help` first.
- **`agents-md` is now its own surface**, split out of the bundled `codex` surface, so the
  `AGENTS.md` block and Codex hooks install independently. Surface IDs: `portable`,
  `agents-md`, `claude`, `codex`.
- **Extensible registry.** The fixed `{ claude, codex }` targeting and the bespoke
  `setupClaudeIfDetected`/`setupCodexIfDetected` methods are replaced by a surface
  registry the run loop iterates. Adding an agent is one registry entry + one
  `installSurface` case — no new flag pair. Detection gating is gone (default = all).

### Why

Surfaced while reviewing why Codex's `external_migration` import wrote a `.codex/hooks.json`
referencing `.claude/scripts/` — the cross-agent coupling this spec's Non-Goals forbid.
tbd's own `setup --codex` writes Codex-local paths correctly; the Codex import did not.
That review also exposed the stale spec status and the non-extensible flag model.

## Implementation (landed)

- [x] **`tbd-zd4h`** — `--surfaces` selector + surface registry; `agents-md`/`codex`
  split; help epilog. (`setup.ts`)
- [x] **`tbd-orup`** — removed the **dead** `scripts/agent/` shared-script constants from
  `integration-paths.ts`. tbd keeps per-agent script copies (`.claude/scripts/`,
  `.codex/`); Codex hooks never reference `.claude/` — a valid alternative per
  cli-agent-skill-patterns §6.6. (Wiring a shared neutral script would require migrating
  Claude's hook paths — out of scope here.)
- [x] **`tbd-l2ym`** — relabeled the `Codex AGENTS.md` diagnostic to `AGENTS.md` in
  `status`/`doctor` (it is now its own surface, read by many agents).
- [x] **`tbd-shsb`** — audited the `@latest` install hints: all are forward-compatibility
  "requires newer tbd" errors (`doctor.ts`, `setup.ts`, `tbd-format.ts`) or the
  first-install bootstrap (`output.ts`), which **correctly** fetch the newest release. The
  session script already pins to `PINNED_NPM_VERSION`. No code change needed; the spec's
  pinning section was corrected to record this.

## Tests / quality gates

- Rewrote the targeting block in `setup-flows.test.ts` for `--surfaces`: default-all
  installs four surfaces; `--surfaces=codex` installs only Codex hooks; `--surfaces=
  agents-md,portable` installs only those two; unknown id errors.
- Updated help/label goldens: `cli-setup-commands`, `cli-beads` (option-column re-wrap),
  `cli-orientation-golden` (AGENTS.md label); dropped the never-written `scripts/agent`
  path from `gitignore-policy`.
- **typecheck + eslint** (`--max-warnings 0`): clean.
- **vitest**: 1146/1146 pass.
- **tryscripts**: 811 pass. The only 6 failures are in `cli-sync.tryscript.md` and are
  **pre-existing/environment-only** — they fail identically on clean `main` with
  `fatal: 'origin' does not appear to be a git repository` (the tryscript sandbox has no
  remote). Unrelated to this change.

See the spec's **Setup Behavior** and **Resolved Decisions (2026-06-02)** for the full
design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
