### PR TITLE
Fix brittle ids.yml count assertion (quoted numeric short IDs)

### DIFF
--- a/packages/tbd/tests/cli-workspace-save.tryscript.md
+++ b/packages/tbd/tests/cli-workspace-save.tryscript.md
@@ -96,8 +96,12 @@ $ ls .tbd/workspaces/my-backup/issues/ | wc -l | tr -d ' '
 
 # Test: Workspace mappings contain exactly 3 entries
 
+Count by the ULID value, not the key: an all-numeric short ID (e.g. `2253`) is
+YAML-serialized as a quoted key (`"2253":`), so a `^[a-z0-9]` key match would undercount
+it (~1.8% of runs). The mapping itself is correct either way.
+
 ```console
-$ grep -c '^[a-z0-9]' .tbd/workspaces/my-backup/mappings/ids.yml
+$ grep -cE ': [0-9a-z]{26}$' .tbd/workspaces/my-backup/mappings/ids.yml
 3
 ? 0
 ```
@@ -129,8 +133,11 @@ $ ls .tbd/workspaces/outbox/issues/ | wc -l | tr -d ' '
 
 # Test: Outbox mappings contain exactly 3 entries (not all mappings)
 
+Count by the ULID value (see note above): a quoted all-numeric short-ID key must still
+be counted.
+
 ```console
-$ grep -c '^[a-z0-9]' .tbd/workspaces/outbox/mappings/ids.yml
+$ grep -cE ': [0-9a-z]{26}$' .tbd/workspaces/outbox/mappings/ids.yml
 3
 ? 0
 ```


### PR DESCRIPTION
Root-causes and fixes the intermittent `cli-workspace-save.tryscript.md` failure that surfaced on #160 and #162. **Not a flake — a brittle test assertion**, debugged systematically.

## Root cause
The two "mappings contain exactly N entries" assertions counted lines with `grep -c '^[a-z0-9]'` over `ids.yml`. Each mapping line is `shortid: ulid` — but when a short ID is **all-numeric** (e.g. `2253`), the YAML serializer writes the key **quoted** (`"2253": 01kt9j10…`). That line starts with `"`, so the key-anchored pattern misses it and counts N−1.

Reproduced deterministically (iter 36 of 60) — the workspace `ids.yml` had **all 3** entries, one of them `"2253": …`, and the old `grep` returned 2:
```
04f7: 01kt9j10nmwxc0x2hqxb9fhx95
"2253": 01kt9j103f384mbc62dznda8hg
2awc: 01kt9j10cgkzdf108ge1j40mgz
```

`generateShortId` draws 4 chars from `[0-9a-z]` via crypto `randomBytes`, so an all-numeric short ID occurs at ≈ (10/36)⁴ ≈ 0.6% per ID → ≈ **1.8%** across the 3 issues in a run. That matches the observed ~1-in-60 rate exactly.

**The product is correct end-to-end** — `save` copies all three mappings, and `loadIdMapping` round-trips the quoted key (it uses a real YAML parser). Only the test assertion was wrong.

## Fix
Count by the **ULID value** (`grep -cE ': [0-9a-z]{26}$'`), which is immune to key quoting, for both the `my-backup` and `outbox` assertions, with an explanatory note.

## Validation
- 100 create→save runs with the new pattern: **0 failures**; 3 of those runs hit a quoted all-numeric short ID (which the old pattern would have failed).
- `cli-workspace-save.tryscript.md`: 36 passed × 3 runs.

This removes the recurring CI noise across PRs (no product change needed).

https://claude.ai/code/session_012pyBedVoUi1LVSpNvpqgfy

---
_Generated by [Claude Code](https://claude.ai/code/session_012pyBedVoUi1LVSpNvpqgfy)_