### PR TITLE
Fix #158: unrelated-history rescue tolerates a dirty sync worktree

### DIFF
--- a/docs/project/specs/active/plan-2026-05-29-tbd-sync-unrelated-history-hardening.md
+++ b/docs/project/specs/active/plan-2026-05-29-tbd-sync-unrelated-history-hardening.md
@@ -274,9 +274,16 @@ New function invoked by `tbd doctor --fix` when `unrelated` is detected.
 **Locking and preconditions (same contract as `initWorktree` / `repairWorktree`).** The
 whole rescue runs inside `withSharedDataSyncLock` so a concurrent `tbd create` /
 `tbd sync` from a sibling worktree cannot race the reset/replay window.
-Before mutating: require a clean data-sync worktree with no merge/rebase in progress (no
-`MERGE_HEAD`/in-progress operation, no unstaged changes); if dirty, abort with guidance
-to resolve or stash first rather than resetting over uncommitted work.
+Before mutating: abort on a merge/rebase in progress (`MERGE_HEAD`/in-progress
+operation).
+
+> **Superseded (2026-06-03, #158 / PR #160,
+> `plan-2026-06-03-unrelated-rescue-dirty-worktree.md`):** the original “abort on a
+> dirty data-sync worktree” precondition was relaxed.
+> A merely-dirty worktree holds tbd’s own uncommitted data-sync writes, which the rescue
+> now commits first (so the `tbd-backup-*` branch captures them) before the
+> reset/replay; only dirty paths *outside* the data-sync tree abort.
+> The merge-in-progress guard is unchanged.
 
 1. `git fetch origin tbd-sync`.
 2. Safety net: `git branch tbd-backup-<nowFilenameTimestamp()> <local tbd-sync HEAD>`

