### PR TITLE
chore: dogfood get-tbd 0.3.0 in this repo

### DIFF
--- a/.claude/scripts/tbd-session.sh
+++ b/.claude/scripts/tbd-session.sh
@@ -18,10 +18,10 @@ fi
 
 # Pinned zero-install fallback. Never use an unpinned runner here.
 if command -v npx &> /dev/null; then
-    npx --yes get-tbd@0.2.3 prime "$@"
+    npx --yes get-tbd@0.3.0 prime "$@"
     exit $?
 fi
 
 echo "[tbd] tbd CLI not found and npx is unavailable."
-echo "[tbd] Install it with: npm install -g get-tbd@0.2.3"
+echo "[tbd] Install it with: npm install -g get-tbd@0.3.0"
 exit 1

--- a/.codex/tbd-session.sh
+++ b/.codex/tbd-session.sh
@@ -18,10 +18,10 @@ fi
 
 # Pinned zero-install fallback. Never use an unpinned runner here.
 if command -v npx &> /dev/null; then
-    npx --yes get-tbd@0.2.3 prime "$@"
+    npx --yes get-tbd@0.3.0 prime "$@"
     exit $?
 fi
 
 echo "[tbd] tbd CLI not found and npx is unavailable."
-echo "[tbd] Install it with: npm install -g get-tbd@0.2.3"
+echo "[tbd] Install it with: npm install -g get-tbd@0.3.0"
 exit 1

--- a/.tbd/config.yml
+++ b/.tbd/config.yml
@@ -1,5 +1,5 @@
 tbd_format: f06
-tbd_version: 0.2.4-dev.60.a9711f6-dirty
+tbd_version: 0.3.0
 # tbd_upgrades: tbd versions that have run `tbd setup` in this repo (oldest first);
 # tbd_version above is the most recent. Informational; updated automatically by setup.
 tbd_upgrades:
@@ -8,6 +8,8 @@ tbd_upgrades:
     at: 2026-06-13T07:40:35.743Z
   - version: 0.2.4-dev.60.a9711f6-dirty
     at: 2026-06-13T08:28:48.395Z
+  - version: 0.3.0
+    at: 2026-06-15T16:37:46.614Z
 display:
   id_prefix: tbd
 sync:


### PR DESCRIPTION
Upgrade this repo's own tbd integration to the freshly published **get-tbd 0.3.0** (`tbd setup --auto`, run from a clean `v0.3.0` build).

Changes (generated, not hand-edited):
- `.tbd/config.yml`: stamp `tbd_version: 0.3.0` and append `0.3.0` to the `f06` upgrade history.
- `.claude/scripts/tbd-session.sh` and `.codex/tbd-session.sh`: repin the zero-install fallback to `get-tbd@0.3.0` (was `0.2.3`).

**Forkable docs intentionally left disabled** — this repo owns its docs as source under `packages/tbd/docs/`, so there's nothing to fork. `setup --auto` confirmed "none forked into the repo."

Verified: full vitest suite (1324 tests) passes against this tree, including the `skills/tbd/SKILL.md` drift test; pre-push gate green.

https://claude.ai/code/session_018erxkUHGwShRZJaoN8oUon

---
_Generated by [Claude Code](https://claude.ai/code/session_018erxkUHGwShRZJaoN8oUon)_