### PR TITLE
Fix #155: structured field-level merge for bead YAML in tbd sync

### DIFF
--- a/docs/project/specs/active/plan-2026-06-03-tbd-sync-structured-bead-merge.md
+++ b/docs/project/specs/active/plan-2026-06-03-tbd-sync-structured-bead-merge.md
@@ -1,0 +1,337 @@
+# Feature: Structured field-level merge for bead YAML in `tbd sync` (no conflict markers, no silent loss)
+
+**Date:** 2026-06-03 (last updated 2026-06-03)
+
+**Author:** Joshua Levy (with agent assistance)
+
+**Status:** Draft
+
+## Overview
+
+Issue **#155** reports that `tbd sync` (v0.2.2) corrupts a bead file when two sessions
+concurrently edit the **same epic’s `child_order_hints` list** (and its `version`
+counter) before syncing.
+Sync delegates reconciliation to git’s **line-based** merge, which writes literal
+`<<<<<<< / ======= / >>>>>>>` markers into the bead’s YAML. The markers make the file
+invalid YAML; `tbd` then **silently skips** the file (`Skipping invalid issue file: …`),
+so the epic and all of its child wiring drop out of the working set.
+In at least one path sync still printed `✓ Synced: received N updated` while leaving the
+corrupted file behind.
+
+Both conflicting fields are semantically mergeable — `child_order_hints` is an
+append-only **set** of child IDs and `version` is a **monotonic counter** — so this
+should be a clean auto-merge, never a textual conflict.
+
+The fix is to stop relying on git’s textual merge for bead `.md` files and instead route
+every conflicted bead through the project’s **existing** field-level three-way merge
+engine (`mergeIssues`), fed with a **real common-ancestor base** so set-union actually
+combines both sides.
+Sync must also **fail loudly** when any bead fails to parse, rather than reporting
+success.
+
+## Goals
+
+- Concurrent edits to a shared epic’s `child_order_hints` merge to the **union** of both
+  sides (deduped), and `version` to the **max** — automatically, with no manual repair.
+- A bead `.md` file is **never** left on disk (or committed) containing git conflict
+  markers.
+- If any bead file fails to parse during or after a sync, sync **exits non-zero** and
+  names the offending file(s) — it never prints `received N updated` over a corrupted
+  store.
+- All bead merges in the codebase use one consistent field-level engine and strategy
+  table; no path silently drops a side without an attic artifact.
+
+## Non-Goals
+
+- No change to the on-disk storage format (`f04`) or the `git-common-dir-v1` layout.
+- No new interactive merge UI.
+- No change to the unrelated-history rescue flow
+  (`plan-2026-05-29-tbd-sync-unrelated-history-hardening.md`); that path already
+  preserves every losing side to `attic/conflicts/` and is reused as-is.
+- Not introducing a git custom merge **driver** for issue files (see Open Questions for
+  why the post-merge resolution approach is preferred for tbd’s ephemeral-clone use
+  case).
+- Issue #135 (silent fallback on a missing worktree) is tracked separately and already
+  largely fixed; out of scope here.
+
+## Background
+
+### The three coupled defects (verified against current source, v0.2.x)
+
+The single user-visible symptom is produced by three distinct defects that compound:
+
+**Defect A — `child_order_hints` uses the wrong merge strategy.** `FIELD_STRATEGIES`
+(`packages/tbd/src/file/git.ts:387`) declares `child_order_hints: 'lww'`, and
+`tbd-design.md` §3.5 documents it as “soft ordering, LWW”. But `child_order_hints` is
+the parent→child wiring — an append-only set of internal child IDs.
+LWW silently discards one session’s appended child on every concurrent edit.
+The correct strategy is `union` (dedupe), exactly like `labels` and `dependencies`.
+`version` (`max`) and `updated_at` (`max`) are already correct.
+
+**Defect B — the conflict path never actually merges the remote, and passes no base.**
+Both conflict-resolution call sites build the merge from the wrong inputs:
+
+- Pull/merge path (`packages/tbd/src/cli/commands/sync.ts:763-785`): after a failed
+  `git merge`, for each local issue it does
+  `const remoteContent = await git('show', '…origin…:…/<id>.md')` only to test
+  existence, then reads the **local** file as the “remote” side
+  (`readIssue(this.dataSyncDir, id)`) and calls
+  `mergeIssues(null, localIssue, remoteIssue)`. So local and “remote” are identical and
+  `base` is `null`.
+- Push-retry callback (`packages/tbd/src/cli/commands/sync.ts:531-561`): identical
+  mistake — reads `readIssue(this.dataSyncDir, id)` as the remote and passes
+  `base = null`.
+
+`base = null` matters because of how `mergeIssues` behaves (below): with a
+null/synthetic base, the `union` strategy **never combines both sides**.
+
+**Defect C — corrupted files are silently skipped, and sync still reports success.**
+Once git writes markers into the epic file it is invalid YAML. `listIssues`
+(`packages/tbd/src/file/storage.ts:110-128`) catches the parse error, prints
+`Skipping invalid issue file:` via `console.warn`, and `continue`s. Consequences:
+
+1. The corrupted epic is **excluded** from `localIssues`, so the conflict loop in Defect
+   B never even visits it — the markers persist on disk.
+2. The epic vanishes from `tbd list`/`ready`/`show`.
+3. The “received N updated” tally comes from a `git diff` file count (`sync.ts:643-646`,
+   `parseGitDiff`), not from successfully parsed issues, so sync reports
+   `✓ Synced: received N updated` even though a bead is unreadable.
+
+The existing `<<<<<<<` safety check (`sync.ts:848-864`) does catch markers **if they
+reach `git add`** — that is the “louder” second path the reporter saw — but the primary
+failure leaves the file unstaged and the warning easy to miss.
+
+### Why strategy + base are coupled (the key insight)
+
+`mergeIssues` (`packages/tbd/src/file/git.ts:519`) only runs a field’s strategy when
+**both** sides differ from the base:
+
+```text
+if (localVal == baseVal && remoteVal == baseVal) continue;   // unchanged
+if (localVal == baseVal) merged = remoteVal;                 // only remote changed
+if (remoteVal == baseVal) merged = localVal;                 // only local changed
+// else: both changed -> apply strategy (union/max/lww)
+```
+
+When `base` is `null`, `mergeIssues` synthesizes a base from the **lower-version side**
+(`git.ts:529-533`). That synthetic base then *equals one of the two sides entirely*, so
+for `child_order_hints` one side always satisfies `localVal == baseVal` and the code
+takes the **other** side wholesale — the `union` branch is never reached.
+**Therefore changing the strategy to `union` is necessary but not sufficient: sync must
+also supply a real common-ancestor base so both sides’ additions are present as deltas
+and the union actually combines them.**
+
+With a real base `[x]`, `local=[x,A]`, `remote=[x,B]`: both differ → `union` →
+`[x,A,B]`. Correct.
+
+### Audit of every bead-merge site (for consistency)
+
+The user asked that the plan be consistent with all existing merging.
+Full inventory:
+
+| Site | Base today | Reads remote correctly? | Verdict |
+| --- | --- | --- | --- |
+| `mergeIssues` engine (`git.ts:519`) | — | — | Keep; flip `child_order_hints` → `union`. All callers benefit. |
+| `workspace.ts` save (`:351/:361`) / import (`:477/:487`) | real `older` by `updated_at`, else synthetic | yes (source vs target) | Correct pattern. Loser already routed to attic via `saveConflictToAttic`. No change. |
+| Unrelated-history rescue (`git.ts:1858`) | `null` **intentionally** (no common ancestor) | yes (`readBranchIssues`) | Correct by design; preserves every losing side to attic (`git.ts:1860-1864`). No change. |
+| Sync pull/merge conflict (`sync.ts:777`) | `null` (bug) | **no** (reads local) | **Fix** (Defect B). |
+| Sync push-retry callback (`sync.ts:549`) | `null` (bug) | **no** (reads local) | **Fix** (Defect B). |
+| ID mappings: `mergeIdMappings` (union) + `ids.yml merge=union` gitattribute + `resolveIdMappingConflicts` | n/a | yes | Already correct and portable (built-in git union driver). No change. |
+| `doc-sync.ts mergeDocCacheConfig` | n/a | n/a | Doc-cache config, unrelated to beads. No change. |
+
+Consistency rules this spec adopts:
+
+- One engine (`mergeIssues`) and one strategy table for **all** bead merges.
+- A merge that discards a side must always leave an artifact (attic) — never a silent
+  drop and never a raw marker.
+- `union` only truly combines when a real base exists; where no common ancestor exists
+  (rescue), the established attic-preserve behavior is the correct and intended
+  fallback, so flipping `child_order_hints` to `union` is safe there (no regression: the
+  losing side is still preserved).
+
+### Why `pushWithRetry` needs different plumbing than the pull path
+
+`pushWithRetry` (`packages/tbd/src/file/git.ts:765`) on a non-fast-forward only does
+`git fetch` + `onMergeNeeded()` — it runs **no `git merge`**, so there is **no
+conflicted index** (no `:1:/:2:/:3:` stages) in that path.
+The pull path (`sync.ts:692-700`) *does* run a real `git merge`, so it is mid-merge with
+`HEAD` / `MERGE_HEAD`. A uniform way to derive base/ours/theirs that works for **both**
+is `git merge-base <oursRef> <theirsRef>` + `git show <ref>:<path>`, rather than index
+stages:
+
+- Pull path (mid-merge): `oursRef = HEAD`, `theirsRef = MERGE_HEAD`.
+- Push callback (post-fetch, no merge): `oursRef = <syncBranch>`,
+  `theirsRef = <remote>/<syncBranch>`.
+- `base = git merge-base oursRef theirsRef` (may be empty → `null`, e.g. add/add).
+
+## Design
+
+### Approach
+
+Introduce one shared helper that performs a **structured three-way merge of a single
+bead from git refs**, and route both sync conflict paths through it.
+Combined with the strategy flip and a fail-loud guard, markers are never parsed or
+written, the union actually unions, and a corrupted store can never masquerade as a
+successful sync. Two small phases so each is independently testable; TDD (Red → Green →
+Refactor) per project guidelines.
+
+### Components
+
+| Area | File | Change |
+| --- | --- | --- |
+| Strategy | `packages/tbd/src/file/git.ts` `FIELD_STRATEGIES` | `child_order_hints: 'lww'` → `'union'`. |
+| Design doc | `packages/tbd/docs/tbd-design.md` §3.5 | Update rule: `child_order_hints` is an append-only set → `union` (dedupe), with rationale. |
+| New helper | `packages/tbd/src/file/git.ts` (e.g. `mergeBeadAcrossRefs`) | Given worktree, dataSyncDir, issueId, `oursRef`, `theirsRef`: compute `base = merge-base`, read base/ours/theirs via `git show <ref>:<path>`, `parseIssue` each (tolerate missing base/file → `null`/skip), call `mergeIssues(base, ours, theirs)`, return `{ merged, conflicts }`. Never reads a marker-laden working file. |
+| Pull conflict path | `packages/tbd/src/cli/commands/sync.ts:763-877` | Enumerate conflicted beads via `git diff --name-only --diff-filter=U -- '…/issues/*.md'`; for each, call helper with `HEAD`/`MERGE_HEAD`; `writeIssue` clean result; `git add`; route `conflicts` to attic. Remove the read-local-as-remote logic. |
+| Push-retry callback | `packages/tbd/src/cli/commands/sync.ts:531-561` | For each bead differing between `<syncBranch>` and `<remote>/<syncBranch>`, call the same helper; `writeIssue`; collect conflicts. Remove the read-local-as-remote logic. |
+| Fail-loud | `packages/tbd/src/cli/commands/sync.ts` (+ `storage.ts` hook) | Thread `listIssues`’ existing `onInvalidIssue`/`InvalidIssueFile` signal through sync’s reads; if any bead is invalid after merge — or any marker survives the safety check — exit non-zero, name the file(s), and suppress the `received N updated` success line. |
+
+### Detailed design
+
+#### Defect A — strategy flip
+
+`child_order_hints: 'union'`. `unionArrays` (`git.ts:475`) already dedupes content-wise,
+preserving local order then appending new remote items — exactly the append-only-set
+semantics #155 asks for.
+Note (documented): `union` does not honor *deletions* (a child removed on one side
+reappears if still present on the other), which is consistent with
+`labels`/`dependencies` and acceptable because child hints are append-only (children
+leave only via reparent/delete, which rewrite the field on both sides over time).
+
+#### Defect B — `mergeBeadAcrossRefs` helper + both call sites
+
+```text
+async function mergeBeadAcrossRefs(worktreePath, dataSyncDir, issueId, oursRef, theirsRef):
+  path = "<DATA_SYNC_DIR>/issues/<issueId>.md"
+  ours   = parseIssue(await gitShow(oursRef:path))      // required
+  theirs = parseIssue(await gitShow(theirsRef:path))    // if absent -> nothing to merge
+  baseSha = await gitMergeBase(oursRef, theirsRef)       // '' -> null
+  base   = baseSha ? parseIssue(await gitShow(baseSha:path)) : null   // tolerate add/add
+  return mergeIssues(base, ours, theirs)
+```
+
+- Reads come straight from git object refs, so a marker-corrupted **working** file is
+  never parsed; the inputs are always valid committed blobs.
+- The real `base` makes `union`/`max`/`lww` evaluate against a true ancestor, fixing the
+  coupling described in Background.
+- Reuses the existing, well-tested `mergeIssues` engine and `attic` conflict routing —
+  no new merge semantics.
+
+Pull path: after the `git merge` throws, list conflicted beads with `--diff-filter=U`,
+resolve each via the helper, `writeIssue`, `git add`, then the existing safety check +
+merge commit complete the merge.
+Non-conflicted files git already merged cleanly are untouched.
+
+Push callback: compute the differing bead set between `<syncBranch>` and
+`<remote>/<syncBranch>` (e.g. `git diff --name-only`), resolve each via the helper,
+`writeIssue`, collect conflicts, return for the existing re-push loop.
+
+#### Defect C — fail loudly, never trust a corrupted store
+
+- `listIssues` already supports `options.onInvalidIssue` and an `InvalidIssueFile`
+  shape. Sync’s post-merge reads pass a collector; after merge resolution, if any bead is
+  still invalid, throw a `SyncError` naming the files and do **not** emit the success
+  summary.
+- Keep the `<<<<<<<` staged-content safety check (`sync.ts:848-864`) as a backstop; with
+  the structured path it should essentially never fire.
+- Reporting: only print `received N updated` when the post-merge store parses cleanly.
+
+### API Changes
+
+- New exported helper in `packages/tbd/src/file/git.ts` (e.g. `mergeBeadAcrossRefs`) for
+  unit testing.
+- `child_order_hints` strategy value changes (internal table).
+- No public CLI flag changes.
+
+## Implementation Plan
+
+### Phase 1: Structured field-level merge (fixes the corruption + data loss)
+
+- [ ] Failing unit test: `mergeIssues` with a real base where both sides append distinct
+  `child_order_hints` → union (deduped); `version`/`updated_at` stay `max`. (Red.)
+- [ ] Flip `child_order_hints` → `union` in `FIELD_STRATEGIES`; update `tbd-design.md`
+  §3.5 and any golden output that pins the strategy table.
+  (Green.)
+- [ ] Add `mergeBeadAcrossRefs` helper (merge-base + `git show` for base/ours/theirs;
+  tolerate missing base/file).
+  Unit-test it against a temp repo: ancestor + two divergent appends → clean union, no
+  markers; add/add (no base) → falls back to the synthetic-base behavior unchanged.
+- [ ] Rewrite the pull/merge conflict path (`sync.ts:763-877`) to enumerate
+  `--diff-filter=U` beads and resolve each via the helper (`HEAD`/`MERGE_HEAD`); keep
+  attic routing, ids.yml union, and the marker safety check.
+- [ ] Rewrite the push-retry callback (`sync.ts:531-561`) to resolve differing beads via
+  the same helper against `<syncBranch>`/`<remote>/<syncBranch>`.
+- [ ] e2e tryscript modeled on #155: two clones, concurrent `--parent` edits to one
+  epic, sync → assert no markers on disk, epic present in `tbd show`,
+  `child_order_hints` is the deduped union, `version` is the max.
+
+### Phase 2: Fail loudly on corrupted beads
+
+- [ ] Failing test: a sync that would leave an unparseable bead exits non-zero, names
+  the file, and does **not** print `received N updated`. (Red.)
+- [ ] Thread `onInvalidIssue` through sync’s reads; throw `SyncError` on any post-merge
+  invalid bead; gate the success summary on a clean parse.
+  (Green.)
+- [ ] Regression assertion in the tryscript: a deliberately corrupted bead makes sync
+  fail loudly rather than reporting success.
+
+## Testing Strategy
+
+- **Unit** — `mergeIssues` union/max matrix for `child_order_hints`/`version` with a
+  real base; `mergeBeadAcrossRefs` against a temp git repo (ancestor + divergent
+  appends; add/add with no base; missing-on-one-side).
+- **Integration** — drive a real `git merge` conflict on a bead in a temp worktree and
+  assert the resolved file is clean union YAML with no markers, plus an attic entry only
+  when a side is genuinely discarded (scalar LWW), never for set/counter fields.
+- **Golden/tryscript** — extend the `packages/tbd/tests/cli-sync-*.tryscript.md` family
+  with the #155 reproduction and the fail-loud case; filter unstable fields (timestamps,
+  ULIDs) per the golden-testing guideline.
+- TDD: one failing test per defect before its fix; run the full (non-long) suite each
+  step; keep the strategy/doc change and the behavioral merge change in separate
+  commits.
+
+## Rollout Plan
+
+Lands on `claude/kind-cori-lSdNU` → draft PR referencing #155. Phase 1 alone stops the
+corruption and data loss and is shippable; Phase 2 adds the loud-failure guard.
+Ships in the next `get-tbd` release; no migration needed (existing corrupted files are
+repaired by re-running sync after upgrade, since the structured path resolves the
+markers from git refs).
+
+## Open Questions
+
+- **Resolved (per user):** `child_order_hints` becomes `union` (design doc updated to
+  match), and we do the full fix (structured merge + real base + fail-loud), not just
+  the strategy flip.
+- **Unify the two conflict paths?** The cleanest end state is for the push-retry path to
+  perform the same real `git merge` + structured resolution as the pull path, collapsing
+  to one merge code path.
+  Lean: route both through `mergeBeadAcrossRefs` now (low blast radius); consider fully
+  unifying `pushWithRetry` in a follow-up if the duplication proves fragile.
+- **Custom git merge driver for `issues/*.md`?** Rejected for now: unlike the built-in
+  `merge=union` used for `ids.yml`, a custom driver must be configured per-clone in git
+  config; on a fresh/ephemeral clone (tbd’s headline environment) an unconfigured driver
+  silently falls back to text merge — re-introducing the exact failure.
+  Post-merge structured resolution needs no local git config and is robust on fresh
+  clones.
+
+## References
+
+- Issue: #155 (concurrent epic `child_order_hints`/`version` edits → conflict markers →
+  silent skip).
+- `packages/tbd/src/file/git.ts` — `FIELD_STRATEGIES` (370), `child_order_hints`
+  strategy (387), `unionArrays` (475), `mergeIssues` (519), synthetic-base logic
+  (529-533), union branch (646), `pushWithRetry` (765), rescue `mergeIssues(null,…)`
+  (1858), `GitError` /`exitCodeOf` (29-80).
+- `packages/tbd/src/cli/commands/sync.ts` — push callback (531-561), `git merge` (692),
+  pull conflict path + marker safety check (763-864), received tally (635-652).
+- `packages/tbd/src/file/storage.ts` — `listIssues`/`onInvalidIssue` (76-144).
+- `packages/tbd/src/file/workspace.ts` — save/import merges (337-412, 463-499).
+- `packages/tbd/docs/tbd-design.md` §3.5 Merge Rules (2224+), `child_order_hints` rule
+  (2293).
+- Prior art: `plan-2026-05-29-tbd-sync-unrelated-history-hardening.md` (rescue path that
+  reuses `mergeIssues` + attic preservation).
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/docs/project/specs/active/plan-2026-06-03-tbd-sync-structured-bead-merge.md
+++ b/docs/project/specs/active/plan-2026-06-03-tbd-sync-structured-bead-merge.md
@@ -4,7 +4,7 @@
 
 **Author:** Joshua Levy (with agent assistance)
 
