### PR TITLE
chore: release get-tbd v0.3.0

### DIFF
--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -1,6 +1,6 @@
 # get-tbd
 
-## Unreleased (0.3.0)
+## 0.3.0
 
 The headline is **forkable docs**: every doc tbd serves (guidelines, shortcuts,
 templates, and the new reference docs) can now be forked into your repo as visible,
@@ -77,6 +77,25 @@ These ship inside the package and are read by agents via `tbd docs show …`,
   the two-axis offer (scope: all standard guidelines or a stack subset; visibility:
   hidden cache or forked into `docs/tbd/`), and the agent skill routes fork, update, and
   missing-file requests to the new commands.
+- **`cli-agent-skill-patterns` guideline expanded** (issues #173, #175): names the L2b
+  self-installing-tool variant and spells out how a self-installer should upgrade its
+  managed generated artifacts deliberately, bake a pin its generator can actually
+  resolve, and stamp the format/forward-compatibility guard; plus Cursor native skill
+  paths and tightened upgrade-scope guidance.
+- **`checkout-third-party-repo` shortcut reuses an existing checkout** (#168): it now
+  updates an existing `attic/<repo>` (with a clean-check and detached-HEAD/tag handling)
+  instead of re-cloning into an existing directory or working from a stale checkout.
+- **Every bundled guideline now declares a `category` in its frontmatter**, so
+  `tbd docs list` and the docmap listings group guidelines consistently.
+
+### Security
+
+Lockfile unchanged since v0.2.3; the resolved dependency tree is byte-identical (same
+`pnpm-lock.yaml` hash) and there are no manifest changes, so no new advisories.
+`pnpm audit --prod` reports no known vulnerabilities.
+
+**Full commit history**:
+[https://github.com/jlevy/tbd/compare/v0.2.3 … v0.3.0](https://github.com/jlevy/tbd/compare/v0.2.3...v0.3.0)
 
 ## 0.2.3
 

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-tbd",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Git-native issue tracking for AI agents and humans",
   "license": "MIT",
   "author": "Joshua Levy <joshua@cal.berkeley.edu> (https://github.com/jlevy)",


### PR DESCRIPTION
Release **get-tbd v0.3.0** — a minor release headlined by **forkable docs**, with a metadata-only repository format bump `f04` → `f06` (`f05` forkable-docs layout, `f06` config upgrade history).

This PR bumps `packages/tbd/package.json` to `0.3.0` and finalizes the `## 0.3.0` CHANGELOG section. After merge, tagging `v0.3.0` on the merge commit triggers `release.yml` to publish to npm and create the GitHub Release.

### Release verification (run locally on this branch)

- `format:check`, `lint:check`, `build`, `publint` — pass
- vitest: 1324 tests / 84 files — pass
- tryscript e2e: 883 checks (incl. 38 forkable-docs scenarios) — pass
- benchmark — exit 0 (soft startup-time warnings only)
- Supply chain: `pnpm-lock.yaml` byte-identical to v0.2.3, no manifest changes, `pnpm audit --prod` clean
- Changelog extraction for `0.3.0` verified (release-body extractor returns the full section)

---

## 0.3.0

The headline is **forkable docs**: every doc tbd serves (guidelines, shortcuts, templates, and the new reference docs) can now be forked into your repo as visible, git-tracked files, edited in place, and reconciled with upstream after upgrades. The repository format bumps `f04` → `f06` in this release: `f05` adds the forkable-docs layout, and `f06` adds a config upgrade history and redefines `tbd_version`. Both migrations are metadata-only, so upgrading is safe and revertible.

### Features

- **Forkable docs** (`tbd docs fork` / `unfork` / `update` / `diff` / `status`): fork any managed doc into a visible fork dir (`docs/tbd/`), shadowing the hidden cache everywhere the doc is served. `tbd docs update` three-way merges upstream changes (`--merge`, `--keep-ours`, `--dry-run`); `tbd docs diff` compares against upstream/base/incoming; `tbd docs status` reports each fork's state from content hashes (fork state lives in committed `.tbd/doc-forks/`).
- **The `tbd docs` surface is re-homed around managed docs**: bare `tbd docs` is the status overview, `tbd docs list` lists all docs across kinds with state markers, the manual moved to `tbd docs show tbd-docs` (alias `tbd docs manual`), and `tbd docs sync` refreshes the cache.
- **docref + docmap formats, and a new `reference` doc kind**: every doc source is addressed by a **docref** URI grammar and every listing is one **docmap** (`docmap/0.1`); both formats ship as forkable `reference` docs alongside the manual and design doc.
- **Fork drift is visible, never auto-fixed**: `tbd status` gains a `Docs:` line and `tbd sync` prints a stale/conflicted/missing notice; only `tbd docs update` ever modifies tracked files.
- **Config upgrade history** (format `f06`): `tbd_version` now records the version that last ran `tbd setup`, and a new `tbd_upgrades` list records the setup history (informational; gating stays on `tbd_format`).

### Guidelines and content

- **New `suggest-upstream-improvements` shortcut** for reviewing fork customizations and contributing them upstream.
- **New `docref-format` and `docmap-format` reference docs**.
- **Onboarding and agent surface updated for forkable docs** (`welcome-user` two-axis offer; agent skill routes fork/update/missing-file requests).
- **`cli-agent-skill-patterns` guideline expanded** (issues #173, #175): L2b self-installer variant, deliberate managed-artifact upgrades, generator-resolvable pins, Cursor native paths.
- **`checkout-third-party-repo` shortcut reuses an existing checkout** (#168).
- **Every bundled guideline now declares a `category`** in its frontmatter.

### Security

Lockfile unchanged since v0.2.3 (same `pnpm-lock.yaml` hash, no manifest changes); `pnpm audit --prod` reports no known vulnerabilities.

**Full commit history**: https://github.com/jlevy/tbd/compare/v0.2.3...v0.3.0

https://claude.ai/code/session_018erxkUHGwShRZJaoN8oUon

---
_Generated by [Claude Code](https://claude.ai/code/session_018erxkUHGwShRZJaoN8oUon)_