### PR TITLE
feat: Detect unwritable shared data-sync lock in doctor (#164)

### DIFF
--- a/packages/tbd/src/cli/commands/doctor.ts
+++ b/packages/tbd/src/cli/commands/doctor.ts
@@ -8,7 +8,7 @@
 
 import { Command } from 'commander';
 import { access, mkdir, readdir, readFile, rmdir, unlink } from 'node:fs/promises';
-import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 
 import { BaseCommand } from '../lib/base-command.js';
@@ -17,7 +17,12 @@ import { listIssues, type InvalidIssueFile } from '../../file/storage.js';
 import { IncompatibleFormatError, readConfig } from '../../file/config.js';
 import { prepareDataSyncContext } from '../lib/data-context.js';
 import type { Config, Issue, IssueStatusType } from '../../lib/types.js';
-import { resolveSharedTbdPaths, TBD_DIR, DATA_SYNC_DIR } from '../../lib/paths.js';
+import {
+  isCommonDirOutsideProject,
+  resolveSharedTbdPaths,
+  TBD_DIR,
+  DATA_SYNC_DIR,
+} from '../../lib/paths.js';
 import { detectDuplicateYamlKeys } from '../../utils/yaml-utils.js';
 import {
   getClaudePaths,
@@ -120,18 +125,6 @@ export function divergenceFinding(
     message: `diverged (${ahead} ahead, ${behind} behind)`,
     suggestion: 'Run: tbd sync to reconcile',
   };
-}
-
-/**
- * True when the Git common dir lives outside the project checkout — the linked
- * worktree shape that lets a checkout be writable while `$GIT_COMMON_DIR/tbd`
- * (shared sync state + lock) is not. This is the generic signal behind the
- * Codex-sandbox case in #164; it does not depend on any `CODEX_*` env var, which
- * that sandbox did not expose.
- */
-export function isCommonDirOutsideProject(gitCommonDir: string, projectRoot: string): boolean {
-  const rel = relative(resolve(projectRoot), resolve(gitCommonDir));
-  return rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel);
 }
 
 /**

--- a/packages/tbd/src/cli/commands/doctor.ts
+++ b/packages/tbd/src/cli/commands/doctor.ts
@@ -7,8 +7,9 @@
  */
 
 import { Command } from 'commander';
-import { access, readdir, readFile, unlink } from 'node:fs/promises';
-import { join } from 'node:path';
+import { access, mkdir, readdir, readFile, rmdir, unlink } from 'node:fs/promises';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { randomUUID } from 'node:crypto';
 
 import { BaseCommand } from '../lib/base-command.js';
 import { requireInit } from '../lib/errors.js';
@@ -120,6 +121,79 @@ export function divergenceFinding(
     suggestion: 'Run: tbd sync to reconcile',
   };
 }