--- a/docs/project/specs/active/plan-2026-06-03-unrelated-rescue-dirty-worktree.md
+++ b/docs/project/specs/active/plan-2026-06-03-unrelated-rescue-dirty-worktree.md
@@ -1,0 +1,246 @@
+# Feature: Unrelated-history rescue tolerates a dirty sync worktree (no advice loop)
+
+**Date:** 2026-06-03 (last updated 2026-06-03)
+
+**Author:** Joshua Levy (with agent assistance)
+
+**Status:** Draft
+
+## Overview
+
+Issue **#158**: when `origin/tbd-sync` and the local `tbd-sync` branch have **unrelated
+histories**, `tbd sync` correctly refuses and points to `tbd doctor --fix`. But if the
+internal sync worktree is **transiently dirty** at that moment, the rescue
+(`rescueUnrelatedHistory`) *also* bails with “the tbd-sync worktree has uncommitted
+changes. Commit or stash them, then retry.”
+Two problems follow:
+
+1. The user never touches the internal worktree, so “commit or stash them” is misleading
+   — the dirtiness is tbd’s own transient data-sync state.
+2. `tbd sync` says run `tbd doctor --fix`; `doctor --fix` fails and a separate check
+   says run `tbd sync` — a closed **advice loop** with no terminating instruction.
+
+The rescue logic itself is correct: it already snapshots the working tree before its
+`reset --hard` and replays local work.
+The refusal is **over-cautious**. This is a UX/robustness fix, not a correctness bug in
+the merge.
+
+A **secondary** concern in the report — `tbd sync` printing `Error:` but exiting 0 — is
+**already fixed on current `main`**: the up-front unrelated-history detection throws
+`UnrelatedHistoriesError` (exit code 1), verified empirically.
+We lock that in with a test and audit the remaining soft-fail push path.
+
+## Goals
+
+- `tbd doctor --fix` completes the unrelated-history rescue when the only blocker is a
+  dirty sync worktree (tbd’s own uncommitted data-sync writes), instead of refusing.
+- The `tbd-backup-*` safety branch faithfully captures the pre-rescue state
+  **including** any uncommitted worktree changes.
+- A genuine **merge-in-progress** in the sync worktree is still refused — with a clear,
+  single terminating instruction (no loop).
+- `tbd doctor` no longer emits the contradictory `diverged → run tbd sync` suggestion
+  when the histories are unrelated (the remediation is the rescue, not sync).
+- `tbd sync` exits non-zero on a hard unrelated-history failure (regression-tested), and
+  the soft push-failure-to-outbox exit behavior is audited and documented.
+
+## Non-Goals
+
+- No change to the rescue’s reconciliation algorithm (ULID buckets, attic preservation,
+  ID-mapping union) — only its dirty-worktree precondition.
+- No change to the on-disk format or the unrelated-history *detection* logic.
+- Not changing the soft-fail-to-outbox design for recoverable network push failures
+  (those intentionally save data and may exit 0); only auditing/clarifying it.
+
+## Background
+
+### Why the dirty refusal is unnecessary (verified against current source)
+
+`rescueUnrelatedHistory` (`packages/tbd/src/file/git.ts:1878`) runs under
+`withSharedDataSyncLock` and today refuses up front:
+
+```ts
+const dirty = (await git('-C', worktreePath, 'status', '--porcelain')).trim();
+if (dirty) {
+  throw new Error('Refusing to rescue: the tbd-sync worktree has uncommitted changes. '
+    + 'Commit or stash them, then retry.');           // git.ts:1888-1892
+}
+```
+
+But the steps that follow already make a dirty worktree safe:
+
+- **Step 3 (`git.ts:1908`)** captures `localIssues = await listIssues(dataSyncPath)`
+  from the **working tree** — uncommitted issue writes included — and the same for
+  `bothDifferent` local sides.
+  The replay (step 5) re-writes these onto the adopted remote base, so uncommitted local
+  work is **not** lost by the `reset --hard`.
+- **The only real gap:** the backup branch (step 2, `git.ts:1913-1916`) is cut from the
+  **committed** `localHead`, so it does *not* include uncommitted work.
+  If anything went wrong mid-rescue, that uncommitted state would only exist in the
+  (about-to-be-reset) working tree.
+
+So the correct fix is not to refuse, but to **commit the pending data-sync state first**
+(the worktree is dedicated to `.tbd/data-sync/`), then cut the backup branch from that
+inclusive HEAD, then proceed.
+The lock guarantees no concurrent writer races this.
+
+A genuine **merge-in-progress** (`MERGE_HEAD` present, `git.ts:1894-1902`) is different
+— a half-finished merge is an unsafe base to reset over — so that refusal stays, but
+with a terminating message.
+
+### The advice loop (two different checks)
+
+- `classifyRemoteSyncHealth` (`doctor.ts:75-82`) reports unrelated histories → “Run: tbd
+  doctor --fix”. With `--fix`, the rescue runs (`doctor.ts:1290-1311`); on the dirty
+  refusal it returns `rescue failed: …` + “Resolve manually…”.
+- Separately, `checkSyncConsistency` (Check 15, `doctor.ts:1465`) sees ahead>0 &&
+  behind>0 (always true for unrelated histories) and emits
+  `diverged (N ahead, M behind)` → **“Run: tbd sync to reconcile”**.
+- `tbd sync` then says run `tbd doctor --fix`. Loop.
+
+Breaking it: `checkSyncConsistency` must be **unrelated-aware** and not suggest
+`tbd sync` when the histories are unrelated (defer to the rescue finding).
+
+### Secondary: sync exit code (already correct on main)
+
+Reproduced an unrelated-history `tbd sync` against current `main`: it prints the
+`UnrelatedHistoriesError` and **exits 1** (the up-front detection at `sync.ts:~865`
+throws; `UnrelatedHistoriesError extends SyncError` → `exitCode = 1` →
+`cli.ts:285-287`). The v0.2.2 “exit 0” came from the older push-failure path.
+We add a regression test, and audit the generic push-failure fall-through
+(`sync.ts:~1048` `return;`) which still exits 0 for *other* (e.g. network) failures —
+that is the deliberate soft-fail-to-outbox behavior; we confirm it only applies when
+data was actually saved and document the distinction.
+
+## Design
+
+### Approach
+
+Three small, independently testable changes.
+TDD throughout.
+
+### Components
+
+| Area | File | Change |
+| --- | --- | --- |
+| Rescue precondition | `packages/tbd/src/file/git.ts` `rescueUnrelatedHistory` | If the worktree is dirty (and not a merge-in-progress) and all changes are within the data-sync tree, commit them first; cut the backup branch from that HEAD; proceed. Keep + reword the merge-in-progress refusal. |
+| Loop break | `packages/tbd/src/cli/commands/doctor.ts` `checkSyncConsistency` | When `checkRemoteBranchHealth(...).unrelated`, don’t suggest `tbd sync`; defer to the rescue (point at `tbd doctor --fix`, or stay quiet since the Remote-sync-branch check owns it). |
+| Rescue-failure message | `doctor.ts` (`:1307-1308`) | Give one terminating next step for the residual merge-in-progress case. |
+| Exit-code regression + audit | `packages/tbd/tests/…` + `sync.ts` | Test `tbd sync` exits non-zero on unrelated histories; audit/justify the soft-fail-to-outbox exit-0 path (and make a truly unrecoverable failure non-zero if the audit finds a gap). |
+
+### Detailed design
+
+#### A. Rescue tolerates a dirty worktree
+
+In `rescueUnrelatedHistory`, replace the dirty refusal with a commit-first step.
+Sketch:
+
+```ts
+// merge-in-progress is genuinely unsafe — refuse with a terminating instruction.
+if (await mergeInProgress(worktreePath)) {
+  throw new Error(
+    'Refusing to rescue: a merge is in progress in the tbd-sync worktree at '
+    + `${worktreePath}. Run \`git -C <path> merge --abort\`, then re-run \`tbd doctor --fix\`.`,
+  );
+}
+
+// A dirty worktree is tbd's own uncommitted data-sync state (this worktree only ever
+// holds .tbd/data-sync/). Commit it so the backup branch captures it faithfully and the
+// reset is safe. Guard: if anything outside the data-sync tree is dirty, refuse clearly.
+const dirty = (await git('-C', worktreePath, 'status', '--porcelain')).trim();
+if (dirty) {
+  assertOnlyDataSyncPaths(dirty);                 // else: terminating refusal
+  await git('-C', worktreePath, 'add', '-A');
+  await gitCommit(worktreePath, '--no-verify', '-m',
+    'tbd rescue: snapshot uncommitted data-sync state before rescue');
+}
+// ...then capture localHead (now inclusive), cut backup branch, proceed as today.
+```
+
+The existing snapshot/replay (steps 3 & 5) is unchanged; committing first only makes the
+backup branch faithful and removes the refusal.
+
+#### B. `checkSyncConsistency` is unrelated-aware
+
+Before returning the `diverged → tbd sync` warning, consult
+`checkRemoteBranchHealth(remote, syncBranch)`; if `unrelated`, return a finding that
+either stays silent on the suggestion or points at `tbd doctor --fix` — never
+`tbd sync`. This is the single edge that closes the loop.
+
+#### C. Exit-code test + push-path audit
+
+- Regression test (integration/tryscript): build unrelated `tbd-sync` roots, run
+  `tbd sync`, assert non-zero exit and the `UnrelatedHistoriesError` message.
+- Audit `pushChanges`/`fullSync` push-failure handling: confirm the `return;` (exit 0)
+  path is reached **only** after a successful outbox save; if a push fails *and* the
+  save fails, ensure that exits non-zero.
+  Document the soft-vs-hard distinction in a code comment and the spec.
+
+## Implementation Plan
+
+### Phase 1: Rescue tolerates dirty worktree + break the loop
+
+- [ ] Failing test: `rescueUnrelatedHistory` against a temp repo with a **dirty** sync
+  worktree succeeds (adopts remote base, replays local-only, backup branch includes the
+  previously-uncommitted work); a **merge-in-progress** worktree still refuses with the
+  terminating message.
+  (Red.)
+- [ ] Implement the commit-first precondition + reworded merge-in-progress refusal.
+  (Green.)
+- [ ] Failing test: `checkSyncConsistency` does not suggest `tbd sync` when histories
+  are unrelated. (Red → Green.)
+- [ ] e2e tryscript: unrelated histories + dirty worktree → `tbd doctor --fix` rescues
+  in one shot; `tbd sync` → in sync.
+  No `commit or stash` dead-end, no loop.
+
+### Phase 2: Exit-code regression + soft-fail audit
+
+- [ ] Regression test: `tbd sync` exits non-zero on unrelated histories.
+- [ ] Audit the push-failure-to-outbox path; add a test that a push failure whose outbox
+  save also fails exits non-zero, and document the soft-fail-exit-0 contract.
+
+## Testing Strategy
+
+- **Unit/integration** — `rescueUnrelatedHistory` dirty-worktree and merge-in-progress
+  cases against real `git` (temp repos), asserting backup-branch fidelity and replay.
+- **Doctor** — `checkSyncConsistency` unrelated-aware behavior (extend `doctor-*`
+  tests).
+- **Golden/tryscript** — extend `cli-sync-unrelated-rescue.tryscript.md` (or a sibling)
+  with the dirty-worktree path and the exit-code assertion.
+  Filter unstable fields (timestamps, ULIDs, backup-branch names) per the golden-testing
+  guideline.
+- TDD: one failing test per behavior before the fix; keep structural and behavioral
+  commits separate.
+
+## Rollout Plan
+
+Lands on `claude/fix-158-unrelated-rescue-dirty-worktree` → draft PR referencing #158.
+Phase 1 is the user-facing fix; Phase 2 locks in the exit-code contract.
+Ships in the next `get-tbd` release; existing stuck repos are unblocked by upgrading and
+re-running `tbd doctor --fix`.
+
+## Open Questions
+
+- **Resolved (per user):** relax the precondition (commit-first), not messaging-only;
+  and do the exit-code test **plus** the push-path audit.
+- If a dirty worktree ever contains paths outside `.tbd/data-sync/` (should be
+  impossible — it is a dedicated worktree), the rescue refuses with a terminating
+  message rather than committing foreign changes.
+  Confirm no tool writes there.
+
+## References
+
+- Issue: #158 (dirty sync-worktree masks the unrelated-history rescue path).
+- `packages/tbd/src/file/git.ts` — `rescueUnrelatedHistory` (1878), dirty refusal
+  (1888-1892), merge-in-progress refusal (1894-1902), working-tree snapshot (1908),
+  backup branch (1913-1916), `reset --hard` (1923).
+- `packages/tbd/src/cli/commands/doctor.ts` — `classifyRemoteSyncHealth` (67), rescue
+  invocation (1290-1311), `checkSyncConsistency` (1465).
+- `packages/tbd/src/cli/commands/sync.ts` — up-front unrelated detection + throw,
+  push-failure fall-through.
+  `packages/tbd/src/cli/lib/errors.ts` — `UnrelatedHistoriesError`.
+- Prior art: `plan-2026-05-29-tbd-sync-unrelated-history-hardening.md` (introduced the
+  rescue and the up-front detection).
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/docs/project/specs/active/plan-2026-06-03-unrelated-rescue-dirty-worktree.md
+++ b/docs/project/specs/active/plan-2026-06-03-unrelated-rescue-dirty-worktree.md
@@ -4,7 +4,7 @@
 
 **Author:** Joshua Levy (with agent assistance)
 
-**Status:** Draft
+**Status:** Implemented (PR pending)
 
 ## Overview
 
@@ -179,23 +179,23 @@ either stays silent on the suggestion or points at `tbd doctor --fix` — never
 
 ### Phase 1: Rescue tolerates dirty worktree + break the loop
 
-- [ ] Failing test: `rescueUnrelatedHistory` against a temp repo with a **dirty** sync
+- [x] Failing test: `rescueUnrelatedHistory` against a temp repo with a **dirty** sync
   worktree succeeds (adopts remote base, replays local-only, backup branch includes the
   previously-uncommitted work); a **merge-in-progress** worktree still refuses with the
   terminating message.
   (Red.)
-- [ ] Implement the commit-first precondition + reworded merge-in-progress refusal.
+- [x] Implement the commit-first precondition + reworded merge-in-progress refusal.
   (Green.)
-- [ ] Failing test: `checkSyncConsistency` does not suggest `tbd sync` when histories
+- [x] Failing test: `checkSyncConsistency` does not suggest `tbd sync` when histories
   are unrelated. (Red → Green.)
-- [ ] e2e tryscript: unrelated histories + dirty worktree → `tbd doctor --fix` rescues
+- [x] e2e tryscript: unrelated histories + dirty worktree → `tbd doctor --fix` rescues
   in one shot; `tbd sync` → in sync.
   No `commit or stash` dead-end, no loop.
 
 ### Phase 2: Exit-code regression + soft-fail audit
 
-- [ ] Regression test: `tbd sync` exits non-zero on unrelated histories.
-- [ ] Audit the push-failure-to-outbox path; add a test that a push failure whose outbox
+- [x] Regression test: `tbd sync` exits non-zero on unrelated histories.
+- [x] Audit the push-failure-to-outbox path; add a test that a push failure whose outbox
   save also fails exits non-zero, and document the soft-fail-exit-0 contract.
 
 ## Testing Strategy

--- a/packages/tbd/src/cli/commands/doctor.ts
+++ b/packages/tbd/src/cli/commands/doctor.ts
@@ -91,6 +91,35 @@ export function classifyRemoteSyncHealth(
   }
   return { name: 'Remote sync branch', status: 'ok', message: `${remote}/${syncBranch}` };
 }
+
+/**
+ * The "Sync consistency" finding for a branch that is both ahead and behind.
+ *
+ * When the histories are unrelated, the remediation is the rescue
+ * (`tbd doctor --fix`), NOT `tbd sync` — otherwise the unrelated-history error
+ * (which says "run doctor --fix") and this warning (which would say "run sync")
+ * point at each other in a loop with no terminating instruction. See #158.
+ */
+export function divergenceFinding(
+  ahead: number,
+  behind: number,
+  unrelated: boolean,
+): DiagnosticResult {
+  if (unrelated) {
+    return {
+      name: 'Sync consistency',
+      status: 'warn',
+      message: `diverged (${ahead} ahead, ${behind} behind) — unrelated histories`,
+      suggestion: 'Run: tbd doctor --fix to reconcile the unrelated histories',
+    };
+  }
+  return {
+    name: 'Sync consistency',
+    status: 'warn',
+    message: `diverged (${ahead} ahead, ${behind} behind)`,
+    suggestion: 'Run: tbd sync to reconcile',
+  };
+}
 import { formatHeading } from '../lib/output.js';
 import {
   renderRepositorySection,
@@ -1492,12 +1521,11 @@ class DoctorHandler extends BaseCommand {
 
       // Check ahead/behind status
       if (consistency.localAhead > 0 && consistency.localBehind > 0) {
-        return {
-          name: 'Sync consistency',
-          status: 'warn',
-          message: `diverged (${consistency.localAhead} ahead, ${consistency.localBehind} behind)`,
-          suggestion: 'Run: tbd sync to reconcile',
-        };
+        // Unrelated histories are always "diverged" (no common ancestor), but
+        // their remediation is the rescue — suggesting `tbd sync` here forms a
+        // loop with the unrelated-history error. Defer to doctor --fix. (#158)
+        const { unrelated } = await checkRemoteBranchHealth(remote, syncBranch, this.cwd);
+        return divergenceFinding(consistency.localAhead, consistency.localBehind, unrelated);
       }
 
       if (consistency.localAhead > 0) {

--- a/packages/tbd/src/cli/commands/sync.ts
+++ b/packages/tbd/src/cli/commands/sync.ts
@@ -1026,9 +1026,10 @@ class SyncHandler extends BaseCommand {
 
       // Handle recovery based on error type (after output.data to avoid async callback)
       // Only show options in non-JSON mode
+      let recovered = false;
       if (errorType === 'permanent' && options.autoSave !== false) {
-        // Auto-save to outbox on permanent failure
-        await this.handlePermanentFailure();
+        // Auto-save to outbox on permanent failure (data durably preserved).
+        recovered = await this.handlePermanentFailure();
       } else if (!this.ctx.json) {
         if (errorType === 'transient') {
           // Suggest retry for transient failures
@@ -1044,6 +1045,14 @@ class SyncHandler extends BaseCommand {
           console.log("    • Run 'tbd sync --status' to check status");
           console.log('    • Save for later:  tbd save --outbox');
         }
+      }
+
+      // A push failure is a hard failure that CI/scripts must be able to detect,
+      // UNLESS the changes were durably saved to the outbox (the soft-fail
+      // recovery path). Local commits remain on tbd-sync either way, but the
+      // remote was not updated. (#158)
+      if (!recovered) {
+        process.exitCode = 1;
       }
       return;
     }
@@ -1066,14 +1075,18 @@ class SyncHandler extends BaseCommand {
   /**
    * Handle permanent push failure by auto-saving to outbox.
    * Called when push fails with a permanent error (e.g., HTTP 403).
+   *
+   * @returns true if the local changes are durably safe (saved to the outbox, or
+   *   nothing needed saving); false if the auto-save itself failed. The caller
+   *   uses this to decide the process exit code. (#158)
    */
-  private async handlePermanentFailure(): Promise<void> {
+  private async handlePermanentFailure(): Promise<boolean> {
     // Count issues in worktree to see if there's anything to save
     const worktreeIssues = await listIssues(this.dataSyncDir);
     if (worktreeIssues.length === 0) {
       console.log('');
       console.log('  No unsynced issues to save (already in sync with remote).');
-      return;
+      return true;
     }
 
     // Check existing outbox count before save
@@ -1128,6 +1141,7 @@ class SyncHandler extends BaseCommand {
           '  WARNING: Do NOT add .tbd/workspaces/ to .gitignore -- that would cause data loss.',
         );
       }
+      return true;
     } catch (saveError) {
       // Auto-save failed - report both errors
       const saveErrorMsg = saveError instanceof Error ? saveError.message : String(saveError);
@@ -1135,6 +1149,7 @@ class SyncHandler extends BaseCommand {
       this.output.error(`Auto-save to outbox also failed: ${saveErrorMsg}`);
       console.log('');
       console.log("  Run 'tbd save --outbox' manually, or 'tbd doctor' to diagnose.");
+      return false;
     }
   }
 

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -1872,8 +1872,10 @@ async function preserveLosingVersion(dataSyncPath: string, loser: Issue): Promis
  * backup branch is created, so the pre-rescue HEAD is always recoverable and
  * the rescue is restartable.
  *
- * MUST be called while holding `withSharedDataSyncLock`. Aborts if the
- * data-sync worktree is dirty or has a merge in progress.
+ * MUST be called while holding `withSharedDataSyncLock`. A merge in progress
+ * aborts the rescue; a merely-dirty worktree does not — its uncommitted
+ * tbd-owned data-sync changes are committed first (so the backup branch captures
+ * them), while any dirty path outside the data-sync tree aborts. See issue #158.
  */
 export async function rescueUnrelatedHistory(
   baseDir: string,

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -1883,21 +1883,42 @@ export async function rescueUnrelatedHistory(
   const { sharedWorktreePath: worktreePath, sharedDataSyncDir: dataSyncPath } =
     await getSharedPaths(baseDir);
 
-  // Preconditions: never reset over uncommitted work or an in-progress merge.
-  const dirty = (await git('-C', worktreePath, 'status', '--porcelain')).trim();
-  if (dirty) {
-    throw new Error(
-      'Refusing to rescue: the tbd-sync worktree has uncommitted changes. ' +
-        'Commit or stash them, then retry.',
-    );
-  }
+  // Preconditions. A half-finished merge is a genuinely unsafe base to reset
+  // over, so refuse it. But a merely-dirty worktree is tbd's own uncommitted
+  // data-sync state (this worktree is dedicated to DATA_SYNC_DIR) — commit it
+  // first so the backup branch captures it faithfully and the reset is safe,
+  // rather than refusing and sending the user into a sync ⇄ doctor loop. (#158)
   const mergeInProgress = await git('-C', worktreePath, 'rev-parse', '-q', '--verify', 'MERGE_HEAD')
     .then(() => true)
     .catch(() => false);
   if (mergeInProgress) {
     throw new Error(
-      'Refusing to rescue: a merge is in progress in the tbd-sync worktree. ' +
-        'Resolve or abort it, then retry.',
+      'Refusing to rescue: a merge is in progress in the tbd-sync worktree at ' +
+        `${worktreePath}. Run \`git -C "${worktreePath}" merge --abort\`, then re-run ` +
+        '`tbd doctor --fix`.',
+    );
+  }
+
+  const dirty = (await git('-C', worktreePath, 'status', '--porcelain')).trim();
+  if (dirty) {
+    // Defensive: this worktree only ever holds DATA_SYNC_DIR. If anything
+    // outside it is dirty, do not auto-commit foreign changes — refuse clearly.
+    const foreign = dirty
+      .split('\n')
+      .map((line) => line.slice(3).trim())
+      .filter((p) => p && !p.startsWith(`${DATA_SYNC_DIR}/`));
+    if (foreign.length > 0) {
+      throw new Error(
+        'Refusing to rescue: the tbd-sync worktree has changes outside the data-sync ' +
+          `tree (${foreign.join(', ')}). Remove or commit them, then re-run \`tbd doctor --fix\`.`,
+      );
+    }
+    await git('-C', worktreePath, 'add', '-A');
+    await gitCommit(
+      worktreePath,
+      '--no-verify',
+      '-m',
+      'tbd rescue: snapshot uncommitted data-sync state before rescue',
     );
   }
 

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -1903,14 +1903,14 @@ export async function rescueUnrelatedHistory(
   if (dirty) {
     // Defensive: this worktree only ever holds DATA_SYNC_DIR. If anything
     // outside it is dirty, do not auto-commit foreign changes — refuse clearly.
-    const foreign = dirty
-      .split('\n')
-      .map((line) => line.slice(3).trim())
-      .filter((p) => p && !p.startsWith(`${DATA_SYNC_DIR}/`));
-    if (foreign.length > 0) {
+    // Let git do the filtering (an exclude pathspec) rather than parse porcelain.
+    const foreign = (
+      await git('-C', worktreePath, 'status', '--porcelain', '--', '.', `:!${DATA_SYNC_DIR}`)
+    ).trim();
+    if (foreign) {
       throw new Error(
         'Refusing to rescue: the tbd-sync worktree has changes outside the data-sync ' +
-          `tree (${foreign.join(', ')}). Remove or commit them, then re-run \`tbd doctor --fix\`.`,
+          `tree:\n${foreign}\nRemove or commit them, then re-run \`tbd doctor --fix\`.`,
       );
     }
     await git('-C', worktreePath, 'add', '-A');

--- a/packages/tbd/tests/cli-sync-push-failure-exit-code-158.tryscript.md
+++ b/packages/tbd/tests/cli-sync-push-failure-exit-code-158.tryscript.md
@@ -1,0 +1,61 @@
+---
+sandbox: true
+env:
+  NO_COLOR: '1'
+  FORCE_COLOR: '0'
+path:
+  - ../dist
+timeout: 60000
+patterns:
+  ULID: '[0-9a-z]{26}'
+  SHORTID: '[0-9a-z]{4,5}'
+  TIMESTAMP: "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z"
+before: |
+  git init --initial-branch=main
+  git config user.email "test@example.com"
+  git config user.name "Test User"
+  git config commit.gpgsign false
+  echo "# Test repo" > README.md
+  git add README.md
+  git commit -m "Initial commit"
+
+  tbd init --prefix=test >/dev/null
+  tbd create "Local issue" --type=task >/dev/null
+  tbd sync >/dev/null 2>&1 || true
+---
+# tbd CLI: A push failure that isn’t durably saved exits non-zero (#158)
+
+A hard sync failure must be detectable by CI/scripts.
+When a push fails and the changes were NOT durably saved to the outbox, `tbd sync` exits
+non-zero (local commits remain on tbd-sync, but the remote was not updated).
+It still prints the retry guidance.
+
+See: plan-2026-06-03-unrelated-rescue-dirty-worktree.md (PR #158 review)
+
+* * *
+
+## A push to an unreachable remote fails hard
+
+# Test: tbd sync exits non-zero when the push fails and nothing was saved
+
+```console
+$ git remote add origin ./nonexistent-remote.git; tbd sync > out.txt 2>&1 && echo "UNEXPECTED-OK" || echo "failed-nonzero"
+failed-nonzero
+? 0
+```
+
+# Test: It still reports the failure and offers recovery options
+
+```console
+$ grep -c "Push failed" out.txt | tr -d ' '
+1
+? 0
+```
+
+# Test: The local commit is not lost (still on tbd-sync, just unpushed)
+
+```console
+$ tbd list --json 2>/dev/null | jq -r '[.[] | select(.title == "Local issue")] | length'
+1
+? 0
+```

--- a/packages/tbd/tests/cli-sync-unrelated-dirty-rescue-158.tryscript.md
+++ b/packages/tbd/tests/cli-sync-unrelated-dirty-rescue-158.tryscript.md
@@ -1,0 +1,113 @@
+---
+sandbox: true
+env:
+  NO_COLOR: '1'
+  FORCE_COLOR: '0'
+path:
+  - ../dist
+timeout: 60000
+patterns:
+  ULID: '[0-9a-z]{26}'
+  SHORTID: '[0-9a-z]{4,5}'
+  TIMESTAMP: "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z"
+before: |
+  # Isolated bare repo as "origin" with an UNRELATED orphan tbd-sync (env B).
+  rm -rf ../origin-158.git ../seed-158
+  mkdir -p ../origin-158.git
+  git init --bare ../origin-158.git
+
+  mkdir -p ../seed-158/.tbd/data-sync/issues
+  ( cd ../seed-158
+    git init --initial-branch=tbd-sync
+    git config user.email "b@example.com"
+    git config user.name "Env B"
+    git config commit.gpgsign false
+    printf '%s\n' '---' 'type: is' 'id: is-01aaaaaaaaaaaaaaaaaaaaaa01' 'title: Remote only issue' \
+      'status: open' 'kind: task' 'priority: 2' 'version: 1' \
+      'created_at: 2026-01-01T00:00:00.000Z' 'updated_at: 2026-01-01T00:00:00.000Z' '---' 'env B body' \
+      > .tbd/data-sync/issues/is-01aaaaaaaaaaaaaaaaaaaaaa01.md
+    git add -A
+    git commit -m "env B orphan"
+    git push ../origin-158.git tbd-sync:refs/heads/tbd-sync )
+
+  # Primary repo with its own independent orphan tbd-sync (unrelated to env B).
+  git init --initial-branch=main
+  git config user.email "test@example.com"
+  git config user.name "Test User"
+  git config commit.gpgsign false
+  echo "# Test repo" > README.md
+  git add README.md
+  git commit -m "Initial commit"
+
+  tbd init --prefix=test >/dev/null
+  tbd create "Local only issue" --type=task >/dev/null
+  tbd sync >/dev/null 2>&1 || true
+  git remote add origin ../origin-158.git
+---
+# tbd CLI: Unrelated history + dirty worktree rescues in one shot (#158)
+
+A transiently dirty sync worktree (tbd’s own uncommitted data-sync writes) must not
+block the unrelated-history rescue, and `tbd doctor` must not bounce the user between
+`tbd sync` and `tbd doctor --fix`.
+
+See: plan-2026-06-03-unrelated-rescue-dirty-worktree.md
+
+* * *
+
+## A dirty internal worktree at the moment of rescue
+
+# Test: Leave an uncommitted issue in the sync worktree
+
+```console
+$ WT="$(git rev-parse --path-format=absolute --git-common-dir)/tbd/data-sync-worktree"; printf '%s\n' '---' 'type: is' 'id: is-01aaaaaaaaaaaaaaaaaaaaaa02' 'title: Uncommitted local' 'status: open' 'kind: task' 'priority: 2' 'version: 1' 'created_at: 2026-01-02T00:00:00.000Z' 'updated_at: 2026-01-02T00:00:00.000Z' '---' body > "$WT/.tbd/data-sync/issues/is-01aaaaaaaaaaaaaaaaaaaaaa02.md"; git -C "$WT" status --porcelain | grep -c . | tr -d ' '
+1
+? 0
+```
+
+* * *
+
+## doctor must route to the rescue, not loop back to sync
+
+# Test: Sync-consistency does not bounce the user to `tbd sync` for unrelated histories
+
+```console
+$ tbd doctor 2>&1 | grep -i "Sync consistency" -A1 | grep -ci "run: tbd sync to reconcile" | tr -d ' '
+0
+? 0
+```
+
+* * *
+
+## doctor --fix rescues in one shot despite the dirty worktree
+
+# Test: tbd doctor --fix succeeds (no “uncommitted changes” dead-end)
+
+```console
+$ tbd doctor --fix 2>&1 | grep -i "Remote sync branch"
+[..]Remote sync branch - rescued: adopted origin/tbd-sync base[..]
+? 0
+```
+
+# Test: The rescue never printed the dirty-worktree refusal
+
+```console
+$ tbd doctor 2>&1 | grep -ci "uncommitted changes" | tr -d ' '
+0
+? 0
+```
+
+# Test: origin/tbd-sync is now an ancestor (push fast-forwards)
+
+```console
+$ git fetch -q origin tbd-sync && git merge-base --is-ancestor origin/tbd-sync tbd-sync && echo "fast-forwardable"
+fast-forwardable
+? 0
+```
+
+# Test: tbd sync settles, and the previously-uncommitted issue survived
+
+```console
+$ tbd sync >/dev/null 2>&1; tbd list --json 2>/dev/null | jq -r '[.[] | select(.title == "Uncommitted local")] | length'
+1
+? 0
+```

--- a/packages/tbd/tests/cli-sync-unrelated-rescue.tryscript.md
+++ b/packages/tbd/tests/cli-sync-unrelated-rescue.tryscript.md
@@ -81,6 +81,14 @@ attached
 ? 0
 ```
 
+# Test: tbd sync exits non-zero on unrelated histories (hard failure, not exit 0)
+
+```console
+$ tbd sync > /dev/null 2>&1 && echo "UNEXPECTED-OK" || echo "failed-nonzero"
+failed-nonzero
+? 0
+```
+
 * * *
 
 ## Detection: doctor reports a hard finding routed to --fix

--- a/packages/tbd/tests/cli-sync.tryscript.md
+++ b/packages/tbd/tests/cli-sync.tryscript.md
@@ -81,7 +81,7 @@ $ tbd sync
     • Retry:  tbd sync
     • Run 'tbd sync --status' to check status
     • Save for later:  tbd save --outbox
-? 0
+? 1
 ```
 
 # Test: After sync, no uncommitted changes remain
@@ -151,7 +151,7 @@ $ tbd sync
     • Retry:  tbd sync
     • Run 'tbd sync --status' to check status
     • Save for later:  tbd save --outbox
-? 0
+? 1
 ```
 
 # Test: All changes committed
@@ -253,7 +253,7 @@ $ tbd sync
     • Retry:  tbd sync
     • Run 'tbd sync --status' to check status
     • Save for later:  tbd save --outbox
-? 0
+? 1
 ```
 
 * * *
@@ -274,7 +274,7 @@ $ tbd sync
     • Retry:  tbd sync
     • Run 'tbd sync --status' to check status
     • Save for later:  tbd save --outbox
-? 0
+? 1
 ```
 
 ```console
@@ -287,7 +287,7 @@ $ tbd sync
     • Retry:  tbd sync
     • Run 'tbd sync --status' to check status
     • Save for later:  tbd save --outbox
-? 0
+? 1
 ```
 
 # Test: No uncommitted changes after double sync
@@ -327,7 +327,7 @@ $ tbd sync --json
   "unpushedCommits": 4,
   "errorType": "unknown"
 }
-? 0
+? 1
 ```
 
 * * *

--- a/packages/tbd/tests/doctor-unrelated.test.ts
+++ b/packages/tbd/tests/doctor-unrelated.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { classifyRemoteSyncHealth } from '../src/cli/commands/doctor.js';
+import { classifyRemoteSyncHealth, divergenceFinding } from '../src/cli/commands/doctor.js';
 import type { RemoteBranchHealth } from '../src/file/git.js';
 
 const base: RemoteBranchHealth = { exists: true, diverged: false, unrelated: false };
@@ -46,5 +46,21 @@ describe('classifyRemoteSyncHealth', () => {
       'tbd-sync',
     );
     expect(diag).toBeNull();
+  });
+});
+
+describe('divergenceFinding (#158 — break the sync ⇄ doctor loop)', () => {
+  it('points a plain divergence at tbd sync', () => {
+    const diag = divergenceFinding(2, 3, false);
+    expect(diag.message).toMatch(/diverged \(2 ahead, 3 behind\)/);
+    expect(diag.suggestion).toMatch(/tbd sync/);
+  });
+
+  it('points an unrelated divergence at doctor --fix, never tbd sync', () => {
+    // For unrelated histories the remediation is the rescue; suggesting tbd sync
+    // forms a loop (sync → doctor --fix → sync).
+    const diag = divergenceFinding(2, 92, true);
+    expect(diag.suggestion).toMatch(/doctor --fix/);
+    expect(diag.suggestion).not.toMatch(/tbd sync/);
   });
 });

--- a/packages/tbd/tests/rescue-dirty-worktree.test.ts
+++ b/packages/tbd/tests/rescue-dirty-worktree.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Integration tests for rescueUnrelatedHistory's worktree preconditions (#158).
+ *
+ * A transiently dirty sync worktree (tbd's own uncommitted data-sync writes)
+ * must NOT block the rescue: the rescue commits that state first (so the
+ * tbd-backup-* branch captures it faithfully) and proceeds. A genuine
+ * merge-in-progress is still refused.
+ *
+ * See: plan-2026-06-03-unrelated-rescue-dirty-worktree.md
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, rm, writeFile as fsWriteFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir, platform } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { initWorktree, rescueUnrelatedHistory, branchExists } from '../src/file/git.js';
+import { writeIssue, listIssues } from '../src/file/storage.js';
+import { SYNC_BRANCH, TBD_DIR, DATA_SYNC_DIR_NAME } from '../src/lib/paths.js';
+import { createTestIssue } from './test-helpers.js';
+
+const execFileAsync = promisify(execFile);
+const isWindows = platform() === 'win32';
+const describeUnlessWindows = isWindows ? describe.skip : describe;
+
+async function g(dir: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, {
+    cwd: dir,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+  });
+  return stdout.trim();
+}
+
+const LOCAL_ONLY = '01rescuedirty0000localonly';
+const REMOTE_ONLY = '01rescuedirty000remoteonly';
+const DIRTY = '01rescuedirty0000000dirty1';
+
+const issuesRel = `${TBD_DIR}/${DATA_SYNC_DIR_NAME}/issues`;
+
+describeUnlessWindows('rescueUnrelatedHistory worktree preconditions (#158)', () => {
+  let testDir: string;
+  let workPath: string;
+  let worktreePath: string;
+  let dataSyncPath: string;
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `tbd-rescue-dirty-${randomBytes(4).toString('hex')}`);
+    const barePath = join(testDir, 'remote.git');
+    workPath = join(testDir, 'work');
+    await mkdir(barePath, { recursive: true });
+    await g(barePath, 'init', '--bare');
+
+    // Work repo, no remote yet → initWorktree creates a local orphan tbd-sync.
+    await mkdir(workPath, { recursive: true });
+    await g(workPath, 'init', '-b', 'main');
+    await g(workPath, 'config', 'user.email', 't@t.com');
+    await g(workPath, 'config', 'user.name', 'T');
+    await g(workPath, 'config', 'commit.gpgsign', 'false');
+    await fsWriteFile(join(workPath, 'README.md'), '# t\n');
+    await g(workPath, 'add', '.');
+    await g(workPath, 'commit', '-m', 'init');
+
+    const init = await initWorktree(workPath);
+    expect(init.success).toBe(true);
+    worktreePath = join(workPath, '.git', 'tbd', 'data-sync-worktree');
+    dataSyncPath = join(worktreePath, TBD_DIR, DATA_SYNC_DIR_NAME);
+
+    // Commit one local-only issue.
+    await writeIssue(
+      dataSyncPath,
+      createTestIssue({ id: `is-${LOCAL_ONLY}`, title: 'local only' }),
+    );
+    await g(worktreePath, 'add', '-A');
+    await g(worktreePath, '-c', 'commit.gpgsign=false', 'commit', '-m', 'local work');
+
+    // Seed the bare remote with an UNRELATED orphan tbd-sync.
+    const seed = join(testDir, 'seedB');
+    await mkdir(join(seed, TBD_DIR, DATA_SYNC_DIR_NAME, 'issues'), { recursive: true });
+    await g(seed, 'init', '-b', SYNC_BRANCH);
+    await g(seed, 'config', 'user.email', 'b@b.com');
+    await g(seed, 'config', 'user.name', 'B');
+    await g(seed, 'config', 'commit.gpgsign', 'false');
+    await writeIssue(
+      join(seed, TBD_DIR, DATA_SYNC_DIR_NAME),
+      createTestIssue({ id: `is-${REMOTE_ONLY}`, title: 'remote only' }),
+    );
+    await g(seed, 'add', '-A');
+    await g(seed, 'commit', '-m', 'env B');
+    await g(seed, 'push', barePath, `${SYNC_BRANCH}:refs/heads/${SYNC_BRANCH}`);
+
+    await g(workPath, 'remote', 'add', 'origin', barePath);
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  it('rescues over a dirty worktree and the backup branch captures the uncommitted work', async () => {
+    // tbd's own uncommitted write lands in the worktree (e.g. a sync in flight).
+    await writeIssue(dataSyncPath, createTestIssue({ id: `is-${DIRTY}`, title: 'uncommitted' }));
+    expect((await g(worktreePath, 'status', '--porcelain')).trim()).not.toBe('');
+
+    const result = await rescueUnrelatedHistory(workPath, 'origin', SYNC_BRANCH);
+
+    // Backup branch exists and faithfully includes the previously-uncommitted file.
+    expect(await branchExists(result.backupBranch, workPath)).toBe(true);
+    await expect(
+      g(workPath, 'cat-file', '-e', `${result.backupBranch}:${issuesRel}/is-${DIRTY}.md`),
+    ).resolves.toBe('');
+
+    // The uncommitted local-only issue survived the rescue (replayed onto base).
+    const ids = (await listIssues(dataSyncPath)).map((i) => i.id).sort();
+    expect(ids).toEqual([`is-${DIRTY}`, `is-${LOCAL_ONLY}`, `is-${REMOTE_ONLY}`].sort());
+
+    // Push will fast-forward.
+    await expect(
+      g(workPath, 'merge-base', '--is-ancestor', `origin/${SYNC_BRANCH}`, SYNC_BRANCH),
+    ).resolves.toBe('');
+  });
+
+  it('still refuses when a merge is in progress in the sync worktree', async () => {
+    const head = await g(worktreePath, 'rev-parse', 'HEAD');
+    // Simulate a half-finished merge without a real conflict.
+    await g(worktreePath, 'update-ref', 'MERGE_HEAD', head);
+
+    await expect(rescueUnrelatedHistory(workPath, 'origin', SYNC_BRANCH)).rejects.toThrow(
+      /merge is in progress/,
+    );
+  });
+});