-**Status:** Draft
+**Status:** Implemented (PR #157; senior-review round folded in)
 
 ## Overview
 
@@ -32,7 +32,9 @@ success.
 ## Goals
 
 - Concurrent edits to a shared epic’s `child_order_hints` merge to the **union** of both
-  sides (deduped), and `version` to the **max** — automatically, with no manual repair.
+  sides (deduped), and `version` reconciles to the **max** of the two sides (then, per
+  the existing `mergeIssues` contract, is incremented by one when the merge produced a
+  substantive change) — automatically, with no manual repair.
 - A bead `.md` file is **never** left on disk (or committed) containing git conflict
   markers.
 - If any bead file fails to parse during or after a sync, sync **exits non-zero** and
@@ -247,33 +249,57 @@ Push callback: compute the differing bead set between `<syncBranch>` and
 
 ### Phase 1: Structured field-level merge (fixes the corruption + data loss)
 
-- [ ] Failing unit test: `mergeIssues` with a real base where both sides append distinct
+- [x] Failing unit test: `mergeIssues` with a real base where both sides append distinct
   `child_order_hints` → union (deduped); `version`/`updated_at` stay `max`. (Red.)
-- [ ] Flip `child_order_hints` → `union` in `FIELD_STRATEGIES`; update `tbd-design.md`
+- [x] Flip `child_order_hints` → `union` in `FIELD_STRATEGIES`; update `tbd-design.md`
   §3.5 and any golden output that pins the strategy table.
   (Green.)
-- [ ] Add `mergeBeadAcrossRefs` helper (merge-base + `git show` for base/ours/theirs;
+- [x] Add `mergeBeadAcrossRefs` helper (merge-base + `git show` for base/ours/theirs;
   tolerate missing base/file).
   Unit-test it against a temp repo: ancestor + two divergent appends → clean union, no
   markers; add/add (no base) → falls back to the synthetic-base behavior unchanged.
-- [ ] Rewrite the pull/merge conflict path (`sync.ts:763-877`) to enumerate
-  `--diff-filter=U` beads and resolve each via the helper (`HEAD`/`MERGE_HEAD`); keep
-  attic routing, ids.yml union, and the marker safety check.
-- [ ] Rewrite the push-retry callback (`sync.ts:531-561`) to resolve differing beads via
-  the same helper against `<syncBranch>`/`<remote>/<syncBranch>`.
-- [ ] e2e tryscript modeled on #155: two clones, concurrent `--parent` edits to one
+- [x] Rewrite the pull/merge conflict path to enumerate `--diff-filter=U` beads and
+  resolve each via the helper (`HEAD`/`MERGE_HEAD`); keep attic routing, ids.yml union,
+  and the marker safety check.
+- [x] Rewrite the push-retry callback to resolve differing beads via the same helper.
+- [x] e2e tryscript modeled on #155: two clones, concurrent `--parent` edits to one
   epic, sync → assert no markers on disk, epic present in `tbd show`,
   `child_order_hints` is the deduped union, `version` is the max.
 
 ### Phase 2: Fail loudly on corrupted beads
 
-- [ ] Failing test: a sync that would leave an unparseable bead exits non-zero, names
+- [x] Failing test: a sync that would leave an unparseable bead exits non-zero, names
   the file, and does **not** print `received N updated`. (Red.)
-- [ ] Thread `onInvalidIssue` through sync’s reads; throw `SyncError` on any post-merge
+- [x] Thread `onInvalidIssue` through sync’s reads; throw `SyncError` on any post-merge
   invalid bead; gate the success summary on a clean parse.
   (Green.)
-- [ ] Regression assertion in the tryscript: a deliberately corrupted bead makes sync
+- [x] Regression assertion in the tryscript: a deliberately corrupted bead makes sync
   fail loudly rather than reporting success.
+
+### Phase 3: Senior-review round (PR #157)
+
+Folded in after the maintainer’s review:
+
+- [x] **Push-retry actually integrates the remote.** Extracted the pull path’s real
+  `git merge` + structured resolution into one shared `mergeRemoteIntoSyncBranch()` used
+  by both paths, so a rejected push advances (and commits) local `tbd-sync` before
+  retrying; `pushWithRetry` keeps retrying after integrating (conflicts are
+  attic-preserved, not a stop signal) and the misleading “Push completed with
+  conflict(s)” message is fixed.
+  e2e: `cli-sync-push-retry-155.tryscript.md`.
+- [x] **Null-safe union.** `child_order_hints` is nullable (a cleared list is `null`);
+  the union branch now coerces non-array inputs to `[]` instead of throwing on a
+  concurrent clear-vs-append.
+  Tests for `null + array` and `undefined + array`.
+- [x] **Distinguish missing from corrupt in `mergeBeadAcrossRefs`.** A missing git
+  object → “absent” (keep ours); a committed-but-unparseable bead now propagates and the
+  sync merge loops fail loudly instead of swallowing it.
+  Test: corrupt committed bead.
+- [x] **Fail-loud CLI regression.** `cli-sync-fail-loud-155.tryscript.md` proves a sync
+  that pulls in an invalid bead exits non-zero, names the file, and prints no success
+  summary.
+- [x] Spec status/checklist updated; `version` wording reconciled to “max, then +1 on a
+  substantive merge”.
 
 ## Testing Strategy
 
@@ -303,11 +329,11 @@ markers from git refs).
 - **Resolved (per user):** `child_order_hints` becomes `union` (design doc updated to
   match), and we do the full fix (structured merge + real base + fail-loud), not just
   the strategy flip.
-- **Unify the two conflict paths?** The cleanest end state is for the push-retry path to
-  perform the same real `git merge` + structured resolution as the pull path, collapsing
-  to one merge code path.
-  Lean: route both through `mergeBeadAcrossRefs` now (low blast radius); consider fully
-  unifying `pushWithRetry` in a follow-up if the duplication proves fragile.
+- **Unify the two conflict paths?
+  — Resolved (review round).** Both the pull path and the push-retry callback now go
+  through one shared `mergeRemoteIntoSyncBranch()` that does a real `git merge` +
+  structured resolution + commit, so a rejected push integrates and advances local
+  `tbd-sync` before retrying rather than looping on the same non-fast-forward commit.
 - **Custom git merge driver for `issues/*.md`?** Rejected for now: unlike the built-in
   `merge=union` used for `ids.yml`, a custom driver must be configured per-clone in git
   config; on a fresh/ephemeral clone (tbd’s headline environment) an unconfigured driver

--- a/packages/tbd/docs/tbd-design.md
+++ b/packages/tbd/docs/tbd-design.md
@@ -2290,7 +2290,7 @@ const issueMergeRules: MergeRules<Issue> = {
   created_by: { strategy: 'preserve_oldest' },
   closed_at: { strategy: 'lww' }, // See status/closed_at rules below
   close_reason: { strategy: 'lww' },
-  child_order_hints: { strategy: 'lww' }, // Soft ordering, LWW on concurrent edits
+  child_order_hints: { strategy: 'union' }, // Append-only set of child IDs; union (dedupe)
 };
 ```
 

--- a/packages/tbd/src/cli/commands/sync.ts
+++ b/packages/tbd/src/cli/commands/sync.ts
@@ -13,12 +13,11 @@ import {
   UnrelatedHistoriesError,
   classifySyncError,
 } from '../lib/errors.js';
-import { listIssues, readIssue, writeIssue } from '../../file/storage.js';
+import { listIssues, writeIssue } from '../../file/storage.js';
 import {
   git,
   gitCommit,
   mergeBeadAcrossRefs,
-  mergeIssues,
   pushWithRetry,
   ensureWorktreeAttachedToBranch,
   checkRemoteBranchHealth,
@@ -530,32 +529,39 @@ class SyncHandler extends BaseCommand {
       syncBranch,
       remote,
       async () => {
-        // Merge callback - called when we need to merge remote changes
+        // Merge callback — invoked when a push is rejected because the remote
+        // advanced after our fetch. Reconcile each diverging bead through the
+        // same structured engine as the pull path (ours = our branch tip,
+        // theirs = the freshly-fetched remote tip), so no path falls back to
+        // git's line-based text merge. See issue #155.
         const conflicts: ConflictEntry[] = [];
+        const theirsRef = `${remote}/${syncBranch}`;
 
-        // Get list of issues that need merging
-        const localIssues = await listIssues(this.dataSyncDir);
+        const diff = await git(
+          '-C',
+          this.worktreePath,
+          'diff',
+          '--name-only',
+          syncBranch,
+          theirsRef,
+          '--',
+          `${DATA_SYNC_DIR}/issues`,
+        );
+        const ids = diff
+          .split('\n')
+          .map((f) => f.trim())
+          .filter((f) => f.endsWith('.md'))
+          .map((f) => basename(f, '.md'));
 
-        for (const localIssue of localIssues) {
+        for (const id of ids) {
           try {
-            // Try to get the remote version (use relative path for git show)
-            const remoteContent = await git(
-              'show',
-              `${remote}/${syncBranch}:${DATA_SYNC_DIR}/issues/${localIssue.id}.md`,
-            );
-
-            if (remoteContent) {
-              // Parse remote issue and merge
-              const remoteIssue = await readIssue(this.dataSyncDir, localIssue.id);
-              const result = mergeIssues(null, localIssue, remoteIssue);
-
-              // Write merged result
+            const result = await mergeBeadAcrossRefs(this.worktreePath, id, syncBranch, theirsRef);
+            if (result) {
               await writeIssue(this.dataSyncDir, result.merged);
               conflicts.push(...result.conflicts);
             }
-          } catch {
-            // Issue doesn't exist remotely - no merge needed
-            this.output.debug(`Issue ${localIssue.id} not on remote, no merge needed`);
+          } catch (error) {
+            this.output.debug(`Issue ${id} merge skipped: ${(error as Error).message}`);
           }
         }
 

--- a/packages/tbd/src/cli/commands/sync.ts
+++ b/packages/tbd/src/cli/commands/sync.ts
@@ -822,16 +822,21 @@ class SyncHandler extends BaseCommand {
             .filter((f) => f.endsWith('.md'))
             .map((f) => basename(f, '.md'));
           for (const id of conflictedIds) {
+            // The helper returns null only for a legitimately absent bead. Any
+            // thrown error is corruption (e.g. a committed bead that fails to
+            // parse) or an unexpected git failure — fail loudly rather than
+            // skip, so we never silently drop a conflicted bead. (#155 review)
+            let result: Awaited<ReturnType<typeof mergeBeadAcrossRefs>>;
             try {
-              const result = await mergeBeadAcrossRefs(worktreePath, id, 'HEAD', 'MERGE_HEAD');
-              if (result) {
-                await writeIssue(this.dataSyncDir, result.merged);
-                conflicts.push(...result.conflicts);
-              }
+              result = await mergeBeadAcrossRefs(worktreePath, id, 'HEAD', 'MERGE_HEAD');
             } catch (error) {
-              this.output.debug(
-                `Could not resolve conflict for ${id}: ${(error as Error).message}`,
+              throw new SyncError(
+                `Failed to merge bead ${id} during sync: ${(error as Error).message}`,
               );
+            }
+            if (result) {
+              await writeIssue(this.dataSyncDir, result.merged);
+              conflicts.push(...result.conflicts);
             }
           }
 

--- a/packages/tbd/src/cli/commands/sync.ts
+++ b/packages/tbd/src/cli/commands/sync.ts
@@ -540,11 +540,13 @@ class SyncHandler extends BaseCommand {
       spinner.stop();
 
       if (result.success) {
-        this.output.success(`Pushed ${ahead} commit(s) to ${remote}/${syncBranch}`);
-      } else if (result.conflicts && result.conflicts.length > 0) {
-        this.output.warn(
-          `Push completed with ${result.conflicts.length} conflict(s) (see attic for details)`,
-        );
+        if (result.conflicts && result.conflicts.length > 0) {
+          this.output.success(
+            `Pushed to ${remote}/${syncBranch} (${result.conflicts.length} conflict(s) preserved in attic)`,
+          );
+        } else {
+          this.output.success(`Pushed ${ahead} commit(s) to ${remote}/${syncBranch}`);
+        }
       } else {
         throw new SyncError(`Failed to push: ${result.error}`);
       }
@@ -555,48 +557,252 @@ class SyncHandler extends BaseCommand {
     }
   }
 
+  /**
+   * Integrate the remote sync branch into the local worktree with a real git
+   * merge, resolving bead conflicts through the structured field-level engine
+   * (never git's line-based text merge), reconciling ID mappings, committing the
+   * result, and asserting no bead was left corrupt.
+   *
+   * Shared by the pull/full-sync path and the push-retry path so both integrate
+   * the remote identically — and so a rejected push actually advances local
+   * `tbd-sync` to include the remote before retrying, instead of looping on the
+   * same non-fast-forward commit. See issue #155.
+   *
+   * @returns field-level conflict entries (the caller preserves them in attic).
+   */
+  private async mergeRemoteIntoSyncBranch(
+    syncBranch: string,
+    remote: string,
+  ): Promise<ConflictEntry[]> {
+    const worktreePath = this.worktreePath;
+    const conflicts: ConflictEntry[] = [];
+
+    // Track HEAD before merge for debug log
+    let headBeforeMerge = '';
+    try {
+      headBeforeMerge = (await git('-C', worktreePath, 'rev-parse', 'HEAD')).trim();
+    } catch {
+      // Ignore - just won't show debug log
+    }
+
+    // Merge remote into local using worktree
+    // This is a proper git merge that preserves both local and remote changes
+    try {
+      await git(
+        '-C',
+        worktreePath,
+        'merge',
+        `${remote}/${syncBranch}`,
+        '-m',
+        'tbd sync: merge remote changes',
+      );
+      this.output.debug('Merged remote changes');
+
+      // Show received commits in debug mode
+      // Use syncBranch explicitly — bare `HEAD` would resolve to the user's
+      // current working branch, not the tbd-sync branch in the worktree.
+      if (headBeforeMerge) {
+        await this.showGitLogDebug('Commits received', `${headBeforeMerge}..${syncBranch}`);
+      }
+
+      // Reconcile ID mappings after clean merge.
+      // A git merge may add issue files without corresponding ids.yml entries
+      // (e.g., when outbox issues were committed to a feature branch).
+      // Try to recover original short IDs from the remote's mapping to preserve
+      // ID stability (so existing references in docs/PRs remain valid).
+      const postMergeIssues = await listIssues(this.dataSyncDir);
+      const postMergeMapping = await loadIdMapping(this.dataSyncDir);
+
+      // Load historical mapping from remote to recover original short IDs
+      let historicalMapping: Awaited<ReturnType<typeof loadIdMapping>> | undefined;
+      try {
+        const remoteIdsContent = await git(
+          'show',
+          `${remote}/${syncBranch}:${DATA_SYNC_DIR}/mappings/ids.yml`,
+        );
+        if (remoteIdsContent) {
+          historicalMapping = parseIdMappingFromYaml(remoteIdsContent);
+        }
+      } catch {
+        // Remote mapping not available - will generate new IDs
+      }
+
+      const reconcileResult = reconcileMappings(
+        postMergeIssues.map((i) => i.id),
+        postMergeMapping,
+        historicalMapping,
+      );
+      const totalReconciled = reconcileResult.created.length + reconcileResult.recovered.length;
+      if (totalReconciled > 0) {
+        await saveIdMapping(this.dataSyncDir, postMergeMapping);
+        // Commit the updated mapping so it's included in the push
+        await git('-C', worktreePath, 'add', '-A');
+        try {
+          await gitCommit(
+            worktreePath,
+            '--no-verify',
+            '-m',
+            `tbd sync: reconcile ${totalReconciled} missing ID mapping(s)`,
+          );
+        } catch {
+          // Nothing to commit if mapping file was unchanged
+        }
+        if (reconcileResult.recovered.length > 0) {
+          this.output.debug(
+            `Recovered ${reconcileResult.recovered.length} ID mapping(s) from history`,
+          );
+        }
+        if (reconcileResult.created.length > 0) {
+          this.output.debug(
+            `Created ${reconcileResult.created.length} new ID mapping(s) (no history available)`,
+          );
+        }
+      }
+    } catch {
+      // Merge conflict - try to resolve at file level
+      this.output.info(`Merge conflict, attempting file-level resolution`);
+
+      // Resolve each conflicted bead with a structured three-way merge read
+      // from git refs (HEAD = ours, MERGE_HEAD = theirs). Reading committed
+      // blobs means a marker-corrupted working file is never parsed, and the
+      // real merge-base lets union fields (e.g. child_order_hints) combine
+      // both sides instead of one winning. See issue #155.
+      const conflictedList = await git(
+        '-C',
+        worktreePath,
+        'diff',
+        '--name-only',
+        '--diff-filter=U',
+        '--',
+        `${DATA_SYNC_DIR}/issues`,
+      );
+      const conflictedIds = conflictedList
+        .split('\n')
+        .map((f) => f.trim())
+        .filter((f) => f.endsWith('.md'))
+        .map((f) => basename(f, '.md'));
+      for (const id of conflictedIds) {
+        // The helper returns null only for a legitimately absent bead. Any
+        // thrown error is corruption (e.g. a committed bead that fails to
+        // parse) or an unexpected git failure — fail loudly rather than
+        // skip, so we never silently drop a conflicted bead. (#155 review)
+        let result: Awaited<ReturnType<typeof mergeBeadAcrossRefs>>;
+        try {
+          result = await mergeBeadAcrossRefs(worktreePath, id, 'HEAD', 'MERGE_HEAD');
+        } catch (error) {
+          throw new SyncError(
+            `Failed to merge bead ${id} during sync: ${(error as Error).message}`,
+          );
+        }
+        if (result) {
+          await writeIssue(this.dataSyncDir, result.merged);
+          conflicts.push(...result.conflicts);
+        }
+      }
+
+      // Merge ids.yml (ID mappings are always additive, so we union both sides)
+      // Also capture the remote mapping for recovery of original short IDs.
+      // The on-disk ids.yml may contain conflict markers after a failed git merge,
+      // so we resolve conflicts by extracting both sides and merging.
+      let conflictRemoteMapping: Awaited<ReturnType<typeof loadIdMapping>> | undefined;
+      try {
+        const remoteIdsContent = await git(
+          'show',
+          `${remote}/${syncBranch}:${DATA_SYNC_DIR}/mappings/ids.yml`,
+        );
+        if (remoteIdsContent) {
+          conflictRemoteMapping = parseIdMappingFromYaml(remoteIdsContent);
+          // Read the on-disk file (which may have conflict markers) and resolve
+          const idsPath = join(this.dataSyncDir, 'mappings', 'ids.yml');
+          const rawContent = await readFile(idsPath, 'utf-8');
+          const localMapping = resolveIdMappingConflicts(rawContent);
+          const mergedMapping = mergeIdMappings(localMapping, conflictRemoteMapping);
+          await saveIdMapping(this.dataSyncDir, mergedMapping);
+          this.output.debug(
+            `Merged ID mappings: ${localMapping.shortToUlid.size} local + ${conflictRemoteMapping.shortToUlid.size} remote = ${mergedMapping.shortToUlid.size} total`,
+          );
+        }
+      } catch (error) {
+        // Remote ids.yml doesn't exist or can't be parsed - keep local
+        this.output.debug(`Could not merge ids.yml: ${(error as Error).message}`);
+      }
+
+      // Reconcile any remaining issues without mappings after conflict resolution.
+      // Use the remote mapping as historical source to recover original short IDs.
+      {
+        const allIssues = await listIssues(this.dataSyncDir);
+        const currentMapping = await loadIdMapping(this.dataSyncDir);
+        const reconcileResult = reconcileMappings(
+          allIssues.map((i) => i.id),
+          currentMapping,
+          conflictRemoteMapping,
+        );
+        const totalReconciled = reconcileResult.created.length + reconcileResult.recovered.length;
+        if (totalReconciled > 0) {
+          await saveIdMapping(this.dataSyncDir, currentMapping);
+          if (reconcileResult.recovered.length > 0) {
+            this.output.debug(
+              `Recovered ${reconcileResult.recovered.length} ID mapping(s) from remote`,
+            );
+          }
+          if (reconcileResult.created.length > 0) {
+            this.output.debug(
+              `Created ${reconcileResult.created.length} new ID mapping(s) after conflict resolution`,
+            );
+          }
+        }
+      }
+
+      // Stage resolved files and complete merge
+      // Use --no-verify to bypass parent repo hooks (lefthook, husky, etc.)
+      await git('-C', worktreePath, 'add', '-A');
+
+      // SAFETY CHECK: Never commit files with unresolved merge conflict markers
+      // This prevents the bug where ids.yml or other files get committed with
+      // <<<<<<< HEAD markers still present
+      const conflictCheck = await git(
+        '-C',
+        worktreePath,
+        'diff',
+        '--cached',
+        '-S<<<<<<< ',
+        '--name-only',
+      );
+      if (conflictCheck.trim()) {
+        const conflictedFiles = conflictCheck.trim().split('\n');
+        throw new SyncError(
+          `Cannot commit: ${conflictedFiles.length} file(s) still have merge conflict markers:\n` +
+            conflictedFiles.map((f) => `  - ${f}`).join('\n') +
+            `\n\nThis is a bug in tbd sync. Please report it and manually resolve conflicts in:\n` +
+            `  ${worktreePath}`,
+        );
+      }
+
+      try {
+        await gitCommit(worktreePath, '--no-verify', '-m', 'tbd sync: resolved merge conflicts');
+      } catch {
+        // May fail if no conflicts needed resolving
+        this.output.debug('No merge commit needed (conflicts already resolved)');
+      }
+    }
+
+    // Never report a successful sync over a corrupted store: if the merge
+    // left any bead unparseable, fail loudly and name it. See issue #155.
+    await this.assertNoCorruptBeads();
+    return conflicts;
+  }
+
   private async doPushWithRetry(syncBranch: string, remote: string): Promise<PushResult> {
     return pushWithRetry(
       syncBranch,
       remote,
       async () => {
         // Merge callback — invoked when a push is rejected because the remote
-        // advanced after our fetch. Reconcile each diverging bead through the
-        // same structured engine as the pull path (ours = our branch tip,
-        // theirs = the freshly-fetched remote tip), so no path falls back to
-        // git's line-based text merge. See issue #155.
-        const conflicts: ConflictEntry[] = [];
-        const theirsRef = `${remote}/${syncBranch}`;
-
-        const diff = await git(
-          '-C',
-          this.worktreePath,
-          'diff',
-          '--name-only',
-          syncBranch,
-          theirsRef,
-          '--',
-          `${DATA_SYNC_DIR}/issues`,
-        );
-        const ids = diff
-          .split('\n')
-          .map((f) => f.trim())
-          .filter((f) => f.endsWith('.md'))
-          .map((f) => basename(f, '.md'));
-
-        for (const id of ids) {
-          try {
-            const result = await mergeBeadAcrossRefs(this.worktreePath, id, syncBranch, theirsRef);
-            if (result) {
-              await writeIssue(this.dataSyncDir, result.merged);
-              conflicts.push(...result.conflicts);
-            }
-          } catch (error) {
-            this.output.debug(`Issue ${id} merge skipped: ${(error as Error).message}`);
-          }
-        }
-
-        return conflicts;
+        // advanced after our fetch. Do a REAL merge of the remote into the local
+        // sync branch (committing the integration) via the same path the pull
+        // uses, so the retried push fast-forwards instead of being rejected
+        // again on the same non-fast-forward commit. See issue #155.
+        return this.mergeRemoteIntoSyncBranch(syncBranch, remote);
       },
       this.tbdRoot,
     );
@@ -717,224 +923,8 @@ class SyncHandler extends BaseCommand {
 
       // STEP 3: If remote has changes, merge them in
       if (behindCommits > 0) {
-        // Track HEAD before merge for debug log
-        let headBeforeMerge = '';
-        try {
-          headBeforeMerge = (await git('-C', worktreePath, 'rev-parse', 'HEAD')).trim();
-        } catch {
-          // Ignore - just won't show debug log
-        }
-
-        // Merge remote into local using worktree
-        // This is a proper git merge that preserves both local and remote changes
-        try {
-          await git(
-            '-C',
-            worktreePath,
-            'merge',
-            `${remote}/${syncBranch}`,
-            '-m',
-            'tbd sync: merge remote changes',
-          );
-          this.output.debug(`Merged ${behindCommits} commit(s) from remote`);
-
-          // Show received commits in debug mode
-          // Use syncBranch explicitly — bare `HEAD` would resolve to the user's
-          // current working branch, not the tbd-sync branch in the worktree.
-          if (headBeforeMerge) {
-            await this.showGitLogDebug('Commits received', `${headBeforeMerge}..${syncBranch}`);
-          }
-
-          // Reconcile ID mappings after clean merge.
-          // A git merge may add issue files without corresponding ids.yml entries
-          // (e.g., when outbox issues were committed to a feature branch).
-          // Try to recover original short IDs from the remote's mapping to preserve
-          // ID stability (so existing references in docs/PRs remain valid).
-          const postMergeIssues = await listIssues(this.dataSyncDir);
-          const postMergeMapping = await loadIdMapping(this.dataSyncDir);
-
-          // Load historical mapping from remote to recover original short IDs
-          let historicalMapping: Awaited<ReturnType<typeof loadIdMapping>> | undefined;
-          try {
-            const remoteIdsContent = await git(
-              'show',
-              `${remote}/${syncBranch}:${DATA_SYNC_DIR}/mappings/ids.yml`,
-            );
-            if (remoteIdsContent) {
-              historicalMapping = parseIdMappingFromYaml(remoteIdsContent);
-            }
-          } catch {
-            // Remote mapping not available - will generate new IDs
-          }
-
-          const reconcileResult = reconcileMappings(
-            postMergeIssues.map((i) => i.id),
-            postMergeMapping,
-            historicalMapping,
-          );
-          const totalReconciled = reconcileResult.created.length + reconcileResult.recovered.length;
-          if (totalReconciled > 0) {
-            await saveIdMapping(this.dataSyncDir, postMergeMapping);
-            // Commit the updated mapping so it's included in the push
-            await git('-C', worktreePath, 'add', '-A');
-            try {
-              await gitCommit(
-                worktreePath,
-                '--no-verify',
-                '-m',
-                `tbd sync: reconcile ${totalReconciled} missing ID mapping(s)`,
-              );
-            } catch {
-              // Nothing to commit if mapping file was unchanged
-            }
-            if (reconcileResult.recovered.length > 0) {
-              this.output.debug(
-                `Recovered ${reconcileResult.recovered.length} ID mapping(s) from history`,
-              );
-            }
-            if (reconcileResult.created.length > 0) {
-              this.output.debug(
-                `Created ${reconcileResult.created.length} new ID mapping(s) (no history available)`,
-              );
-            }
-          }
-        } catch {
-          // Merge conflict - try to resolve at file level
-          this.output.info(`Merge conflict, attempting file-level resolution`);
-
-          // Resolve each conflicted bead with a structured three-way merge read
-          // from git refs (HEAD = ours, MERGE_HEAD = theirs). Reading committed
-          // blobs means a marker-corrupted working file is never parsed, and the
-          // real merge-base lets union fields (e.g. child_order_hints) combine
-          // both sides instead of one winning. See issue #155.
-          const conflictedList = await git(
-            '-C',
-            worktreePath,
-            'diff',
-            '--name-only',
-            '--diff-filter=U',
-            '--',
-            `${DATA_SYNC_DIR}/issues`,
-          );
-          const conflictedIds = conflictedList
-            .split('\n')
-            .map((f) => f.trim())
-            .filter((f) => f.endsWith('.md'))
-            .map((f) => basename(f, '.md'));
-          for (const id of conflictedIds) {
-            // The helper returns null only for a legitimately absent bead. Any
-            // thrown error is corruption (e.g. a committed bead that fails to
-            // parse) or an unexpected git failure — fail loudly rather than
-            // skip, so we never silently drop a conflicted bead. (#155 review)
-            let result: Awaited<ReturnType<typeof mergeBeadAcrossRefs>>;
-            try {
-              result = await mergeBeadAcrossRefs(worktreePath, id, 'HEAD', 'MERGE_HEAD');
-            } catch (error) {
-              throw new SyncError(
-                `Failed to merge bead ${id} during sync: ${(error as Error).message}`,
-              );
-            }
-            if (result) {
-              await writeIssue(this.dataSyncDir, result.merged);
-              conflicts.push(...result.conflicts);
-            }
-          }
-
-          // Merge ids.yml (ID mappings are always additive, so we union both sides)
-          // Also capture the remote mapping for recovery of original short IDs.
-          // The on-disk ids.yml may contain conflict markers after a failed git merge,
-          // so we resolve conflicts by extracting both sides and merging.
-          let conflictRemoteMapping: Awaited<ReturnType<typeof loadIdMapping>> | undefined;
-          try {
-            const remoteIdsContent = await git(
-              'show',
-              `${remote}/${syncBranch}:${DATA_SYNC_DIR}/mappings/ids.yml`,
-            );
-            if (remoteIdsContent) {
-              conflictRemoteMapping = parseIdMappingFromYaml(remoteIdsContent);
-              // Read the on-disk file (which may have conflict markers) and resolve
-              const idsPath = join(this.dataSyncDir, 'mappings', 'ids.yml');
-              const rawContent = await readFile(idsPath, 'utf-8');
-              const localMapping = resolveIdMappingConflicts(rawContent);
-              const mergedMapping = mergeIdMappings(localMapping, conflictRemoteMapping);
-              await saveIdMapping(this.dataSyncDir, mergedMapping);
-              this.output.debug(
-                `Merged ID mappings: ${localMapping.shortToUlid.size} local + ${conflictRemoteMapping.shortToUlid.size} remote = ${mergedMapping.shortToUlid.size} total`,
-              );
-            }
-          } catch (error) {
-            // Remote ids.yml doesn't exist or can't be parsed - keep local
-            this.output.debug(`Could not merge ids.yml: ${(error as Error).message}`);
-          }
-
-          // Reconcile any remaining issues without mappings after conflict resolution.
-          // Use the remote mapping as historical source to recover original short IDs.
-          {
-            const allIssues = await listIssues(this.dataSyncDir);
-            const currentMapping = await loadIdMapping(this.dataSyncDir);
-            const reconcileResult = reconcileMappings(
-              allIssues.map((i) => i.id),
-              currentMapping,
-              conflictRemoteMapping,
-            );
-            const totalReconciled =
-              reconcileResult.created.length + reconcileResult.recovered.length;
-            if (totalReconciled > 0) {
-              await saveIdMapping(this.dataSyncDir, currentMapping);
-              if (reconcileResult.recovered.length > 0) {
-                this.output.debug(
-                  `Recovered ${reconcileResult.recovered.length} ID mapping(s) from remote`,
-                );
-              }
-              if (reconcileResult.created.length > 0) {
-                this.output.debug(
-                  `Created ${reconcileResult.created.length} new ID mapping(s) after conflict resolution`,
-                );
-              }
-            }
-          }
-
-          // Stage resolved files and complete merge
-          // Use --no-verify to bypass parent repo hooks (lefthook, husky, etc.)
-          await git('-C', worktreePath, 'add', '-A');
-
-          // SAFETY CHECK: Never commit files with unresolved merge conflict markers
-          // This prevents the bug where ids.yml or other files get committed with
-          // <<<<<<< HEAD markers still present
-          const conflictCheck = await git(
-            '-C',
-            worktreePath,
-            'diff',
-            '--cached',
-            '-S<<<<<<< ',
-            '--name-only',
-          );
-          if (conflictCheck.trim()) {
-            const conflictedFiles = conflictCheck.trim().split('\n');
-            throw new SyncError(
-              `Cannot commit: ${conflictedFiles.length} file(s) still have merge conflict markers:\n` +
-                conflictedFiles.map((f) => `  - ${f}`).join('\n') +
-                `\n\nThis is a bug in tbd sync. Please report it and manually resolve conflicts in:\n` +
-                `  ${worktreePath}`,
-            );
-          }
-
-          try {
-            await gitCommit(
-              worktreePath,
-              '--no-verify',
-              '-m',
-              'tbd sync: resolved merge conflicts',
-            );
-          } catch {
-            // May fail if no conflicts needed resolving
-            this.output.debug('No merge commit needed (conflicts already resolved)');
-          }
-        }
-
-        // Never report a successful sync over a corrupted store: if the merge
-        // left any bead unparseable, fail loudly and name it. See issue #155.
-        await this.assertNoCorruptBeads();
+        const mergeConflicts = await this.mergeRemoteIntoSyncBranch(syncBranch, remote);
+        conflicts.push(...mergeConflicts);
       }
     } catch (error) {
       // Surface real sync failures (e.g. unrelated histories) instead of

--- a/packages/tbd/src/cli/commands/sync.ts
+++ b/packages/tbd/src/cli/commands/sync.ts
@@ -13,7 +13,7 @@ import {
   UnrelatedHistoriesError,
   classifySyncError,
 } from '../lib/errors.js';
-import { listIssues, writeIssue } from '../../file/storage.js';
+import { listIssues, writeIssue, type InvalidIssueFile } from '../../file/storage.js';
 import {
   git,
   gitCommit,
@@ -55,6 +55,20 @@ import {
   deleteWorkspace,
 } from '../../file/workspace.js';
 import { withDataSyncContext } from '../lib/data-context.js';
+
+/**
+ * List bead files in a data-sync directory that fail to parse. Used as a
+ * post-merge guard so sync never reports success over a corrupted store (e.g. a
+ * bead left holding git conflict markers). See issue #155.
+ */
+export async function findInvalidBeads(dataSyncDir: string): Promise<InvalidIssueFile[]> {
+  const invalid: InvalidIssueFile[] = [];
+  await listIssues(dataSyncDir, {
+    warnOnInvalid: false,
+    onInvalidIssue: (entry) => invalid.push(entry),
+  });
+  return invalid;
+}
 
 interface SyncOptions {
   push?: boolean;
@@ -461,6 +475,23 @@ class SyncHandler extends BaseCommand {
         return emptyTallies();
       }
       throw error;
+    }
+  }
+
+  /**
+   * Abort the sync if any bead file fails to parse, naming the offending
+   * file(s). Prevents the silent "received N updated" success over a store left
+   * corrupted by a merge. See issue #155.
+   */
+  private async assertNoCorruptBeads(): Promise<void> {
+    const invalid = await findInvalidBeads(this.dataSyncDir);
+    if (invalid.length > 0) {
+      throw new SyncError(
+        `Sync left ${invalid.length} unreadable bead file(s):\n` +
+          invalid.map((i) => `  - ${i.file}: ${i.reason}`).join('\n') +
+          `\n\nThis is a bug in tbd sync. Please report it and resolve the file(s) in:\n` +
+          `  ${this.worktreePath}`,
+      );
     }
   }
 
@@ -895,6 +926,10 @@ class SyncHandler extends BaseCommand {
             this.output.debug('No merge commit needed (conflicts already resolved)');
           }
         }
+
+        // Never report a successful sync over a corrupted store: if the merge
+        // left any bead unparseable, fail loudly and name it. See issue #155.
+        await this.assertNoCorruptBeads();
       }
     } catch (error) {
       // Surface real sync failures (e.g. unrelated histories) instead of

--- a/packages/tbd/src/cli/commands/sync.ts
+++ b/packages/tbd/src/cli/commands/sync.ts
@@ -17,6 +17,7 @@ import { listIssues, readIssue, writeIssue } from '../../file/storage.js';
 import {
   git,
   gitCommit,
+  mergeBeadAcrossRefs,
   mergeIssues,
   pushWithRetry,
   ensureWorktreeAttachedToBranch,
@@ -25,7 +26,7 @@ import {
   type PushResult,
 } from '../../file/git.js';
 import { DATA_SYNC_DIR } from '../../lib/paths.js';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { access, readFile } from 'node:fs/promises';
 import { writeFile } from 'atomically';
 import {
@@ -764,23 +765,36 @@ class SyncHandler extends BaseCommand {
           // Merge conflict - try to resolve at file level
           this.output.info(`Merge conflict, attempting file-level resolution`);
 
-          // For each conflicted issue, do field-level merge
-          const localIssues = await listIssues(this.dataSyncDir);
-          for (const localIssue of localIssues) {
+          // Resolve each conflicted bead with a structured three-way merge read
+          // from git refs (HEAD = ours, MERGE_HEAD = theirs). Reading committed
+          // blobs means a marker-corrupted working file is never parsed, and the
+          // real merge-base lets union fields (e.g. child_order_hints) combine
+          // both sides instead of one winning. See issue #155.
+          const conflictedList = await git(
+            '-C',
+            worktreePath,
+            'diff',
+            '--name-only',
+            '--diff-filter=U',
+            '--',
+            `${DATA_SYNC_DIR}/issues`,
+          );
+          const conflictedIds = conflictedList
+            .split('\n')
+            .map((f) => f.trim())
+            .filter((f) => f.endsWith('.md'))
+            .map((f) => basename(f, '.md'));
+          for (const id of conflictedIds) {
             try {
-              const remoteContent = await git(
-                'show',
-                `${remote}/${syncBranch}:${DATA_SYNC_DIR}/issues/${localIssue.id}.md`,
-              );
-              if (remoteContent) {
-                const remoteIssue = await readIssue(this.dataSyncDir, localIssue.id);
-                const result = mergeIssues(null, localIssue, remoteIssue);
+              const result = await mergeBeadAcrossRefs(worktreePath, id, 'HEAD', 'MERGE_HEAD');
+              if (result) {
                 await writeIssue(this.dataSyncDir, result.merged);
                 conflicts.push(...result.conflicts);
               }
-            } catch {
-              // Issue doesn't exist remotely - keep local version
-              this.output.debug(`Issue ${localIssue.id} not on remote, keeping local`);
+            } catch (error) {
+              this.output.debug(
+                `Could not resolve conflict for ${id}: ${(error as Error).message}`,
+              );
             }
           }
 

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -646,10 +646,12 @@ export function mergeIssues(base: Issue | null, local: Issue, remote: Issue): Me
       }
 
       case 'union':
-        // Combine arrays and deduplicate
+        // Combine arrays and deduplicate. Coerce non-array values (null /
+        // undefined) to []: union fields like child_order_hints are nullable
+        // (a cleared list is null), and union ignores deletions. See #155.
         (merged as Record<string, unknown>)[key] = unionArrays(
-          localVal as unknown[],
-          remoteVal as unknown[],
+          (Array.isArray(localVal) ? localVal : []) as unknown[],
+          (Array.isArray(remoteVal) ? remoteVal : []) as unknown[],
         );
         break;
 

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -1807,15 +1807,20 @@ export async function mergeBeadAcrossRefs(
 
   const ours = parseIssue(await git('-C', repoDir, 'show', `${oursRef}:${path}`));
 
-  let theirs: Issue;
+  // Read the other side's blob. A missing git object means the bead does not
+  // exist there (nothing to merge — keep ours). A blob that EXISTS but fails to
+  // parse is corruption (e.g. committed conflict markers) and must propagate to
+  // the fail-loud path — never be silently treated as absent. So the git read
+  // and the parse are separated: only git-object errors map to "absent". (#155)
+  let theirsContent: string;
   try {
-    theirs = parseIssue(await git('-C', repoDir, 'show', `${theirsRef}:${path}`));
-  } catch {
-    // Bead absent on the other side — nothing to merge, keep ours.
-    return null;
+    theirsContent = await git('-C', repoDir, 'show', `${theirsRef}:${path}`);
+  } catch (err) {
+    if (err instanceof GitError) return null; // bead absent on the other side
+    throw err;
   }
+  const theirs = parseIssue(theirsContent);
 
-  let base: Issue | null = null;
   let baseSha = '';
   try {
     baseSha = (await git('-C', repoDir, 'merge-base', oursRef, theirsRef)).trim();
@@ -1824,13 +1829,18 @@ export async function mergeBeadAcrossRefs(
     // other exit status is a real failure and must propagate.
     if (exitCodeOf(err) !== 1) throw err;
   }
+
+  let base: Issue | null = null;
   if (baseSha) {
+    let baseContent: string | null = null;
     try {
-      base = parseIssue(await git('-C', repoDir, 'show', `${baseSha}:${path}`));
-    } catch {
-      // Bead added independently on both sides (absent at the ancestor) — no base.
-      base = null;
+      baseContent = await git('-C', repoDir, 'show', `${baseSha}:${path}`);
+    } catch (err) {
+      // Bead added independently on both sides (absent at the ancestor) — no
+      // base. A non-git error is unexpected and must propagate.
+      if (!(err instanceof GitError)) throw err;
     }
+    if (baseContent !== null) base = parseIssue(baseContent);
   }
 
   return mergeIssues(base, ours, theirs);

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -777,11 +777,21 @@ export async function pushWithRetry(
   // Build -C prefix args when baseDir is provided
   const dirArgs = baseDir ? ['-C', baseDir] : [];
 
+  // Field-level conflicts accumulate across retries; they are informational
+  // (the data is preserved in the attic) and must NOT abort the retry loop —
+  // the merge that produced them has been committed, so the next push can
+  // fast-forward. Surfaced on the final result for reporting.
+  const allConflicts: ConflictEntry[] = [];
+
   for (let attempt = 1; attempt <= MAX_PUSH_RETRIES; attempt++) {
     try {
       // Try to push
       await git(...dirArgs, 'push', remote, refspec);
-      return { success: true, attempt };
+      return {
+        success: true,
+        attempt,
+        conflicts: allConflicts.length > 0 ? allConflicts : undefined,
+      };
     } catch (error) {
       if (!isNonFastForward(error)) {
         // Unrecoverable error
@@ -789,6 +799,7 @@ export async function pushWithRetry(
           success: false,
           attempt,
           error: error instanceof Error ? error.message : String(error),
+          conflicts: allConflicts.length > 0 ? allConflicts : undefined,
         };
       }
 
@@ -797,19 +808,17 @@ export async function pushWithRetry(
           success: false,
           attempt,
           error: `Push failed after ${MAX_PUSH_RETRIES} attempts. Remote has conflicting changes.`,
+          conflicts: allConflicts.length > 0 ? allConflicts : undefined,
         };
       }
 
-      // Fetch and merge remote changes
+      // Fetch the advanced remote and integrate it (a real merge that commits),
+      // so the next push fast-forwards. onMergeNeeded must advance local
+      // `syncBranch` to include `${remote}/${syncBranch}`.
       await git(...dirArgs, 'fetch', remote, syncBranch);
-      const conflicts = await onMergeNeeded();
+      allConflicts.push(...(await onMergeNeeded()));
 
-      if (conflicts.length > 0) {
-        // Return conflicts but continue trying
-        return { success: false, attempt, conflicts };
-      }
-
-      // Loop to retry push
+      // Loop to retry push.
     }
   }
 

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -1778,6 +1778,62 @@ async function readBranchMapping(baseDir: string, ref: string): Promise<IdMappin
   }
 }
 
+/**
+ * Three-way merge a single bead read directly from git refs.
+ *
+ * Resolves the common ancestor with `git merge-base` and reads base/ours/theirs
+ * from committed blobs (never the working tree), so a conflict-marker-corrupted
+ * working file is never parsed. Feeds the field-level {@link mergeIssues} engine
+ * a real base, which is what lets `union` fields (e.g. child_order_hints) combine
+ * both sides instead of one side winning.
+ *
+ * Returns `null` when the bead does not exist on the `theirsRef` side (nothing to
+ * merge — keep ours). Used by sync's conflict paths in place of git's line-based
+ * text merge. See issue #155.
+ *
+ * @param repoDir - Directory to run git in (the data-sync worktree). `oursRef` and
+ *   `theirsRef` (e.g. `HEAD`/`MERGE_HEAD`, or a branch and `origin/<branch>`) must
+ *   resolve there.
+ */
+export async function mergeBeadAcrossRefs(
+  repoDir: string,
+  issueId: string,
+  oursRef: string,
+  theirsRef: string,
+): Promise<MergeResult | null> {
+  const path = `${DATA_SYNC_DIR}/issues/${issueId}.md`;
+
+  const ours = parseIssue(await git('-C', repoDir, 'show', `${oursRef}:${path}`));
+
+  let theirs: Issue;
+  try {
+    theirs = parseIssue(await git('-C', repoDir, 'show', `${theirsRef}:${path}`));
+  } catch {
+    // Bead absent on the other side — nothing to merge, keep ours.
+    return null;
+  }
+
+  let base: Issue | null = null;
+  let baseSha = '';
+  try {
+    baseSha = (await git('-C', repoDir, 'merge-base', oursRef, theirsRef)).trim();
+  } catch (err) {
+    // Exit 1 = the refs share no common ancestor (unrelated histories); any
+    // other exit status is a real failure and must propagate.
+    if (exitCodeOf(err) !== 1) throw err;
+  }
+  if (baseSha) {
+    try {
+      base = parseIssue(await git('-C', repoDir, 'show', `${baseSha}:${path}`));
+    } catch {
+      // Bead added independently on both sides (absent at the ancestor) — no base.
+      base = null;
+    }
+  }
+
+  return mergeIssues(base, ours, theirs);
+}
+
 /** Preserve a losing issue version explicitly under attic/conflicts/. */
 async function preserveLosingVersion(dataSyncPath: string, loser: Issue): Promise<void> {
   const conflictsDir = join(dataSyncPath, 'attic', 'conflicts');

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -384,7 +384,9 @@ const FIELD_STRATEGIES: Record<keyof Issue, MergeStrategy> = {
   priority: 'lww',
   assignee: 'lww',
   parent_id: 'lww',
-  child_order_hints: 'lww',
+  // Append-only set of child IDs (parent->child wiring). Must never lose a
+  // concurrently-added child, so union (dedupe), not LWW. See issue #155.
+  child_order_hints: 'union',
   updated_at: 'max',
   closed_at: 'lww',
   close_reason: 'lww',

--- a/packages/tbd/tests/cli-sync-concurrent-epic-155.tryscript.md
+++ b/packages/tbd/tests/cli-sync-concurrent-epic-155.tryscript.md
@@ -1,0 +1,95 @@
+---
+sandbox: true
+env:
+  NO_COLOR: '1'
+  FORCE_COLOR: '0'
+path:
+  - ../dist
+timeout: 60000
+patterns:
+  ULID: '[0-9a-z]{26}'
+  SHORTID: '[0-9a-z]{4,5}'
+  TIMESTAMP: "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z"
+before: |
+  # Isolated bare repo as "origin", shared by both sessions.
+  rm -rf ../origin-155.git ../sessionB ../epic.txt
+  mkdir -p ../origin-155.git
+  git init --bare --initial-branch=main ../origin-155.git
+
+  # Session A: a normal tbd repo wired to origin.
+  git init --initial-branch=main
+  git config user.email "a@example.com"
+  git config user.name "Session A"
+  git config commit.gpgsign false
+  echo "# Test repo" > README.md
+  git add README.md
+  git commit -m "Initial commit"
+  git remote add origin ../origin-155.git
+  git push -u origin main
+
+  tbd init --prefix=test
+  # Publish the tbd config on main so a fresh clone is already initialized.
+  git add .tbd
+  git commit -m "Add tbd config"
+  git push origin main
+
+  # Create the shared epic and publish it on tbd-sync (the common ancestor).
+  tbd create "Shared Epic" --type=epic --json | jq -r '.id' | tee ../epic.txt
+  tbd sync
+---
+# tbd CLI: Concurrent edits to one epic merge cleanly (#155)
+
+Two sessions each append a different child to the **same** epic before syncing.
+The losing side must not be dropped and the bead must never end up holding git conflict
+markers: `child_order_hints` is an append-only set, so the result is the **union** of
+both children and `tbd sync` succeeds.
+
+See: plan-2026-06-03-tbd-sync-structured-bead-merge.md
+
+* * *
+
+## Session B publishes a child, then Session A diverges with another
+
+# Test: Session B (a second clone) appends Child B and pushes
+
+```console
+$ git clone -q ../origin-155.git ../sessionB && ( cd ../sessionB && git config user.email "b@example.com" && git config user.name "Session B" && git config commit.gpgsign false && tbd sync >/dev/null 2>&1 && tbd create "Child B" --parent "$(cat ../epic.txt)" >/dev/null 2>&1 && tbd sync >/dev/null 2>&1 ) && echo done
+done
+? 0
+```
+
+# Test: Session A appends Child A locally without pulling B’s change
+
+```console
+$ tbd create "Child A" --parent "$(cat ../epic.txt)" --no-sync >/dev/null 2>&1; echo done
+done
+? 0
+```
+
+* * *
+
+## The conflicting sync resolves into a clean union
+
+# Test: tbd sync succeeds (structured merge, no manual repair)
+
+```console
+$ tbd sync >/dev/null 2>&1; echo "exit=$?"
+exit=0
+? 0
+```
+
+# Test: The epic now carries BOTH children (union, nothing dropped)
+
+```console
+$ tbd show "$(cat ../epic.txt)" --json | jq '.child_order_hints | length'
+2
+? 0
+```
+
+# Test: No bead file holds git conflict markers
+
+```console
+$ ! grep -rq '<<<<<<<' "$(git rev-parse --path-format=absolute --git-common-dir)/tbd/data-sync-worktree/.tbd/data-sync/issues" && echo clean
+clean
+? 0
+```

--- a/packages/tbd/tests/cli-sync-fail-loud-155.tryscript.md
+++ b/packages/tbd/tests/cli-sync-fail-loud-155.tryscript.md
@@ -1,0 +1,80 @@
+---
+sandbox: true
+env:
+  NO_COLOR: '1'
+  FORCE_COLOR: '0'
+path:
+  - ../dist
+timeout: 60000
+patterns:
+  ULID: '[0-9a-z]{26}'
+  SHORTID: '[0-9a-z]{4,5}'
+  TIMESTAMP: "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z"
+before: |
+  # Isolated bare repo as "origin".
+  rm -rf ../origin-faillou.git ../inject ../epic-fl.txt
+  mkdir -p ../origin-faillou.git
+  git init --bare --initial-branch=main ../origin-faillou.git
+
+  # A normal tbd repo wired to origin, with tbd-sync established.
+  git init --initial-branch=main
+  git config user.email "a@example.com"
+  git config user.name "Session A"
+  git config commit.gpgsign false
+  echo "# Test repo" > README.md
+  git add README.md
+  git commit -m "Initial commit"
+  git remote add origin ../origin-faillou.git
+  git push -u origin main
+
+  tbd init --prefix=test
+  tbd create "An issue" --type=task >/dev/null
+  tbd sync
+---
+# tbd CLI: Sync fails loudly on a corrupt bead, never reports success (#155)
+
+If a sync pulls in a bead whose YAML is invalid (e.g. one left holding git conflict
+markers by an older client), `tbd sync` must **exit non-zero** and name the file — it
+must not print `Synced: received ...` over a store it cannot read.
+
+See: plan-2026-06-03-tbd-sync-structured-bead-merge.md (PR #157 review)
+
+* * *
+
+## A corrupt bead arrives from the remote
+
+# Test: Inject a bead with conflict markers onto origin/tbd-sync
+
+```console
+$ git clone -q ../origin-faillou.git ../inject && ( cd ../inject && git config user.email "i@example.com" && git config user.name "Inject" && git config commit.gpgsign false && git checkout -q tbd-sync && mkdir -p .tbd/data-sync/issues && printf '%s\n' '---' 'type: is' 'id: is-01failtestbead000000000001' '<<<<<<< HEAD' 'version: 1' '=======' 'version: 2' '>>>>>>> origin/tbd-sync' '---' 'body' > .tbd/data-sync/issues/is-01failtestbead000000000001.md && git add -A && git commit -q -m "inject corrupt bead" && git push -q origin tbd-sync ) && echo injected
+injected
+? 0
+```
+
+* * *
+
+## Sync must fail loudly, not report success
+
+# Test: tbd sync exits non-zero when the merge brings in an unreadable bead
+
+```console
+$ tbd sync > out.txt 2>&1 && echo "UNEXPECTED-OK" || echo "failed-as-expected"
+failed-as-expected
+? 0
+```
+
+# Test: The error names the unreadable bead file
+
+```console
+$ grep -c "unreadable bead file" out.txt | tr -d ' '
+1
+? 0
+```
+
+# Test: It does NOT print a success summary over the corrupted store
+
+```console
+$ grep -c "Synced: received" out.txt || true
+0
+? 0
+```

--- a/packages/tbd/tests/cli-sync-push-retry-155.tryscript.md
+++ b/packages/tbd/tests/cli-sync-push-retry-155.tryscript.md
@@ -1,0 +1,103 @@
+---
+sandbox: true
+env:
+  NO_COLOR: '1'
+  FORCE_COLOR: '0'
+path:
+  - ../dist
+timeout: 60000
+patterns:
+  ULID: '[0-9a-z]{26}'
+  SHORTID: '[0-9a-z]{4,5}'
+  TIMESTAMP: "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z"
+before: |
+  # Isolated bare repo as "origin", shared by both sessions.
+  rm -rf ../origin-pushretry.git ../sessionB-pr ../epic-pr.txt
+  mkdir -p ../origin-pushretry.git
+  git init --bare --initial-branch=main ../origin-pushretry.git
+
+  # Session A: a normal tbd repo wired to origin.
+  git init --initial-branch=main
+  git config user.email "a@example.com"
+  git config user.name "Session A"
+  git config commit.gpgsign false
+  echo "# Test repo" > README.md
+  git add README.md
+  git commit -m "Initial commit"
+  git remote add origin ../origin-pushretry.git
+  git push -u origin main
+
+  tbd init --prefix=test
+  git add .tbd
+  git commit -m "Add tbd config"
+  git push origin main
+
+  tbd create "Shared Epic" --type=epic --json | jq -r '.id' | tee ../epic-pr.txt
+  tbd sync
+---
+# tbd CLI: Push-retry integrates the remote before retrying (#155)
+
+`tbd sync --push` does not pull first, so when the remote has advanced it forces the
+**push-retry** path: the first push is rejected (non-fast-forward), the retry callback
+must do a real merge that *commits* the remote into local `tbd-sync`, and the retried
+push must then fast-forward.
+Before the fix the callback wrote merged files but never advanced the branch, so this
+path failed after the retry limit even on a clean structured merge.
+
+See: plan-2026-06-03-tbd-sync-structured-bead-merge.md (PR #157 review)
+
+* * *
+
+## Set up a divergence, then force the push-retry path
+
+# Test: Session B appends Child B and pushes (remote advances)
+
+```console
+$ git clone -q ../origin-pushretry.git ../sessionB-pr && ( cd ../sessionB-pr && git config user.email "b@example.com" && git config user.name "Session B" && git config commit.gpgsign false && tbd sync >/dev/null 2>&1 && tbd create "Child B" --parent "$(cat ../epic-pr.txt)" >/dev/null 2>&1 && tbd sync >/dev/null 2>&1 ) && echo done
+done
+? 0
+```
+
+# Test: Session A appends Child A locally (committed on next push, not pulled)
+
+```console
+$ tbd create "Child A" --parent "$(cat ../epic-pr.txt)" --no-sync >/dev/null 2>&1; echo done
+done
+? 0
+```
+
+* * *
+
+## The push-only sync must integrate the remote and succeed
+
+# Test: tbd sync --push succeeds via the retry path (real merge + fast-forward)
+
+```console
+$ tbd sync --push >/dev/null 2>&1; echo "exit=$?"
+exit=0
+? 0
+```
+
+# Test: The epic carries BOTH children after the push-retry merge
+
+```console
+$ tbd show "$(cat ../epic-pr.txt)" --json | jq '.child_order_hints | length'
+2
+? 0
+```
+
+# Test: The remote tbd-sync received the integrated result (push really happened)
+
+```console
+$ git fetch -q origin tbd-sync && git ls-tree -r --name-only origin/tbd-sync | grep -c 'issues/is-' | tr -d ' '
+3
+? 0
+```
+
+# Test: No bead file holds git conflict markers
+
+```console
+$ ! grep -rq '<<<<<<<' "$(git rev-parse --path-format=absolute --git-common-dir)/tbd/data-sync-worktree/.tbd/data-sync/issues" && echo clean
+clean
+? 0
+```

--- a/packages/tbd/tests/merge-refs.test.ts
+++ b/packages/tbd/tests/merge-refs.test.ts
@@ -154,6 +154,31 @@ describeUnlessWindows('mergeBeadAcrossRefs', () => {
     expect(result).not.toBeNull();
   });
 
+  it('propagates a parse error when a committed bead is corrupt (not treated as absent)', async () => {
+    const id = SHARED;
+    await commitBead(createTestIssue({ id, title: 'Base' }), 'base');
+
+    await git('checkout', '-b', 'ours');
+    await commitBead(
+      createTestIssue({ id, title: 'Base', version: 2, status: 'in_progress' }),
+      'ours edits',
+    );
+
+    // theirs: the bead EXISTS but its YAML is corrupt (e.g. conflict markers a
+    // prior merge left committed). This is data corruption, not an absent file,
+    // and must surface — never be silently skipped as "nothing to merge".
+    await git('checkout', 'main');
+    await git('checkout', '-b', 'theirs');
+    await writeFile(
+      join(repo, DATA_SYNC_DIR, 'issues', `${id}.md`),
+      '---\ntype: is\n<<<<<<< HEAD\nversion: 1\n=======\nversion: 2\n>>>>>>> x\n---\n',
+    );
+    await git('add', '-A');
+    await git('commit', '-m', 'theirs corrupt');
+
+    await expect(mergeBeadAcrossRefs(repo, id, 'ours', 'theirs')).rejects.toThrow();
+  });
+
   // End-to-end of the pull-path resolution as sync drives it: a real `git merge`
   // leaves conflict markers in the bead, then the structured resolution turns it
   // into a clean union with no markers. Reproduces issue #155.

--- a/packages/tbd/tests/merge-refs.test.ts
+++ b/packages/tbd/tests/merge-refs.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, rm, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir, platform } from 'node:os';
 import { randomBytes } from 'node:crypto';
@@ -152,5 +152,71 @@ describeUnlessWindows('mergeBeadAcrossRefs', () => {
     const result = await mergeBeadAcrossRefs(repo, id, 'ours', 'theirs');
 
     expect(result).not.toBeNull();
+  });
+
+  // End-to-end of the pull-path resolution as sync drives it: a real `git merge`
+  // leaves conflict markers in the bead, then the structured resolution turns it
+  // into a clean union with no markers. Reproduces issue #155.
+  it('resolves a real git merge conflict on an epic into a clean union', async () => {
+    const id = EPIC;
+    await commitBead(
+      createTestIssue({ id, title: 'Epic', kind: 'epic', child_order_hints: [COMMON] }),
+      'base',
+    );
+
+    await git('checkout', '-b', 'ours');
+    await commitBead(
+      createTestIssue({
+        id,
+        title: 'Epic',
+        kind: 'epic',
+        version: 2,
+        child_order_hints: [COMMON, CHILD_A],
+        updated_at: '2025-01-02T00:00:00Z',
+      }),
+      'ours appends A',
+    );
+
+    await git('checkout', 'main');
+    await git('checkout', '-b', 'theirs');
+    await commitBead(
+      createTestIssue({
+        id,
+        title: 'Epic',
+        kind: 'epic',
+        version: 2,
+        child_order_hints: [COMMON, CHILD_B],
+        updated_at: '2025-01-03T00:00:00Z',
+      }),
+      'theirs appends B',
+    );
+
+    // A real git merge produces a textual conflict (markers written to disk).
+    await git('checkout', 'ours');
+    let conflicted = false;
+    try {
+      await git('merge', 'theirs');
+    } catch {
+      conflicted = true;
+    }
+    expect(conflicted).toBe(true);
+
+    // Sync enumerates conflicted beads exactly this way.
+    const { stdout: diff } = await git('diff', '--name-only', '--diff-filter=U');
+    expect(diff).toContain(`${id}.md`);
+
+    // Resolve with the mid-merge refs, write clean YAML, and complete the merge.
+    const result = await mergeBeadAcrossRefs(repo, id, 'HEAD', 'MERGE_HEAD');
+    expect(result).not.toBeNull();
+    const beadPath = join(repo, DATA_SYNC_DIR, 'issues', `${id}.md`);
+    await writeFile(beadPath, serializeIssue(result!.merged));
+    await git('add', '-A');
+    await git('commit', '--no-edit');
+
+    const finalText = await readFile(beadPath, 'utf-8');
+    expect(finalText).not.toContain('<<<<<<<');
+    expect(finalText).not.toContain('>>>>>>>');
+    expect(result!.merged.child_order_hints).toEqual([COMMON, CHILD_A, CHILD_B]);
+    expect(result!.merged.version).toBe(3);
   });
 });

--- a/packages/tbd/tests/merge-refs.test.ts
+++ b/packages/tbd/tests/merge-refs.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for mergeBeadAcrossRefs — the structured three-way merge primitive
+ * that reads base/ours/theirs for a single bead directly from git refs.
+ *
+ * See: issue #155, plan-2026-06-03-tbd-sync-structured-bead-merge.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir, platform } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { mergeBeadAcrossRefs } from '../src/file/git.js';
+import { serializeIssue } from '../src/file/parser.js';
+import { DATA_SYNC_DIR } from '../src/lib/paths.js';
+import { createTestIssue, testId, TEST_ULIDS } from './test-helpers.js';
+import type { Issue } from '../src/lib/types.js';
+
+const EPIC = testId(TEST_ULIDS.ULID_1);
+const COMMON = testId(TEST_ULIDS.ULID_2);
+const CHILD_A = testId(TEST_ULIDS.ULID_3);
+const CHILD_B = testId(TEST_ULIDS.ULID_4);
+const SHARED = testId(TEST_ULIDS.ULID_5);
+const OTHER = testId(TEST_ULIDS.ULID_6);
+const X = testId(TEST_ULIDS.ULID_8);
+const Y = testId(TEST_ULIDS.ULID_9);
+
+const execFileAsync = promisify(execFile);
+const isWindows = platform() === 'win32';
+const describeUnlessWindows = isWindows ? describe.skip : describe;
+
+describeUnlessWindows('mergeBeadAcrossRefs', () => {
+  let repo: string;
+
+  const git = (...args: string[]) => execFileAsync('git', args, { cwd: repo });
+
+  /** Commit a bead at its canonical data-sync path on the current branch. */
+  const commitBead = async (issue: Issue, message: string) => {
+    const dir = join(repo, DATA_SYNC_DIR, 'issues');
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, `${issue.id}.md`), serializeIssue(issue));
+    await git('add', '-A');
+    await git('commit', '-m', message);
+  };
+
+  beforeEach(async () => {
+    repo = join(tmpdir(), `tbd-merge-refs-${randomBytes(6).toString('hex')}`);
+    await mkdir(repo, { recursive: true });
+    await git('init', '-b', 'main');
+    await git('config', 'user.email', 'test@example.com');
+    await git('config', 'user.name', 'Test');
+    // Keep commits hermetic — never invoke the environment's commit signer.
+    await git('config', 'commit.gpgsign', 'false');
+    await git('config', 'tag.gpgsign', 'false');
+  });
+
+  afterEach(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it('unions children appended on each branch from a shared base', async () => {
+    const id = EPIC;
+    await commitBead(
+      createTestIssue({ id, title: 'Epic', kind: 'epic', child_order_hints: [COMMON] }),
+      'base',
+    );
+
+    // ours: append child A
+    await git('checkout', '-b', 'ours');
+    await commitBead(
+      createTestIssue({
+        id,
+        title: 'Epic',
+        kind: 'epic',
+        version: 2,
+        child_order_hints: [COMMON, CHILD_A],
+        updated_at: '2025-01-02T00:00:00Z',
+      }),
+      'ours appends A',
+    );
+
+    // theirs: branch from base, append child B
+    await git('checkout', 'main');
+    await git('checkout', '-b', 'theirs');
+    await commitBead(
+      createTestIssue({
+        id,
+        title: 'Epic',
+        kind: 'epic',
+        version: 2,
+        child_order_hints: [COMMON, CHILD_B],
+        updated_at: '2025-01-03T00:00:00Z',
+      }),
+      'theirs appends B',
+    );
+
+    const result = await mergeBeadAcrossRefs(repo, id, 'ours', 'theirs');
+
+    expect(result).not.toBeNull();
+    expect(result!.merged.child_order_hints).toEqual([COMMON, CHILD_A, CHILD_B]);
+    expect(result!.merged.version).toBe(3);
+  });
+
+  it('returns null when the bead is absent on the theirs side', async () => {
+    const id = SHARED;
+    await commitBead(createTestIssue({ id, title: 'Base' }), 'base');
+    await git('checkout', '-b', 'ours');
+    await commitBead(
+      createTestIssue({ id, title: 'Base', version: 2, status: 'in_progress' }),
+      'ours edits',
+    );
+    // theirs is an orphan root where this bead's file is missing.
+    await git('checkout', '--orphan', 'theirs');
+    await git('rm', '-rf', '.');
+    await commitBead(createTestIssue({ id: OTHER, title: 'Unrelated' }), 'theirs other');
+
+    const result = await mergeBeadAcrossRefs(repo, id, 'ours', 'theirs');
+
+    expect(result).toBeNull();
+  });
+
+  it('merges add/add with no common ancestor (no base)', async () => {
+    const id = EPIC;
+    // ours root
+    await git('checkout', '-b', 'ours');
+    await commitBead(
+      createTestIssue({
+        id,
+        title: 'Added',
+        child_order_hints: [X],
+        created_at: '2025-01-01T00:00:00Z',
+      }),
+      'ours root',
+    );
+    // theirs: unrelated orphan root with the same bead id
+    await git('checkout', '--orphan', 'theirs');
+    await git('rm', '-rf', '.');
+    await commitBead(
+      createTestIssue({
+        id,
+        title: 'Added',
+        child_order_hints: [Y],
+        created_at: '2025-01-01T00:00:00Z',
+      }),
+      'theirs root',
+    );
+
+    // No merge-base exists; helper must still produce a merge, not throw.
+    const result = await mergeBeadAcrossRefs(repo, id, 'ours', 'theirs');
+
+    expect(result).not.toBeNull();
+  });
+});

--- a/packages/tbd/tests/merge.test.ts
+++ b/packages/tbd/tests/merge.test.ts
@@ -247,6 +247,40 @@ describe('mergeIssues', () => {
       expect(sharedCount).toBe(1);
       expect(result.merged.child_order_hints).toContain('is-childB');
     });
+
+    it('does not throw when one side cleared the hints to null', () => {
+      // `tbd update --child-order ""` writes null. A concurrent clear vs. append
+      // must merge cleanly (union ignores deletions), not throw on null. (#155 review)
+      const base = makeIssue({ child_order_hints: ['is-common'] });
+      const local = makeIssue({
+        child_order_hints: null,
+        version: 2,
+        updated_at: '2025-01-02T00:00:00Z',
+      });
+      const remote = makeIssue({
+        child_order_hints: ['is-common', 'is-childB'],
+        version: 2,
+        updated_at: '2025-01-03T00:00:00Z',
+      });
+
+      const result = mergeIssues(base, local, remote);
+
+      expect(result.merged.child_order_hints).toEqual(['is-common', 'is-childB']);
+    });
+
+    it('does not throw when one side has undefined (legacy missing) hints', () => {
+      const base = makeIssue({ child_order_hints: ['is-common'] });
+      const local = makeIssue({ child_order_hints: undefined, version: 2 });
+      const remote = makeIssue({
+        child_order_hints: ['is-common', 'is-childB'],
+        version: 2,
+        updated_at: '2025-01-03T00:00:00Z',
+      });
+
+      const result = mergeIssues(base, local, remote);
+
+      expect(result.merged.child_order_hints).toEqual(['is-common', 'is-childB']);
+    });
   });
 
   describe('Max strategy (version)', () => {

--- a/packages/tbd/tests/merge.test.ts
+++ b/packages/tbd/tests/merge.test.ts
@@ -201,6 +201,54 @@ describe('mergeIssues', () => {
     });
   });
 
+  describe('Union strategy (child_order_hints)', () => {
+    it('unions children appended by each side from a shared base', () => {
+      // Two sessions each append a distinct child to the same epic. The wiring
+      // must survive on both sides — union, not last-writer-wins. See issue #155.
+      const base = makeIssue({ child_order_hints: ['is-common'] });
+      const local = makeIssue({
+        child_order_hints: ['is-common', 'is-childA'],
+        version: 2,
+        updated_at: '2025-01-02T00:00:00Z',
+      });
+      const remote = makeIssue({
+        child_order_hints: ['is-common', 'is-childB'],
+        version: 2,
+        updated_at: '2025-01-03T00:00:00Z',
+      });
+
+      const result = mergeIssues(base, local, remote);
+
+      expect(result.merged.child_order_hints).toEqual(['is-common', 'is-childA', 'is-childB']);
+      // Counter is monotonic: max of both sides, then bumped for the substantive merge.
+      expect(result.merged.version).toBe(3);
+      // Union never discards data, so no conflict is recorded for the field.
+      expect(result.conflicts.some((c) => c.field === 'child_order_hints')).toBe(false);
+    });
+
+    it('deduplicates a child both sides appended', () => {
+      const base = makeIssue({ child_order_hints: ['is-common'] });
+      const local = makeIssue({
+        child_order_hints: ['is-common', 'is-shared'],
+        version: 2,
+        updated_at: '2025-01-02T00:00:00Z',
+      });
+      const remote = makeIssue({
+        child_order_hints: ['is-common', 'is-shared', 'is-childB'],
+        version: 2,
+        updated_at: '2025-01-02T00:00:00Z',
+      });
+
+      const result = mergeIssues(base, local, remote);
+
+      const sharedCount = (result.merged.child_order_hints ?? []).filter(
+        (id) => id === 'is-shared',
+      ).length;
+      expect(sharedCount).toBe(1);
+      expect(result.merged.child_order_hints).toContain('is-childB');
+    });
+  });
+
   describe('Max strategy (version)', () => {
     it('returns higher version without bumping when no substantive changes', () => {
       const base = makeIssue({ version: 1 });

--- a/packages/tbd/tests/sync-fail-loud.test.ts
+++ b/packages/tbd/tests/sync-fail-loud.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for the fail-loud guard: sync must never report success over a bead
+ * file that fails to parse (e.g. one left holding git conflict markers).
+ *
+ * See: issue #155, plan-2026-06-03-tbd-sync-structured-bead-merge.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+
+import { findInvalidBeads } from '../src/cli/commands/sync.js';
+import { writeIssue } from '../src/file/storage.js';
+import { createTestIssue, testId, TEST_ULIDS } from './test-helpers.js';
+
+describe('findInvalidBeads', () => {
+  let dataSyncDir: string;
+
+  beforeEach(async () => {
+    dataSyncDir = join(tmpdir(), `tbd-fail-loud-${randomBytes(6).toString('hex')}`);
+    await mkdir(join(dataSyncDir, 'issues'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(dataSyncDir, { recursive: true, force: true });
+  });
+
+  it('returns empty when every bead parses', async () => {
+    await writeIssue(dataSyncDir, createTestIssue({ id: testId(TEST_ULIDS.ULID_1), title: 'Ok' }));
+
+    const invalid = await findInvalidBeads(dataSyncDir);
+
+    expect(invalid).toEqual([]);
+  });
+
+  it('names a bead left holding git conflict markers', async () => {
+    await writeIssue(dataSyncDir, createTestIssue({ id: testId(TEST_ULIDS.ULID_1), title: 'Ok' }));
+    // A bead whose YAML was clobbered by git's line-based merge — exactly the
+    // #155 corruption. It must be detected, not silently skipped.
+    const badId = testId(TEST_ULIDS.ULID_2);
+    await writeFile(
+      join(dataSyncDir, 'issues', `${badId}.md`),
+      [
+        '---',
+        'type: is',
+        `id: ${badId}`,
+        '<<<<<<< HEAD',
+        'version: 68',
+        '=======',
+        'version: 75',
+        '>>>>>>> origin/tbd-sync',
+        '---',
+        '',
+      ].join('\n'),
+    );
+
+    const invalid = await findInvalidBeads(dataSyncDir);
+
+    expect(invalid).toHaveLength(1);
+    expect(invalid[0]!.file).toContain(badId);
+  });
+});


### PR DESCRIPTION
Fixes #155 — `tbd sync` writing git conflict markers into bead YAML on concurrent epic
`child_order_hints`/`version` edits, after which the file is silently skipped and the
epic disappears.

Spec: `docs/project/specs/active/plan-2026-06-03-tbd-sync-structured-bead-merge.md`
(tracked as epic `tbd-902g` + 6 children).

## Root cause (three coupled defects)
- **A — wrong strategy:** `child_order_hints` merged last-writer-wins, but it is the
  append-only parent→child wiring. Concurrent edits silently dropped a child.
- **B — conflict path never merged the remote:** both sync conflict sites read the
  *local* file as the "remote" side and passed `base = null`. With a null/synthetic base,
  `mergeIssues` never reaches its `union` branch — so the strategy fix alone is
  insufficient; a real `git merge-base` ancestor is required.
- **C — silent success over corruption:** marker-laden YAML fails to parse, `listIssues`
  skips it, and the `received N updated` tally (a `git diff` count) still printed success.

## The fix (6 commits)
1. **Union-merge `child_order_hints`** (+ update `tbd-design.md` §3.5).
2. **`mergeBeadAcrossRefs`** — structured three-way merge reading base/ours/theirs from
   git refs (`merge-base` + `git show`), so committed blobs (never a marker-corrupted
   working file) feed the existing `mergeIssues` engine with a real base.
3. **Pull-path rewrite** — enumerate conflicts via `--diff-filter=U`, resolve each via
   the helper (`HEAD`/`MERGE_HEAD`).
4. **Push-retry callback rewrite** — same helper against the branch tip and the
   freshly-fetched remote tip (this path has no conflicted index, so `merge-base` is the
   right primitive).
5. **Fail loudly** — `findInvalidBeads` + an `assertNoCorruptBeads` guard; sync now exits
   non-zero naming any unparseable bead instead of reporting success.
6. **e2e tests** — a real `git merge` conflict resolved to a clean union (integration),
   plus a two-session CLI tryscript that converges to the union with no markers.

Reuses the existing merge engine and attic conflict routing; consistent with the
unrelated-history rescue and workspace/import merges (full audit in the spec).

## Testing
- 1153 vitest tests green; 155 sync/child-order tryscripts green (incl. the new repro).
- The new tryscript was confirmed to **fail** under the old `lww` strategy (1 child
  survives) and **pass** with `union` (both children), so it genuinely guards #155.

## Notes
- The push-retry callback's writes are committed by `pushWithRetry` only in the normal
  flow; fully unifying that path with the pull path is flagged as a follow-up in the
  spec's Open Questions (low-risk; out of scope here).
- Beads (`tbd-902g` + children) are committed on the local `tbd-sync` branch but not
  pushed to `origin/tbd-sync` due to a pre-existing unrelated-history state there
  (`tbd doctor --fix` reconciles it non-destructively).

https://claude.ai/code/session_012pyBedVoUi1LVSpNvpqgfy