### PR TITLE
chore: release get-tbd v0.2.3

### DIFF
--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -1,5 +1,82 @@
 # get-tbd
 
+## 0.2.3
+
+A drop-in patch on top of v0.2.2. **No on-disk format change** (`f04` stays `f04`), so
+any machine already on v0.2.0 or later can upgrade without a migration.
+The headline is hardened issue sync — a structured, field-level three-way merge of
+issues that no longer loses child wiring or silently corrupts data — plus a new
+`tbd doctor` check for an unwritable shared lock in agent sandboxes.
+
+### Features
+
+- **`tbd doctor` detects an unwritable shared data-sync lock**: every write command
+  (`create`, `update`, `sync`) must take a repo-scoped lock under the Git common dir.
+  When that path is not writable — common in agent sandboxes such as Codex worktrees,
+  where the common dir lives outside the writable checkout — read-only commands still
+  work but every write fails.
+  Doctor now probes this up front and reports it as a hard error with sandbox-aware
+  remediation, instead of letting writes fail later with a bare `EPERM`.
+- **`tbd setup --surfaces` selector**: setup replaces its per-agent flags with a single
+  `--surfaces=<list>` selector backed by a surface registry.
+  Choose any comma-separated mix of `portable`, `agents-md`, `claude`, `codex`, or `all`
+  (the default) to control exactly which integration surfaces are installed.
+  **Note:** this removes the old `--all`, `--claude`, `--codex`, `--skip-claude`, and
+  `--skip-codex` flags; scripts using them should move to `--surfaces`.
+
+### Fixes
+
+- **Structured three-way merge for issue sync (#155)**: sync now merges issues
+  field-by-field from their git refs instead of doing a line-level text merge.
+  This closes several ways a concurrent or push-retry sync could previously mangle data:
+  - `child_order_hints` are union-merged (and null-safe), so concurrent edits no longer
+    drop child-ordering wiring.
+  - A missing issue is distinguished from a corrupt one during a ref merge.
+  - Push-retry integrates the remote into the sync branch and re-runs the structured
+    merge before retrying, rather than retrying against stale state.
+  - A post-merge guard fails the sync loudly if any issue is left unparseable, instead
+    of committing corrupt data.
+- **Sync exits non-zero when a push failure isn’t parked in the outbox (#158)**: a
+  failed push that could not be saved to the outbox for later retry now surfaces as a
+  non-zero exit, so automation sees the failure instead of treating it as success.
+- **Non-destructive rescue tolerates a dirty sync worktree (#158)**: recovery from
+  unrelated histories no longer refuses when the sync worktree has uncommitted changes —
+  the rescue captures that work on a backup branch — and unrelated-history divergence no
+  longer suggests the unhelpful `tbd sync`.
+- **Worktree auto-heal is surfaced at the point of use (#135)**: when a read or create
+  re-creates a missing sync worktree, tbd now tells you it healed instead of repairing
+  invisibly.
+- **`tbd sync --status` shows the incoming remote commits**: the remote-commit lookup
+  used an invalid `git log --limit` flag that threw and was swallowed, so the list was
+  always empty; it now reports the commits the remote is ahead by.
+- **Generated session script pins the published version**: the session script now pins
+  `get-tbd@<published version>` instead of a dev/dirty `git describe` build string that
+  isn’t installable from npm and churned generated files on every local build.
+
+### Guidelines and content
+
+These ship inside the package and are read by agents via `tbd guidelines …` and
+`tbd setup`:
+
+- **New `general-eng-agent-principles` guideline**: consolidates the core engineering
+  standards — objectivity, communication, and the engineering process (understanding,
+  verification, end-to-end ownership, scope discipline) — into one document, replacing
+  the older `general-eng-assistant-rules`.
+- **`cli-agent-skill-patterns` — attention-routing framing and an L0–L3 ladder**:
+  expanded guidance on how coding agents discover and monitor CLI-backed skills, plus
+  research on agent-skill and CLI packaging practices.
+- **TypeScript guideline refresh**: clarifications across `typescript-rules`,
+  `typescript-cli-tool-rules`, `typescript-code-coverage`, and the YAML/sorting rules.
+- **`repren` agent skill** is now installed alongside the other surfaces for
+  large-scale, multi-file renames.
+
+### Security
+
+Lockfile unchanged since v0.2.2; the resolved dependency tree is byte-identical, so no
+new advisories. The only manifest change is a dev-tooling formatter swap (`flowmark` →
+first-party `flowmark-rs`, pinned with a documented cool-off exception); it is not a
+runtime dependency of the published package.
+
 ## 0.2.2
 
 A drop-in patch on top of v0.2.1. **No on-disk format change** (`f04` stays `f04`), so
@@ -99,7 +176,8 @@ These ship inside the package and are read by agents via `tbd guidelines …` an
 - Lockfile is byte-identical to v0.2.0 — no manifest changes and no new advisories
   (`pnpm audit --prod` clean, `pnpm check:package-age` reports 0 violations).
 
-**Full commit history**: https://github.com/jlevy/tbd/compare/v0.2.0...v0.2.1
+**Full commit history**:
+[https://github.com/jlevy/tbd/compare/v0.2.0 … v0.2.1](https://github.com/jlevy/tbd/compare/v0.2.0...v0.2.1)
 
 ## 0.2.0
 

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-tbd",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Git-native issue tracking for AI agents and humans",
   "license": "MIT",
   "author": "Joshua Levy <joshua@cal.berkeley.edu> (https://github.com/jlevy)",

--- a/packages/tbd/src/cli/commands/doctor.ts
+++ b/packages/tbd/src/cli/commands/doctor.ts
@@ -128,6 +128,21 @@ export function divergenceFinding(
 }
 
 /**
+ * Inputs for {@link buildLockWritabilityFinding}: the errno from the lock-write
+ * probe plus the resolved shared-tbd paths used to phrase the finding and its
+ * remediation.
+ */
+export interface LockWritabilityProbe {
+  /** errno from the probe `mkdir`, or undefined when the lock path is writable. */
+  code: string | undefined;
+  sharedLockPath: string;
+  sharedLocksDir: string;
+  sharedTbdDir: string;
+  gitCommonDir: string;
+  projectRoot: string;
+}
+
+/**
  * Build the "Shared lock writability" finding from a probe result.
  *
  * `code` is the errno from attempting to create a directory under the shared
@@ -138,14 +153,7 @@ export function divergenceFinding(
  * warning since it cannot be positively interpreted. Never `fixable`: tbd cannot
  * widen a sandbox or change filesystem permissions itself.
  */
-export function buildLockWritabilityFinding(params: {
-  code: string | undefined;
-  sharedLockPath: string;
-  sharedLocksDir: string;
-  sharedTbdDir: string;
-  gitCommonDir: string;
-  projectRoot: string;
-}): DiagnosticResult {
+export function buildLockWritabilityFinding(params: LockWritabilityProbe): DiagnosticResult {
   const { code, sharedLockPath, sharedLocksDir, sharedTbdDir, gitCommonDir, projectRoot } = params;
 
   if (!code) {
@@ -1281,10 +1289,14 @@ class DoctorHandler extends BaseCommand {
     const probeDir = join(paths.sharedLocksDir, `.tbd-doctor-probe-${randomUUID()}.lock`);
     let code: string | undefined;
     try {
+      // Mirrors withSharedDataSyncLock: ensuring the locks dir may create it as a
+      // side effect, which is harmless — any write command would create it anyway.
       await mkdir(paths.sharedLocksDir, { recursive: true });
       await mkdir(probeDir);
     } catch (error) {
-      code = (error as NodeJS.ErrnoException).code ?? 'UNKNOWN';
+      // The thrown value may not be an ErrnoException; optional-chain so a
+      // non-Error throw degrades to 'UNKNOWN' instead of crashing the probe.
+      code = (error as NodeJS.ErrnoException | undefined)?.code ?? 'UNKNOWN';
     } finally {
       await rmdir(probeDir).catch(() => {});
     }

--- a/packages/tbd/src/cli/commands/setup.ts
+++ b/packages/tbd/src/cli/commands/setup.ts
@@ -2027,6 +2027,12 @@ class SetupAutoHandler extends BaseCommand {
         return this.installClaudeSurface(cwd);
       case 'codex':
         return this.installCodexSurface(cwd);
+      default: {
+        // Exhaustiveness guard: adding a SurfaceId without a case here is a
+        // compile-time error, not a silent `undefined` return.
+        const unhandled: never = id;
+        throw new Error(`Unhandled setup surface: ${String(unhandled)}`);
+      }
     }
   }
 

--- a/packages/tbd/src/cli/commands/sync.ts
+++ b/packages/tbd/src/cli/commands/sync.ts
@@ -367,7 +367,7 @@ class SyncHandler extends BaseCommand {
           'log',
           '--oneline',
           `${syncBranch}..${remote}/${syncBranch}`,
-          '--limit=10',
+          '--max-count=10',
         );
         for (const line of logOutput.split('\n')) {
           if (line) {

--- a/packages/tbd/src/file/common-dir-layout.ts
+++ b/packages/tbd/src/file/common-dir-layout.ts
@@ -201,8 +201,10 @@ export async function withSharedDataSyncLock<T>(tbdRoot: string, fn: () => Promi
   } catch (error) {
     // Only translate a permission failure on the lock directory itself. `fn`
     // writes issue data elsewhere (the worktree), so its errors pass through.
+    // The `.path` match relies on withLockfile surfacing the raw `mkdir`
+    // ErrnoException (which carries `.path`); revisit this guard if that changes.
     const code = lockPermissionCode(error);
-    if (code && (error as NodeJS.ErrnoException).path === paths.sharedLockPath) {
+    if (code && (error as NodeJS.ErrnoException | undefined)?.path === paths.sharedLockPath) {
       throw new SharedLockUnwritableError(code, paths, tbdRoot);
     }
     throw error;

--- a/packages/tbd/src/lib/integration-paths.ts
+++ b/packages/tbd/src/lib/integration-paths.ts
@@ -13,7 +13,6 @@
  */
 
 import { join } from 'node:path';
-import { homedir } from 'node:os';
 import { CURRENT_FORMAT } from './tbd-format.js';
 
 /**
@@ -123,17 +122,6 @@ export const CODEX_CONFIG_REL = '.codex/config.toml';
 // reference `.claude/`, so Codex setup does not depend on Claude Code setup.
 // (See cli-agent-skill-patterns §6.6: per-agent copies are a valid alternative
 // to a shared neutral script.)
-
-// =============================================================================
-// Global Paths (for detection only - NOT for installation)
-// =============================================================================
-
-/**
- * Global Claude Code directory in user's home.
- * Used ONLY for detecting if Claude Code is installed (for agent detection).
- * All installations are project-local.
- */
-export const GLOBAL_CLAUDE_DIR = join(homedir(), '.claude');
 
 // =============================================================================
 // Path Resolution Utilities

--- a/packages/tbd/tests/doctor-lock-writability.test.ts
+++ b/packages/tbd/tests/doctor-lock-writability.test.ts
@@ -12,7 +12,10 @@
 import { describe, it, expect } from 'vitest';
 import { join } from 'node:path';
 
-import { buildLockWritabilityFinding } from '../src/cli/commands/doctor.js';
+import {
+  buildLockWritabilityFinding,
+  type LockWritabilityProbe,
+} from '../src/cli/commands/doctor.js';
 import { SharedLockUnwritableError } from '../src/file/common-dir-layout.js';
 import { buildSharedTbdPaths, isCommonDirOutsideProject } from '../src/lib/paths.js';
 
@@ -20,7 +23,7 @@ const projectRoot = '/home/user/project';
 const insideCommonDir = join(projectRoot, '.git');
 const outsideCommonDir = '/home/user/original-repo/.git';
 
-function findingParams(code: string | undefined, gitCommonDir: string) {
+function findingParams(code: string | undefined, gitCommonDir: string): LockWritabilityProbe {
   const paths = buildSharedTbdPaths(gitCommonDir);
   return {
     code,


### PR DESCRIPTION
Release PR for **get-tbd v0.2.3**, prepared via a full pre-release code review of the 53 commits since `v0.2.2`.

## What this PR contains (vs `main`)

1. `fix:` Use `--max-count` not `--limit` for `git log` in sync status — real bug found in review (`--limit` is not a git flag; the call threw and was swallowed, so `tbd sync --status` never listed incoming remote commits).
2. `refactor:` Pre-release review cleanups (no behavior change) — exhaustiveness guard on the setup `installSurface` switch, named `LockWritabilityProbe` type extraction, hardened catch-variable errno casts, and removal of the dead `GLOBAL_CLAUDE_DIR` export.
3. `chore:` Version bump to 0.2.3 + CHANGELOG.

## Review summary

Reviewed the source delta (~1080 changed lines, concentrated in `sync.ts`, `setup.ts`, `doctor.ts`, `git.ts`) against the project's TypeScript guidelines. **No blockers found.** The structured-merge sync work (#155), the doctor lock-writability feature (#164), and the version-pinning fix are well-structured. A few lower-priority items were deliberately left as follow-ups to keep the patch tight (e.g. `setup` failure output stream/exit-code, a broad catch in `mergeRemoteIntoSyncBranch` that is already backstopped by the post-merge corruption guard).

## Verification (all green at 0.2.3)

- `pnpm build`, `pnpm typecheck`, `pnpm lint:check`, `pnpm format:check` ✓
- `pnpm test` — 74 files, **1173 tests pass** ✓
- `pnpm release:verify` (build + publint "All good!") ✓
- `pnpm check:package-age` — 0 violations / 31 pins ✓
- **Supply chain:** `pnpm-lock.yaml` byte-identical to v0.2.2 (no new advisories); only manifest change is a dev-tooling formatter swap (`flowmark` → first-party `flowmark-rs`).
- **On-disk format unchanged** (`f04` → `f04`): no migration.

## Release notes

The `## 0.2.3` section in `packages/tbd/CHANGELOG.md` is the source of truth; `release.yml` extracts it for the GitHub Release body (verified the extractor output).

> ### Features
> - `tbd doctor` detects an unwritable shared data-sync lock (agent-sandbox case, #164).
> - `tbd setup --surfaces` selector replaces the per-agent flags (`--all`/`--claude`/`--codex`/`--skip-*` removed).
>
> ### Fixes
> - Structured three-way merge for issue sync (#155); non-zero exit on un-parked push failure (#158); dirty-worktree-tolerant rescue (#158); worktree auto-heal surfaced at point of use (#135); sync-status remote commits; session script pins the published version.
>
> ### Guidelines and content
> - New `general-eng-agent-principles` guideline; `cli-agent-skill-patterns` expansion; TypeScript guideline refresh; `repren` skill installed.

**Note on versioning:** this range includes `feat` commits and a breaking `tbd setup` flag change, so by the strict semver heuristic it could be a `0.3.0` minor. Tagged as a patch (`v0.2.3`) per request.

https://claude.ai/code/session_016ceSBMBdX6gKmdGRYxxDXM

---
_Generated by [Claude Code](https://claude.ai/code/session_016ceSBMBdX6gKmdGRYxxDXM)_