--- a/packages/tbd/tests/rescue-dirty-worktree.test.ts
+++ b/packages/tbd/tests/rescue-dirty-worktree.test.ts
@@ -122,9 +122,11 @@ describeUnlessWindows('rescueUnrelatedHistory worktree preconditions (#158)', ()
   });
 
   it('still refuses when a merge is in progress in the sync worktree', async () => {
+    // Simulate a half-finished merge by writing MERGE_HEAD directly. (Newer git
+    // refuses `update-ref MERGE_HEAD` as a pseudoref, so write the file.)
+    const gitDir = await g(worktreePath, 'rev-parse', '--absolute-git-dir');
     const head = await g(worktreePath, 'rev-parse', 'HEAD');
-    // Simulate a half-finished merge without a real conflict.
-    await g(worktreePath, 'update-ref', 'MERGE_HEAD', head);
+    await fsWriteFile(join(gitDir, 'MERGE_HEAD'), `${head}\n`);
 
     await expect(rescueUnrelatedHistory(workPath, 'origin', SYNC_BRANCH)).rejects.toThrow(
       /merge is in progress/,

--- a/packages/tbd/tests/rescue-divergence.test.ts
+++ b/packages/tbd/tests/rescue-divergence.test.ts
@@ -5,7 +5,8 @@
  *   identical             -> no-op
  *   same-origin field diff -> field-merge (no data discarded, no attic)
  *   true conflict          -> losing version preserved in attic/conflicts/
- * Plus preconditions: rescue aborts on a dirty worktree or a merge in progress
+ * Plus preconditions: rescue tolerates a dirty worktree (commits it first) but
+ * still aborts on a merge in progress
  * (never resets over uncommitted work).
  *
  * See: plan-2026-05-29-tbd-sync-unrelated-history-hardening.md (Phase 2 tests)
@@ -19,7 +20,7 @@ import { randomBytes } from 'node:crypto';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
-import { initWorktree, rescueUnrelatedHistory } from '../src/file/git.js';
+import { initWorktree, rescueUnrelatedHistory, branchExists } from '../src/file/git.js';
 import { writeIssue, readIssue } from '../src/file/storage.js';
 import { loadIdMapping, saveIdMapping, type IdMapping } from '../src/file/id-mapping.js';
 import { SYNC_BRANCH, TBD_DIR, DATA_SYNC_DIR_NAME } from '../src/lib/paths.js';
@@ -285,23 +286,35 @@ describeUnlessWindows('rescue divergence matrix + preconditions', () => {
     expect(localHead).toBe(remoteHead);
   });
 
-  it('aborts on a dirty worktree without resetting or creating a backup branch', async () => {
+  it('tolerates a dirty worktree by committing it first, then rescues (#158)', async () => {
     const created = '2026-01-01T00:00:00Z';
     await buildUnrelated(
       createTestIssue({ id: `is-${SHARED}`, title: 'local', created_at: created }),
       createTestIssue({ id: `is-${SHARED}`, title: 'remote', created_at: created }),
     );
-    // Uncommitted change in the worktree.
-    await fsWriteFile(join(dataSyncPath, 'issues', 'is-01dirtyuncommitted00000000.md'), 'junk\n');
-
-    const headBefore = await g(workPath, 'rev-parse', SYNC_BRANCH);
-    await expect(rescueUnrelatedHistory(workPath, 'origin', SYNC_BRANCH)).rejects.toThrow(
-      /uncommitted changes/i,
+    // tbd's own uncommitted data-sync write (e.g. a sync caught mid-flight).
+    await writeIssue(
+      dataSyncPath,
+      createTestIssue({ id: 'is-01dirtyuncommitted00000001', title: 'uncommitted' }),
     );
-    // No reset happened and no backup branch was created.
-    expect(await g(workPath, 'rev-parse', SYNC_BRANCH)).toBe(headBefore);
-    const backups = (await g(workPath, 'branch', '--list', 'tbd-backup-*')).trim();
-    expect(backups).toBe('');
+
+    const result = await rescueUnrelatedHistory(workPath, 'origin', SYNC_BRANCH);
+
+    // It no longer aborts: a backup branch is created and the rescue completes.
+    expect(await branchExists(result.backupBranch, workPath)).toBe(true);
+    // The backup captures the previously-uncommitted file faithfully.
+    await expect(
+      g(
+        workPath,
+        'cat-file',
+        '-e',
+        `${result.backupBranch}:${TBD_DIR}/${DATA_SYNC_DIR_NAME}/issues/is-01dirtyuncommitted00000001.md`,
+      ),
+    ).resolves.toBe('');
+    // Push will fast-forward over the adopted remote base.
+    await expect(
+      g(workPath, 'merge-base', '--is-ancestor', `origin/${SYNC_BRANCH}`, SYNC_BRANCH),
+    ).resolves.toBe('');
   });
 
   it('aborts when a merge is in progress in the worktree', async () => {


### PR DESCRIPTION
Fixes #158 — a transiently dirty internal sync worktree made `tbd doctor --fix` refuse the unrelated-history rescue, and `tbd doctor` bounced the user between `tbd sync` and `tbd doctor --fix` in a loop.

Spec: `docs/project/specs/active/plan-2026-06-03-unrelated-rescue-dirty-worktree.md` (epic `tbd-lmqu` + 5 children).

## Root cause
The rescue (`rescueUnrelatedHistory`) already snapshots the working tree before its `reset --hard` and replays local work, and it holds the shared lock — so a dirty worktree (tbd's own uncommitted data-sync writes) was already safe to proceed through. The refusal was over-cautious, and its "commit or stash them" message was misleading (the user never touches the internal worktree). Separately, doctor's `checkSyncConsistency` flagged unrelated histories as "diverged → Run: tbd sync", which loops against the unrelated-history error that says "Run tbd doctor --fix".

## Changes
1. **Rescue tolerates a dirty worktree** (`740999f`): commit the pending data-sync state first (so the `tbd-backup-*` branch captures it faithfully and the reset is safe), then proceed. Still refuse a genuine **merge-in-progress**, now with a terminating instruction. Foreign-path guard uses a git exclude pathspec (robust).
2. **Break the advice loop** (`71cc37b`): `divergenceFinding()` routes unrelated divergence to `tbd doctor --fix`, never `tbd sync`.
3. **Exit-code audit** (`1a80072`): a push failure now exits non-zero **unless** the changes were durably saved to the outbox (the permanent soft-fail recovery path keeps exit 0). Transient/unknown failures that saved nothing previously exited 0, hiding hard failures from CI/scripts. Local commits still remain on `tbd-sync`.
4. **Tests**: dirty-worktree + merge-in-progress rescue (`rescue-dirty-worktree.test.ts`); unrelated-aware `divergenceFinding`; e2e tryscripts for the one-shot dirty rescue, the non-zero exit on unrelated histories, and the non-zero exit on an unsaved push failure; updated the missing-remote goldens.

## Notes
- The report's secondary "sync exits 0 on unrelated histories" was **already fixed on `main`** (up-front `UnrelatedHistoriesError`, exit 1) — verified and locked in with a test.
- Behavior change: full-sync push failures without a durable outbox save now exit non-zero (goldens updated accordingly).

## Testing
1160 vitest tests + 153 sync tryscripts green locally; pre-push hook ran the full suite.

https://claude.ai/code/session_012pyBedVoUi1LVSpNvpqgfy

---
_Generated by [Claude Code](https://claude.ai/code/session_012pyBedVoUi1LVSpNvpqgfy)_