+
+/**
+ * True when the Git common dir lives outside the project checkout — the linked
+ * worktree shape that lets a checkout be writable while `$GIT_COMMON_DIR/tbd`
+ * (shared sync state + lock) is not. This is the generic signal behind the
+ * Codex-sandbox case in #164; it does not depend on any `CODEX_*` env var, which
+ * that sandbox did not expose.
+ */
+export function isCommonDirOutsideProject(gitCommonDir: string, projectRoot: string): boolean {
+  const rel = relative(resolve(projectRoot), resolve(gitCommonDir));
+  return rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel);
+}
+
+/**
+ * Build the "Shared lock writability" finding from a probe result.
+ *
+ * `code` is the errno from attempting to create a directory under the shared
+ * locks dir, or undefined on success. EPERM/EACCES is a hard error: every write
+ * command must acquire this lock, so an unwritable lock path breaks all writes
+ * (the #164 Codex-sandbox case) — and a lock tbd needs but cannot take is a
+ * fatal condition, not a soft warning. Any other probe failure is reported as a
+ * warning since it cannot be positively interpreted. Never `fixable`: tbd cannot
+ * widen a sandbox or change filesystem permissions itself.
+ */
+export function buildLockWritabilityFinding(params: {
+  code: string | undefined;
+  sharedLockPath: string;
+  sharedLocksDir: string;
+  sharedTbdDir: string;
+  gitCommonDir: string;
+  projectRoot: string;
+}): DiagnosticResult {
+  const { code, sharedLockPath, sharedLocksDir, sharedTbdDir, gitCommonDir, projectRoot } = params;
+
+  if (!code) {
+    return { name: 'Shared lock writability', status: 'ok', path: sharedLocksDir };
+  }
+
+  if (code === 'EPERM' || code === 'EACCES') {
+    const outsideProject = isCommonDirOutsideProject(gitCommonDir, projectRoot);
+    const details = [
+      `Cannot create the shared data-sync lock (${code}): ${sharedLockPath}`,
+      'Read-only commands work, but every write command (create, update, sync) needs',
+      'this lock, so they will fail until the lock path is writable.',
+    ];
+    if (outsideProject) {
+      details.push(
+        `The checkout (${projectRoot}) is writable, but the shared tbd state under`,
+        `${sharedTbdDir} lives in the Git common dir (${gitCommonDir}) outside it —`,
+        'a common situation in agent sandboxes such as Codex worktrees.',
+      );
+    }
+    const suggestion = outsideProject
+      ? `Grant write access to ${sharedTbdDir} (in an agent sandbox such as Codex, add it ` +
+        `to the writable roots), or re-run the write command with sandbox escalation.`
+      : `Ensure ${sharedTbdDir} is writable by this user (check filesystem permissions).`;
+    return {
+      name: 'Shared lock writability',
+      status: 'error',
+      message: `lock path not writable (${code})`,
+      path: sharedLockPath,
+      details,
+      suggestion,
+    };
+  }
+
+  return {
+    name: 'Shared lock writability',
+    status: 'warn',
+    message: `unable to verify (${code})`,
+    path: sharedLocksDir,
+  };
+}
 import { formatHeading } from '../lib/output.js';
 import {
   renderRepositorySection,
@@ -171,46 +245,69 @@ class DoctorHandler extends BaseCommand {
     // Gather stats info (async to check remote when local is empty)
     const statsInfo = await this.gatherStatsInfo();
 
-    // Run health checks (core system checks)
+    // Run health checks (core system checks). Each check runs under safeCheck so
+    // a single unexpected failure produces an error finding instead of aborting
+    // the whole report — doctor must list every issue it can find. (issue #164)
     const healthChecks: DiagnosticResult[] = [];
 
     // Check 1: Git version
-    healthChecks.push(await this.checkGitVersion());
+    healthChecks.push(await this.safeCheck('Git version', () => this.checkGitVersion()));
 
     // Check 2: Config directory and file
-    healthChecks.push(await this.checkConfig());
+    healthChecks.push(await this.safeCheck('Config file', () => this.checkConfig()));
 
     // Check 3: Issues directory
-    healthChecks.push(await this.checkIssuesDirectory());
+    healthChecks.push(await this.safeCheck('Issues directory', () => this.checkIssuesDirectory()));
 
     // Check 4: Orphaned dependencies
-    healthChecks.push(this.checkOrphanedDependencies(this.issues));
+    healthChecks.push(
+      await this.safeCheck('Dependencies', async () => this.checkOrphanedDependencies(this.issues)),
+    );
 
     // Check 5: Duplicate IDs
-    healthChecks.push(this.checkDuplicateIds(this.issues));
+    healthChecks.push(
+      await this.safeCheck('Unique IDs', async () => this.checkDuplicateIds(this.issues)),
+    );
 
     // Check 5b: Merge conflict markers in ids.yml
-    healthChecks.push(await this.checkIdMappingConflicts(options.fix));
+    healthChecks.push(
+      await this.safeCheck('ID mapping conflicts', () => this.checkIdMappingConflicts(options.fix)),
+    );
 
     // Check 6: Duplicate mapping keys in ids.yml
-    healthChecks.push(await this.checkIdMappingDuplicates(options.fix));
+    healthChecks.push(
+      await this.safeCheck('ID mapping keys', () => this.checkIdMappingDuplicates(options.fix)),
+    );
 
     // Check 7: Orphaned temp files
-    healthChecks.push(await this.checkTempFiles(options.fix));
+    healthChecks.push(await this.safeCheck('Temp files', () => this.checkTempFiles(options.fix)));
 
     // Check 8: Issue validity
-    healthChecks.push(this.checkIssueValidity(this.issues, this.invalidIssueFiles));
+    healthChecks.push(
+      await this.safeCheck('Issue validity', async () =>
+        this.checkIssueValidity(this.issues, this.invalidIssueFiles),
+      ),
+    );
 
     // Check 9: Worktree health (with fix support)
     // Run BEFORE ID mapping check — worktree repair and data migration can
     // overwrite ids.yml, so mappings must be verified after migration.
-    healthChecks.push(await this.checkWorktree(options.fix));
+    healthChecks.push(await this.safeCheck('Worktree', () => this.checkWorktree(options.fix)));
 
     // Check 9b: Common-dir layout metadata against config (with fix support)
-    healthChecks.push(await this.checkCommonDirLayout(options.fix));
+    healthChecks.push(
+      await this.safeCheck('Common-dir layout', () => this.checkCommonDirLayout(options.fix)),
+    );
+
+    // Check 9c: Shared data-sync lock is writable by this process
+    healthChecks.push(
+      await this.safeCheck('Shared lock writability', () => this.checkSharedLockWritability()),
+    );
 
     // Check 10: Data location (issues in wrong path, with fix support)
-    const dataLocationResult = await this.checkDataLocation(options.fix);
+    const dataLocationResult = await this.safeCheck('Data location', () =>
+      this.checkDataLocation(options.fix),
+    );
     healthChecks.push(dataLocationResult);
 
     // If data was migrated, reload issues and refresh dataSyncDir so
@@ -233,37 +330,47 @@ class DoctorHandler extends BaseCommand {
     const parsedMaxHistory = options.maxHistory ? parseInt(options.maxHistory, 10) : 50;
     const maxHistory =
       Number.isNaN(parsedMaxHistory) || parsedMaxHistory < 0 ? 50 : parsedMaxHistory;
-    healthChecks.push(await this.checkMissingMappings(options.fix, maxHistory));
+    healthChecks.push(
+      await this.safeCheck('ID mapping coverage', () =>
+        this.checkMissingMappings(options.fix, maxHistory),
+      ),
+    );
 
     // Check 11: Local sync branch health
-    healthChecks.push(await this.checkLocalSyncBranch());
+    healthChecks.push(await this.safeCheck('Local sync branch', () => this.checkLocalSyncBranch()));
 
     // Check 12: Remote sync branch health
-    healthChecks.push(await this.checkRemoteSyncBranch(options.fix));
+    healthChecks.push(
+      await this.safeCheck('Remote sync branch', () => this.checkRemoteSyncBranch(options.fix)),
+    );
 
     // Check 13: Local has data but remote empty (ai-trade-arena bug detection)
-    healthChecks.push(await this.checkLocalVsRemoteData());
+    healthChecks.push(await this.safeCheck('Sync status', () => this.checkLocalVsRemoteData()));
 
     // Check 14: Multi-user/clone scenario detection
-    healthChecks.push(await this.checkCloneScenarios());
+    healthChecks.push(await this.safeCheck('Clone status', () => this.checkCloneScenarios()));
 
     // Check 15: Sync consistency (worktree matches local, ahead/behind counts)
-    healthChecks.push(await this.checkSyncConsistency());
+    healthChecks.push(await this.safeCheck('Sync consistency', () => this.checkSyncConsistency()));
 
     // Run integration checks (optional IDE/agent integrations)
     const integrationChecks: DiagnosticResult[] = [];
 
     // Integration 1: Portable Agent Skill (.agents/skills — primary)
-    integrationChecks.push(await this.checkPortableSkill());
+    integrationChecks.push(
+      await this.safeCheck('Portable Agent Skill', () => this.checkPortableSkill()),
+    );
 
     // Integration 2: Claude Code skill mirror
-    integrationChecks.push(await this.checkClaudeSkill());
+    integrationChecks.push(
+      await this.safeCheck('Claude Code skill', () => this.checkClaudeSkill()),
+    );
 
     // Integration 3: Codex AGENTS.md (also used by Cursor since v1.6)
-    integrationChecks.push(await this.checkCodexAgents());
+    integrationChecks.push(await this.safeCheck('AGENTS.md', () => this.checkCodexAgents()));
 
     // Integration 4: Codex hooks
-    integrationChecks.push(await this.checkCodexHooks());
+    integrationChecks.push(await this.safeCheck('Codex hooks', () => this.checkCodexHooks()));
 
     // Combine for overall status
     const allChecks = [...healthChecks, ...integrationChecks];
@@ -1149,6 +1256,74 @@ class DoctorHandler extends BaseCommand {
         path: layoutPath,
         fixable: true,
         suggestion: 'Run: tbd doctor --fix',
+      };
+    }
+  }
+
+  /**
+   * Probe whether this process can create the shared data-sync lock.
+   *
+   * Read-only diagnostics never take the lock, so a checkout whose
+   * `$GIT_COMMON_DIR/tbd` is outside the writable sandbox (e.g. a Codex
+   * worktree) looks healthy here while every write command fails with EPERM on
+   * the lock mkdir. This probe mirrors `withSharedDataSyncLock`: ensure the
+   * locks dir, then create and remove a uniquely named probe directory inside
+   * it. It is fully self-contained and never throws, so it cannot abort the
+   * doctor run. See issue #164.
+   */
+  private async checkSharedLockWritability(): Promise<DiagnosticResult> {
+    let paths;
+    try {
+      paths = await resolveSharedTbdPaths(this.cwd);
+    } catch (error) {
+      return {
+        name: 'Shared lock writability',
+        status: 'warn',
+        message: `unable to resolve shared paths: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      };
+    }
+
+    const probeDir = join(paths.sharedLocksDir, `.tbd-doctor-probe-${randomUUID()}.lock`);
+    let code: string | undefined;
+    try {
+      await mkdir(paths.sharedLocksDir, { recursive: true });
+      await mkdir(probeDir);
+    } catch (error) {
+      code = (error as NodeJS.ErrnoException).code ?? 'UNKNOWN';
+    } finally {
+      await rmdir(probeDir).catch(() => {});
+    }
+
+    return buildLockWritabilityFinding({
+      code,
+      sharedLockPath: paths.sharedLockPath,
+      sharedLocksDir: paths.sharedLocksDir,
+      sharedTbdDir: paths.sharedTbdDir,
+      gitCommonDir: paths.gitCommonDir,
+      projectRoot: this.cwd,
+    });
+  }
+
+  /**
+   * Run a single diagnostic check, converting an unexpected throw into an error
+   * finding instead of letting it abort the whole `tbd doctor` run. Doctor must
+   * surface every issue it can find, not just the first failure. (issue #164)
+   */
+  private async safeCheck(
+    name: string,
+    fn: () => Promise<DiagnosticResult>,
+  ): Promise<DiagnosticResult> {
+    try {
+      return await fn();
+    } catch (error) {
+      return {
+        name,
+        status: 'error',
+        message: `check could not complete: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
       };
     }
   }

--- a/packages/tbd/src/file/common-dir-layout.ts
+++ b/packages/tbd/src/file/common-dir-layout.ts
@@ -9,7 +9,11 @@ import { parse as parseYaml } from 'yaml';
 
 import type { CommonDirLayout, Config } from '../lib/types.js';
 import { CommonDirLayoutSchema, COMMON_DIR_LAYOUT_FIELD_ORDER } from '../lib/schemas.js';
-import { resolveSharedTbdPaths, type SharedTbdPaths } from '../lib/paths.js';
+import {
+  isCommonDirOutsideProject,
+  resolveSharedTbdPaths,
+  type SharedTbdPaths,
+} from '../lib/paths.js';
 import { CURRENT_FORMAT, formatUpgradeMessage, isCompatibleFormat } from '../lib/tbd-format.js';
 import { sortKeys, stringifyYaml } from '../utils/yaml-utils.js';
 import { now } from '../utils/time-utils.js';
@@ -135,14 +139,25 @@ export class SharedLockUnwritableError extends Error {
   constructor(
     public readonly code: string,
     paths: SharedTbdPaths,
+    projectRoot: string,
   ) {
+    // Mirror the doctor finding's inside/outside classification so the wording is
+    // accurate in both the agent-sandbox case (common dir outside the checkout)
+    // and a plain filesystem-permission case (common dir inside the checkout).
+    const outside = isCommonDirOutsideProject(paths.gitCommonDir, projectRoot);
+    const cause = outside
+      ? `The checkout is writable, but the shared tbd state under ${paths.sharedTbdDir} ` +
+        `is outside this process's writable area (a common agent-sandbox shape, e.g. Codex ` +
+        `worktrees), so write commands cannot proceed.`
+      : `The shared tbd state under ${paths.sharedTbdDir} is not writable by this process, ` +
+        `so write commands cannot proceed.`;
+    const fix = outside
+      ? `Fix: grant write access to ${paths.sharedTbdDir} — in an agent sandbox such as Codex ` +
+        `add it to the writable roots, or re-run with sandbox escalation.`
+      : `Fix: ensure ${paths.sharedTbdDir} is writable by this user (check filesystem permissions).`;
     super(
       `Cannot acquire the shared tbd data-sync lock (${code}): ${paths.sharedLockPath}\n` +
-        `The checkout is writable, but the shared tbd state under ${paths.sharedTbdDir} ` +
-        `is outside this process's writable area, so write commands cannot proceed.\n` +
-        `Fix: grant write access to ${paths.sharedTbdDir} — in an agent sandbox such as ` +
-        `Codex add it to the writable roots, or re-run with sandbox escalation. ` +
-        `Run \`tbd doctor\` to confirm the diagnosis.`,
+        `${cause}\n${fix} Run \`tbd doctor\` to confirm the diagnosis.`,
     );
     this.name = 'SharedLockUnwritableError';
   }
@@ -176,7 +191,7 @@ export async function withSharedDataSyncLock<T>(tbdRoot: string, fn: () => Promi
   } catch (error) {
     const code = lockPermissionCode(error);
     if (code) {
-      throw new SharedLockUnwritableError(code, paths);
+      throw new SharedLockUnwritableError(code, paths, tbdRoot);
     }
     throw error;
   }
@@ -188,7 +203,7 @@ export async function withSharedDataSyncLock<T>(tbdRoot: string, fn: () => Promi
     // writes issue data elsewhere (the worktree), so its errors pass through.
     const code = lockPermissionCode(error);
     if (code && (error as NodeJS.ErrnoException).path === paths.sharedLockPath) {
-      throw new SharedLockUnwritableError(code, paths);
+      throw new SharedLockUnwritableError(code, paths, tbdRoot);
     }
     throw error;
   }

--- a/packages/tbd/src/file/common-dir-layout.ts
+++ b/packages/tbd/src/file/common-dir-layout.ts
@@ -121,10 +121,75 @@ export async function ensureCommonDirLayout(
 }
 
 /**
+ * Error thrown when the shared data-sync lock cannot be created because the lock
+ * path is not writable by this process (EPERM/EACCES).
+ *
+ * The common trigger is an agent sandbox (e.g. Codex) where the *checkout* is
+ * writable but `$GIT_COMMON_DIR/tbd` — which holds the shared sync worktree and
+ * the lock — lives in the user's original repo directory, outside the sandbox's
+ * writable boundary. Read-only commands work, but any write needs the lock and
+ * fails here. This is fatal for the command: without the lock we cannot safely
+ * mutate shared state. See issue #164.
+ */
+export class SharedLockUnwritableError extends Error {
+  constructor(
+    public readonly code: string,
+    paths: SharedTbdPaths,
+  ) {
+    super(
+      `Cannot acquire the shared tbd data-sync lock (${code}): ${paths.sharedLockPath}\n` +
+        `The checkout is writable, but the shared tbd state under ${paths.sharedTbdDir} ` +
+        `is outside this process's writable area, so write commands cannot proceed.\n` +
+        `Fix: grant write access to ${paths.sharedTbdDir} — in an agent sandbox such as ` +
+        `Codex add it to the writable roots, or re-run with sandbox escalation. ` +
+        `Run \`tbd doctor\` to confirm the diagnosis.`,
+    );
+    this.name = 'SharedLockUnwritableError';
+  }
+}
+
+/**
+ * Return the EPERM/EACCES code if `error` is a filesystem permission error,
+ * otherwise undefined. Used to translate raw lock-creation failures into a
+ * clear, actionable error.
+ */
+function lockPermissionCode(error: unknown): string | undefined {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code === 'EPERM' || code === 'EACCES' ? code : undefined;
+}
+
+/**
  * Run a critical section while holding the repo-scoped data-sync lock.
+ *
+ * A permission failure creating either the locks directory or the lock itself
+ * is rethrown as a `SharedLockUnwritableError` with remediation. The lock-path
+ * match keeps an unrelated EPERM thrown by `fn` (e.g. writing issue data) from
+ * being misreported as a lock-writability problem.
  */
 export async function withSharedDataSyncLock<T>(tbdRoot: string, fn: () => Promise<T>): Promise<T> {
   const paths = await resolveSharedTbdPaths(tbdRoot);
-  await mkdir(paths.sharedLocksDir, { recursive: true });
-  return withLockfile(paths.sharedLockPath, fn, DATA_SYNC_LOCK_OPTIONS);
+
+  try {
+    // `mkdir(..., { recursive: true })` resolves silently when the directory
+    // already exists, so an EPERM here means the locks tree itself is unwritable.
+    await mkdir(paths.sharedLocksDir, { recursive: true });
+  } catch (error) {
+    const code = lockPermissionCode(error);
+    if (code) {
+      throw new SharedLockUnwritableError(code, paths);
+    }
+    throw error;
+  }
+
+  try {
+    return await withLockfile(paths.sharedLockPath, fn, DATA_SYNC_LOCK_OPTIONS);
+  } catch (error) {
+    // Only translate a permission failure on the lock directory itself. `fn`
+    // writes issue data elsewhere (the worktree), so its errors pass through.
+    const code = lockPermissionCode(error);
+    if (code && (error as NodeJS.ErrnoException).path === paths.sharedLockPath) {
+      throw new SharedLockUnwritableError(code, paths);
+    }
+    throw error;
+  }
 }

--- a/packages/tbd/src/lib/paths.ts
+++ b/packages/tbd/src/lib/paths.ts
@@ -32,7 +32,7 @@
 
 import { execFile } from 'node:child_process';
 import { homedir } from 'node:os';
-import { isAbsolute, join, resolve } from 'node:path';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { promisify } from 'node:util';
 
 /** The tbd configuration directory on main branch */
@@ -198,6 +198,19 @@ export function buildSharedTbdPaths(gitCommonDir: string): SharedTbdPaths {
  */
 export async function resolveSharedTbdPaths(baseDir: string): Promise<SharedTbdPaths> {
   return buildSharedTbdPaths(await resolveGitCommonDir(baseDir));
+}
+
+/**
+ * True when the Git common dir lives outside the project checkout — the linked
+ * worktree shape where the checkout can be writable while `$GIT_COMMON_DIR/tbd`
+ * (shared sync state + lock) is not. This is the generic signal behind the
+ * Codex-sandbox case in #164; it does not depend on any `CODEX_*` env var, which
+ * that sandbox did not expose. Used by both the `doctor` lock-writability finding
+ * and the write-side `SharedLockUnwritableError` so their wording matches.
+ */
+export function isCommonDirOutsideProject(gitCommonDir: string, projectRoot: string): boolean {
+  const rel = relative(resolve(projectRoot), resolve(gitCommonDir));
+  return rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel);
 }
 
 // =============================================================================

--- a/packages/tbd/tests/cli-orientation-golden.tryscript.md
+++ b/packages/tbd/tests/cli-orientation-golden.tryscript.md
@@ -115,6 +115,7 @@ HEALTH CHECKS
 ✓ Issue validity
 ✓ Worktree ([PATH])
 ✓ Common-dir layout ([PATH])
+✓ Shared lock writability ([PATH])
 ✓ Data location
 ✓ ID mapping coverage
 ✓ Local sync branch - tbd-sync

--- a/packages/tbd/tests/doctor-lock-writability-e2e.test.ts
+++ b/packages/tbd/tests/doctor-lock-writability-e2e.test.ts
@@ -1,0 +1,72 @@
+/**
+ * End-to-end coverage for the "Shared lock writability" doctor check (issue #164).
+ *
+ * The failing (EPERM) path is not reproducible as root, so this asserts the
+ * happy path: a normal repo reports the lock as writable and the check takes its
+ * place in the full health-check list (doctor does not abort).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir, platform } from 'node:os';
+import { join } from 'node:path';
+
+const execFileAsync = promisify(execFile);
+const isWindows = platform() === 'win32';
+const describeUnlessWindows = isWindows ? describe.skip : describe;
+const tbdBin = join(__dirname, '..', 'dist', 'bin.mjs');
+
+async function gitIn(dir: string, ...args: string[]): Promise<void> {
+  await execFileAsync('git', args, { cwd: dir });
+}
+
+function runTbd(cwd: string, args: string[]): { stdout: string; stderr: string; status: number } {
+  const result = spawnSync('node', [tbdBin, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, FORCE_COLOR: '0' },
+  });
+  return { stdout: result.stdout || '', stderr: result.stderr || '', status: result.status ?? 1 };
+}
+
+interface DoctorJson {
+  healthy: boolean;
+  healthChecks: { name: string; status: string }[];
+}
+
+describeUnlessWindows('doctor shared lock writability (e2e)', { timeout: 30000 }, () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'tbd-lockwrite-e2e-'));
+    await gitIn(dir, 'init', '--initial-branch=main');
+    await gitIn(dir, 'config', 'user.email', 'test@test.com');
+    await gitIn(dir, 'config', 'user.name', 'Test');
+    expect(runTbd(dir, ['init', '--prefix=test']).status).toBe(0);
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('reports the lock as writable in a normal repo and keeps the full check list', () => {
+    const result = runTbd(dir, ['doctor', '--json']);
+    expect(result.status).toBe(0);
+
+    const report = JSON.parse(result.stdout) as DoctorJson;
+    const names = report.healthChecks.map((c) => c.name);
+
+    const lockCheck = report.healthChecks.find((c) => c.name === 'Shared lock writability');
+    expect(lockCheck, `lock check missing; got: ${names.join(', ')}`).toBeDefined();
+    expect(lockCheck?.status).toBe('ok');
+
+    // The new check does not displace existing ones — doctor lists the whole set
+    // and no core health check errors in a clean repo.
+    expect(names).toContain('Worktree');
+    expect(names).toContain('Common-dir layout');
+    expect(report.healthChecks.filter((c) => c.status === 'error')).toEqual([]);
+  });
+});

--- a/packages/tbd/tests/doctor-lock-writability.test.ts
+++ b/packages/tbd/tests/doctor-lock-writability.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for the "Shared lock writability" doctor finding (issue #164).
+ *
+ * A shared data-sync lock that tbd needs but cannot create (EPERM/EACCES) is a
+ * fatal condition for write commands — it must surface as an error finding, with
+ * agent-sandbox guidance when the Git common dir lives outside the checkout. The
+ * EPERM path itself is not reproducible as root (CI runs as root, which bypasses
+ * filesystem permissions), so the classification is exercised here as a pure
+ * function; the happy path is covered end-to-end in doctor-lock-writability.e2e.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+
+import {
+  buildLockWritabilityFinding,
+  isCommonDirOutsideProject,
+} from '../src/cli/commands/doctor.js';
+import { SharedLockUnwritableError } from '../src/file/common-dir-layout.js';
+import { buildSharedTbdPaths } from '../src/lib/paths.js';
+
+const projectRoot = '/home/user/project';
+const insideCommonDir = join(projectRoot, '.git');
+const outsideCommonDir = '/home/user/original-repo/.git';
+
+function findingParams(code: string | undefined, gitCommonDir: string) {
+  const paths = buildSharedTbdPaths(gitCommonDir);
+  return {
+    code,
+    sharedLockPath: paths.sharedLockPath,
+    sharedLocksDir: paths.sharedLocksDir,
+    sharedTbdDir: paths.sharedTbdDir,
+    gitCommonDir: paths.gitCommonDir,
+    projectRoot,
+  };
+}
+
+describe('isCommonDirOutsideProject', () => {
+  it('is false for the normal in-checkout .git', () => {
+    expect(isCommonDirOutsideProject(insideCommonDir, projectRoot)).toBe(false);
+  });
+
+  it('is true when the common dir lives outside the checkout (linked worktree)', () => {
+    expect(isCommonDirOutsideProject(outsideCommonDir, projectRoot)).toBe(true);
+  });
+
+  it('is false when the common dir equals the project root', () => {
+    expect(isCommonDirOutsideProject(projectRoot, projectRoot)).toBe(false);
+  });
+});
+
+describe('buildLockWritabilityFinding', () => {
+  it('reports ok when the probe succeeded (no error code)', () => {
+    const finding = buildLockWritabilityFinding(findingParams(undefined, insideCommonDir));
+    expect(finding.status).toBe('ok');
+    expect(finding.name).toBe('Shared lock writability');
+    expect(finding.fixable).toBeUndefined();
+  });
+
+  it('reports a hard error for EPERM and points at the lock path', () => {
+    const params = findingParams('EPERM', outsideCommonDir);
+    const finding = buildLockWritabilityFinding(params);
+    expect(finding.status).toBe('error');
+    // Not auto-fixable: tbd cannot widen a sandbox or change FS permissions.
+    expect(finding.fixable).toBeUndefined();
+    expect(finding.message).toMatch(/EPERM/);
+    expect(finding.path).toBe(params.sharedLockPath);
+  });
+
+  it('reports a hard error for EACCES', () => {
+    const finding = buildLockWritabilityFinding(findingParams('EACCES', outsideCommonDir));
+    expect(finding.status).toBe('error');
+    expect(finding.message).toMatch(/EACCES/);
+  });
+
+  it('includes agent-sandbox guidance when the common dir is outside the checkout', () => {
+    const finding = buildLockWritabilityFinding(findingParams('EPERM', outsideCommonDir));
+    const text = [finding.message, finding.suggestion, ...(finding.details ?? [])].join('\n');
+    expect(text).toMatch(/sandbox/i);
+    expect(text).toMatch(/writable roots/i);
+    expect(text).toMatch(/Codex/);
+  });
+
+  it('omits sandbox framing when the common dir is inside the checkout', () => {
+    const finding = buildLockWritabilityFinding(findingParams('EPERM', insideCommonDir));
+    const text = [finding.message, finding.suggestion, ...(finding.details ?? [])].join('\n');
+    expect(finding.status).toBe('error');
+    expect(text).not.toMatch(/writable roots/i);
+    expect(text).toMatch(/permission/i);
+  });
+
+  it('reports an unrecognized probe failure as a warning, not a hard error', () => {
+    const finding = buildLockWritabilityFinding(findingParams('EIO', insideCommonDir));
+    expect(finding.status).toBe('warn');
+    expect(finding.message).toMatch(/EIO/);
+  });
+});
+
+describe('SharedLockUnwritableError', () => {
+  it('explains the failure with the lock path and remediation', () => {
+    const paths = buildSharedTbdPaths(outsideCommonDir);
+    const err = new SharedLockUnwritableError('EPERM', paths);
+    expect(err.name).toBe('SharedLockUnwritableError');
+    expect(err.code).toBe('EPERM');
+    expect(err.message).toContain(paths.sharedLockPath);
+    expect(err.message).toContain(paths.sharedTbdDir);
+    expect(err.message).toMatch(/sandbox|writable/i);
+    expect(err.message).toMatch(/tbd doctor/);
+  });
+});

--- a/packages/tbd/tests/doctor-lock-writability.test.ts
+++ b/packages/tbd/tests/doctor-lock-writability.test.ts
@@ -12,12 +12,9 @@
 import { describe, it, expect } from 'vitest';
 import { join } from 'node:path';
 
-import {
-  buildLockWritabilityFinding,
-  isCommonDirOutsideProject,
-} from '../src/cli/commands/doctor.js';
+import { buildLockWritabilityFinding } from '../src/cli/commands/doctor.js';
 import { SharedLockUnwritableError } from '../src/file/common-dir-layout.js';
-import { buildSharedTbdPaths } from '../src/lib/paths.js';
+import { buildSharedTbdPaths, isCommonDirOutsideProject } from '../src/lib/paths.js';
 
 const projectRoot = '/home/user/project';
 const insideCommonDir = join(projectRoot, '.git');
@@ -97,14 +94,24 @@ describe('buildLockWritabilityFinding', () => {
 });
 
 describe('SharedLockUnwritableError', () => {
-  it('explains the failure with the lock path and remediation', () => {
+  it('uses sandbox wording when the common dir is outside the checkout', () => {
     const paths = buildSharedTbdPaths(outsideCommonDir);
-    const err = new SharedLockUnwritableError('EPERM', paths);
+    const err = new SharedLockUnwritableError('EPERM', paths, projectRoot);
     expect(err.name).toBe('SharedLockUnwritableError');
     expect(err.code).toBe('EPERM');
     expect(err.message).toContain(paths.sharedLockPath);
     expect(err.message).toContain(paths.sharedTbdDir);
-    expect(err.message).toMatch(/sandbox|writable/i);
+    expect(err.message).toMatch(/sandbox/i);
+    expect(err.message).toMatch(/writable roots/i);
+    expect(err.message).toMatch(/tbd doctor/);
+  });
+
+  it('uses filesystem-permission wording when the common dir is inside the checkout', () => {
+    const paths = buildSharedTbdPaths(insideCommonDir);
+    const err = new SharedLockUnwritableError('EACCES', paths, projectRoot);
+    expect(err.message).toContain(paths.sharedLockPath);
+    expect(err.message).toMatch(/not writable by this process|filesystem permissions/i);
+    expect(err.message).not.toMatch(/writable roots/i);
     expect(err.message).toMatch(/tbd doctor/);
   });
 });


### PR DESCRIPTION
## Summary

In an agent sandbox (e.g. Codex worktrees), the checkout can be writable while
`$GIT_COMMON_DIR/tbd` — which holds the shared sync worktree and the data-sync
lock — lives outside the sandbox's writable boundary. Read-only commands and
`tbd doctor` reported healthy, but the first write died with a raw
`EPERM: … mkdir '…/locks/data-sync.lock'`. This adds a `doctor` check that
surfaces the condition, makes the write-side failure a clear fatal error, and
hardens `doctor` so one failing check never aborts the whole report.

Fixes #164 (items 1–3; the security-sensitive `tbd setup --codex` config-writer in
item 4 is intentionally deferred — see Notes).

## Changes

- **`doctor` — new "Shared lock writability" check** (`doctor.ts`): probes the
  shared locks dir by creating and removing a uniquely named probe directory,
  mirroring `withSharedDataSyncLock`. An unwritable lock (`EPERM`/`EACCES`) is a
  hard **error** finding (sets exit 1) because every write command must take this
  lock. Remediation text is sandbox-aware (writable roots / sandbox escalation)
  when the Git common dir lives outside the checkout, and generic
  (filesystem-permissions) otherwise. The probe is self-contained and never throws.
- **`doctor` never aborts on one check** (`doctor.ts`): every health and
  integration check now runs under a `safeCheck` guard, so an unexpected throw
  becomes an error *finding* and the rest of the report still runs — doctor must
  list every issue, not just the first.
- **Clear fatal write error** (`common-dir-layout.ts`): `withSharedDataSyncLock`
  translates `EPERM`/`EACCES` on the shared lock path into a
  `SharedLockUnwritableError` that names the lock path, the shared tbd dir, and
  the remediation. The match is path-scoped so an unrelated `EPERM` thrown by the
  critical section (e.g. writing issue data) passes through unchanged.
- **Tests**: pure-function unit tests for the finding classifier, the
  outside-checkout detector, and the error message
  (`doctor-lock-writability.test.ts`); an e2e happy-path test asserting a normal
  repo reports the lock writable and `doctor` still lists the full check set
  (`doctor-lock-writability-e2e.test.ts`).

## Test Plan

- [x] Unit tests pass — `doctor-lock-writability.test.ts` (10 tests)
- [x] E2e happy-path test passes — `doctor-lock-writability-e2e.test.ts`
- [x] Full suite green (`pnpm test`) — 74 files / 1172 tests
- [x] Build succeeds (`pnpm build`), typecheck + lint + prettier clean
- [x] **Live `EPERM` reproduction** (`chattr +i` on the locks dir, since CI runs
      as root and can't reproduce permission denial via `chmod`):
  - Write command (`tbd create`) fails with the new
    `SharedLockUnwritableError` message and exit 1 — not a raw `mkdir` error.
  - `tbd doctor` flags "Shared lock writability" as `error` (exit 1) while still
    listing all 19 health checks (no abort).
- Edge cases considered:
  - Common dir **inside** the checkout → generic permission guidance (no sandbox
    framing); common dir **outside** → sandbox/writable-roots guidance.
  - Unrelated `EPERM` from the critical section is not misclassified as a lock
    problem (path-scoped match).
  - Steady-state read commands still take no lock, so they keep working in a
    sandbox where the worktree/layout are already valid (matches #164).

### Reviewer note on reproduction

The sandbox EPERM path is not reproducible with `chmod` under CI's root, so the
classification logic is exercised as pure functions; the happy path is covered
e2e; and the wired EPERM behavior was verified manually with `chattr +i`.

## Related Beads

None. The deferred `tbd setup --codex` writable-roots helper (issue #164 item 4,
marked "Consider" in the issue) is intentionally out of scope here — it edits
machine-local, security-sensitive Codex config and warrants its own change with a
confirmation UX. Happy to file a bead for it if desired.

https://claude.ai/code/session_01HQnFgn8byLa88Sw2FuUHxV

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQnFgn8byLa88Sw2FuUHxV)_