### PR TITLE
Surface worktree auto-heal at the point of use (#135)

### DIFF
--- a/packages/tbd/src/cli/commands/create.ts
+++ b/packages/tbd/src/cli/commands/create.ts
@@ -23,7 +23,7 @@ import { parsePriority } from '../../lib/priority.js';
 import { now } from '../../utils/time-utils.js';
 import { resolveAndValidatePath, getPathErrorMessage } from '../../lib/project-paths.js';
 import { validateIssueTitle } from '../lib/issue-input-validation.js';
-import { withDataSyncContext } from '../lib/data-context.js';
+import { withDataSyncContext, notifyWorktreeRepaired } from '../lib/data-context.js';
 
 interface CreateOptions {
   fromFile?: string;
@@ -104,7 +104,10 @@ class CreateHandler extends BaseCommand {
       await withDataSyncContext(
         tbdRoot,
         { lock: true },
-        async ({ dataSyncDir, config, mapping }) => {
+        async ({ dataSyncDir, config, mapping, repairedWorktreeStatus }) => {
+          // Surface a silent worktree heal so a write never looks like it landed
+          // normally when the worktree had to be materialized first. #135
+          notifyWorktreeRepaired(repairedWorktreeStatus);
           prefix = config.display.id_prefix;
 
           shortId = generateUniqueShortId(mapping);

--- a/packages/tbd/src/cli/lib/data-context.ts
+++ b/packages/tbd/src/cli/lib/data-context.ts
@@ -164,6 +164,24 @@ function notifyConfigMigrated(fromFormat: string | undefined, toFormat: string):
   );
 }
 
+/**
+ * Emit a one-line stderr notice when a data command auto-materialized a missing
+ * sync worktree at the point of use.
+ *
+ * The shared worktree can be absent in a fresh/ephemeral clone (or if it was
+ * deleted). `withDataSyncContext` heals it transparently, but a silent heal on a
+ * read/write command looks indistinguishable from "the tracker is empty" or "my
+ * issue was saved normally" — the exact confusion reported in #135. A terse
+ * stderr note keeps stdout (and JSON) clean while making the heal visible.
+ */
+export function notifyWorktreeRepaired(status: WorktreeStatus | undefined): void {
+  if (status !== 'missing' && status !== 'prunable') return;
+  process.stderr.write(
+    `• tbd-sync worktree was ${status} — auto-materialized it ` +
+      `(fresh clone, or the worktree was removed).\n`,
+  );
+}
+
 async function assembleDataContext(
   tbdRoot: string,
   probe: DataSyncProbe,
@@ -234,7 +252,11 @@ export async function withDataSyncContext<T>(
  * migration or worktree repair.
  */
 export async function loadDataContext(tbdRoot: string): Promise<TbdDataContext> {
-  return withDataSyncContext(tbdRoot, { lock: false }, async (context) => context);
+  return withDataSyncContext(tbdRoot, { lock: false }, async (context) => {
+    // Surface a silent worktree heal at the point of use (read commands). #135
+    notifyWorktreeRepaired(context.repairedWorktreeStatus);
+    return context;
+  });
 }
 
 /**

--- a/packages/tbd/tests/cli-shared-common-dir-worktree.tryscript.md
+++ b/packages/tbd/tests/cli-shared-common-dir-worktree.tryscript.md
@@ -114,10 +114,13 @@ fatal: 'tbd-sync' is already used by worktree at [..]
 The first mutating command in a checkout whose `.tbd/config.yml` still says `f03` emits
 a one-time stderr notice (`tbd-afjh`) before the success line, so users see the tracked
 config bump coming rather than discovering it later as a surprise diff.
+The migration also materializes the shared worktree for the first time, which emits its
+own point-of-use notice (#135).
 
 ```console
 $ tbd create "Main checkout issue" --type=task
 • tbd_format f03 → f04: .tbd/config.yml updated in this checkout. Commit on this branch or merge main to publish the format upgrade.
+• tbd-sync worktree was missing — auto-materialized it (fresh clone, or the worktree was removed).
 ✓ Created test-[SHORTID]: Main checkout issue
 ? 0
 ```

--- a/packages/tbd/tests/cli-sync-missing-worktree-135.tryscript.md
+++ b/packages/tbd/tests/cli-sync-missing-worktree-135.tryscript.md
@@ -86,6 +86,14 @@ worktree absent
 
 ## tbd list heals and reads the real issues (no silent fallback)
 
+# Test: tbd list announces the auto-heal at the point of use (not silent)
+
+```console
+$ tbd list 2>&1 | grep -c "auto-materialized" | tr -d ' '
+1
+? 0
+```
+
 # Test: tbd list reflects the real issues (does not silently report empty)
 
 ```console


### PR DESCRIPTION
Addresses the remaining item in #135.

## Context: the core hazard is already fixed
The dangerous symptoms in #135 (v0.1.30) — `tbd list` showing "No issues found" and `tbd create` writing to the gitignored fallback when the sync worktree is missing — were **already fixed** by the shared-common-dir refactor: `withDataSyncContext` auto-heals a `missing`/`prunable` worktree (via `repairWorktree`), throws loudly for other unhealthy states, and resolves with `allowFallback: false`. The regression test `cli-sync-missing-worktree-135.tryscript.md` already proves `list`/`create` heal and never write to `.tbd/data-sync/`. I verified this empirically on `main`.

The maintainer's [May 31 comment](https://github.com/jlevy/tbd/issues/135#issuecomment-4587520945) predates that fix, but raised one residual point that was still open: the heal is **silent** at the point of use — a healed `list`/`create` looks indistinguishable from a normal run.

## This PR
Adds a one-line **stderr** notice when a data command auto-materializes a missing worktree, so the heal is visible — mirroring the existing `tbd_format` migration notice. stdout/JSON stay clean.

- `notifyWorktreeRepaired(status)` in `data-context.ts` (stderr, only fires for `missing`/`prunable`).
- Emitted from the read path (`loadDataContext` → covers `list`/`show`/`ready`/…) and from `create`.
- `sync` is unchanged (it already prints `✓ Worktree repaired successfully`).

Example:
```
• tbd-sync worktree was missing — auto-materialized it (fresh clone, or the worktree was removed).
2 issue(s)
```

## Tests
- Extended `cli-sync-missing-worktree-135.tryscript.md` to assert the notice appears on the healing `tbd list`.
- Updated the `cli-shared-common-dir-worktree` golden (the f03→f04 first-write also materializes the worktree, so both one-time notices now print).
- 1156 vitest tests + full tryscript suite (833) green locally.

Note: the pre-existing `cli-workspace-save` mapping flake (seen on #160) is unrelated and passed here.

https://claude.ai/code/session_012pyBedVoUi1LVSpNvpqgfy

---
_Generated by [Claude Code](https://claude.ai/code/session_012pyBedVoUi1LVSpNvpqgfy)_