### PR TITLE
docs(shortcuts): PR review lifecycle — decouple reviewing from addressing

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ status or context or knowledge and know what to do next:
 | “Create a bead for the bug where …” | Agent creates and tracks a bead | `tbd create "..." --type=bug` |
 | “Let’s work on current beads” | Agent finds ready beads and starts working | `tbd ready` |
 | “Review this code” | Agent performs comprehensive code review with all guidelines | [`tbd shortcut review-code`](packages/tbd/docs/shortcuts/standard/review-code.md) |
-| “Review this PR” | Agent reviews a GitHub pull request and can comment/fix | [`tbd shortcut review-github-pr`](packages/tbd/docs/shortcuts/standard/review-github-pr.md) |
+| “Review this PR” | Agent reviews a GitHub pull request and publishes the review | [`tbd shortcut review-github-pr`](packages/tbd/docs/shortcuts/standard/review-github-pr.md) |
 | “Use the shortcut to commit” | Agent runs full pre-commit checks, code review, and commits | [`tbd shortcut code-review-and-commit`](packages/tbd/docs/shortcuts/standard/code-review-and-commit.md) |
 | “Create a PR” | Agent creates or updates the pull request | [`tbd shortcut create-or-update-pr-simple`](packages/tbd/docs/shortcuts/standard/create-or-update-pr-simple.md) |
 | “Let’s create a research brief on …” | Agent creates a research document using a template | [`tbd shortcut new-research-brief`](packages/tbd/docs/shortcuts/standard/new-research-brief.md) |
@@ -443,8 +443,10 @@ tbd docs fork --all              # Or fork by name: tbd docs fork <name> [<name>
 |  | `new-architecture-doc` | Create an architecture document |
 |  | `revise-architecture-doc` | Update an architecture doc to match current code |
 |  | `revise-all-architecture-docs` | Revise all current architecture documents |
-| **Review** | `review-code` | Comprehensive code review (uncommitted, branch, or PR) |
-|  | `review-github-pr` | Review a GitHub PR with commenting and CI checks |
+| **Review** | `pr-review-workflows` | Map of the PR review lifecycle and its shortcuts |
+|  | `review-code` | Comprehensive code review (uncommitted, branch, or PR) |
+|  | `review-github-pr` | Review a GitHub PR and publish the review |
+|  | `address-pr-review` | Address a published PR review (fix, rebut, or defer each finding) |
 |  | `review-code-typescript` | TypeScript-focused code review |
 |  | `review-code-python` | Python-focused code review |
 | **Git** | `precommit-process` | Pre-commit review and testing |

--- a/packages/tbd/docs/shortcuts/standard/address-pr-review.md
+++ b/packages/tbd/docs/shortcuts/standard/address-pr-review.md
@@ -1,0 +1,114 @@
+---
+title: Address PR Review
+description: Address an existing PR review from any channel—track every finding as a bead, fix or rebut each, reply with a per-finding disposition map, and get CI green
+category: review
+author: Joshua Levy (github.com/jlevy) with LLM assistance
+---
+This shortcut **addresses an existing review** of a pull request: a review that someone
+else (agent or human) already published.
+It is the counterpart of `tbd shortcut review-github-pr`, which creates and publishes
+such reviews.
+For the full lifecycle, the channels a review can arrive on, and the review
+artifact format, see `tbd shortcut pr-review-workflows`.
+
+The guarantee this workflow provides: **every finding is tracked as a bead and gets an
+explicit disposition** (fixed, rebutted, or deferred)—nothing is silently dropped.
+
+## Instructions
+
+Create a to-do list with the following items then perform all of them:
+
+1. **GitHub CLI setup:**
+   - Verify: `gh auth status` (if issues, run `tbd shortcut setup-github-cli`)
+   - Get repo:
+     `REPO=$(git remote get-url origin | sed -E 's#.*/git/##; s#.*github.com[:/]##; s#\.git$##')`
+   - Use `--repo $REPO` on all gh commands
+
+2. **Locate the review(s) to address:**
+   - If the user pointed at a specific review (PR number, comment URL, issue number, or
+     review-doc path), start there
+   - Then sweep all channels for other unaddressed review content on the PR (see
+     `tbd shortcut pr-review-workflows` for the channels):
+     - Formal reviews: `gh api repos/$REPO/pulls/<PR_NUMBER>/reviews`
+     - Inline review comments: `gh api repos/$REPO/pulls/<PR_NUMBER>/comments`
+     - PR comments: `gh pr view <PR_NUMBER> --repo $REPO --comments`
+     - GitHub issues referencing the PR:
+       `gh issue list --repo $REPO --search "<PR_NUMBER>"`
+     - In-repo review docs linked from the PR or its comments (e.g. under
+       `docs/project/reviews/`)
+   - Skip review content already answered by a later “Addressed … in `<commit>`” reply;
+     a PR may have accumulated several reviews, so aggregate everything still
+     unaddressed
+
+3. **Parse the findings:**
+   - Enumerate every finding with its ID, severity, `file:line` references, and
+     suggested fix
+   - Keep the reviewer’s IDs (R1..RN or 1..N); if a review has none, assign sequential
+     IDs so your reply can reference them
+   - Respect “False positives / do not fix” sections: these get no code change
+   - Non-blocking “Suggestions” are optional: apply the cheap ones, and explicitly defer
+     or decline the rest (they still appear in the disposition map)
+
+4. **Create tracking beads:**
+   - Parent bead:
+     `tbd create "Address review: PR #<NUMBER> — <topic>" --type task --priority P1`
+   - One child bead per finding:
+     `tbd create "PR #<NUMBER> review <ID>: <finding>" --type bug --parent <parent-id>`
+     with `file:line` references and the PR number in the description
+   - Dedup first: `tbd search` for existing beads covering the same problem; if one
+     exists, append the review context to it instead of creating a duplicate, and use
+     that bead in the disposition map
+
+5. **Check out the PR branch:**
+   - `gh pr checkout <PR_NUMBER> --repo $REPO`
+   - If the base branch has moved substantially, run `tbd shortcut merge-upstream` first
+     so fixes land on a current branch
+
+6. **Triage and address each finding, in severity order:**
+
+   For each child bead, mark it in_progress, then choose one disposition:
+   - **Fix**: make the change, following `tbd guidelines general-tdd-guidelines`; run
+     the affected tests; close the bead
+   - **Rebut**: if the finding is factually wrong or the suggested fix would make things
+     worse, do NOT change the code; write a specific technical justification for the
+     reply in step 8 and close the bead with `--reason`
+   - **Defer**: if the finding is real but out of scope for this PR, leave the bead open
+     and record where and when it should be handled
+
+   If a finding offers “Fix (pick one):” options, choose one and record which and why.
+   Never silently skip a finding.
+
+7. **Verify and push:**
+   - Run the full test suite and lint (see project docs for the exact commands)
+   - Commit with conventional commit messages and push
+   - Run `gh pr checks <PR_NUMBER> --repo $REPO --watch 2>&1` and wait for the **final
+     summary**—do not stop at early “passing” output
+   - If CI fails: analyze, fix, push, and restart this step
+
+8. **Close the loop—publish the disposition map:**
+   - Reply on the same channel the review arrived on, with a comment titled “Addressed
+     the review findings in `<commit>`:” followed by one line per finding:
+     - `<ID>: fixed — <what changed>`
+     - `<ID>: rebutted — <why the finding does not apply>`
+     - `<ID>: deferred — tracked as <bead-id>`
+   - For formal reviews with inline threads: reply to and resolve each thread
+   - For a review carried in a GitHub issue: post the disposition map there and close
+     the issue if every finding is resolved
+   - For an in-repo review doc: append a dated “Status Addendum” section (never rewrite
+     the original findings) and commit it on the repo’s default branch, where the review
+     doc lives—not the checked-out PR branch
+   - Update the PR description if the fixes changed its scope
+
+9. **Close out tracking:**
+   - Close the parent bead once all children are fixed or rebutted (deferred children
+     stay open under the parent or re-linked as appropriate)
+   - Run `tbd sync`
+
+10. **Report to user:**
+    - The disposition map (finding ID → fixed/rebutted/deferred)
+    - Beads created, closed, and left open
+    - Commit SHAs, CI status, and the PR URL
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/packages/tbd/docs/shortcuts/standard/pr-review-workflows.md
+++ b/packages/tbd/docs/shortcuts/standard/pr-review-workflows.md
@@ -1,0 +1,87 @@
+---
+title: PR Review Workflows
+description: The PR review lifecycle—how reviews are created, published (formal review, PR comment, GitHub issue, or review doc), and addressed, and which shortcut runs each stage. Start here to pick the right review shortcut.
+category: review
+author: Joshua Levy (github.com/jlevy) with LLM assistance
+---
+This is the **map of the PR review lifecycle**: the stages a code review moves through,
+which shortcut runs each stage, and the conventions that let one agent write a review
+and a different agent address it later.
+
+Read this before writing or addressing any PR review, or whenever you need to pick the
+right review shortcut.
+
+## The Lifecycle
+
+A PR review moves through distinct stages, each with its own shortcut.
+Reviewing and addressing are **decoupled on purpose**: they are often done by different
+agents in different sessions, and the published review artifact is the handoff between
+them.
+
+| Stage | What happens | Shortcut |
+| --- | --- | --- |
+| 1. Prepare the PR | Work committed and pushed, PR created or updated, CI green | `code-review-and-commit` (commit and push), then `create-or-update-pr-simple` or `create-or-update-pr-with-validation-plan` |
+| 2. Review | A reviewer (agent or human) reviews the diff and compiles structured findings | `review-github-pr` (wraps `review-code`) |
+| 3. Publish | The review is posted as a durable artifact on one channel (see below) | final steps of `review-github-pr` |
+| 4. Address | An agent (often a different one) picks up the published review, tracks every finding as a bead, and fixes, rebuts, or explicitly defers each | `address-pr-review` |
+
+The core review engine is `tbd shortcut review-code`, which reviews any diff
+(uncommitted changes, branch work, or a GitHub PR). `review-code-typescript` and
+`review-code-python` are narrower, language-only variants; `review-code` itself loads
+the same language guidelines, so use the variants only when a language-scoped review is
+explicitly wanted.
+
+Pre-commit reviews (`tbd shortcut precommit-process`) use `review-code` directly and fix
+issues immediately—the publish and address stages apply to reviews of pushed PRs, where
+the review and the fix are separate pieces of work.
+
+## Review Channels
+
+A published review can live in any of these places.
+The same artifact format (below) applies on every channel, and `address-pr-review` must
+check all of them:
+
+- **Formal GitHub review** on the PR (`gh pr review --comment`). Often a single long
+  review body. Verdicts are usually textual (e.g. “Verdict: approve with nits”) rather
+  than GitHub approve/request-changes states, since reviewer and author may share one
+  account.
+- **Plain PR comment**: one long review posted as an issue comment on the PR.
+- **GitHub issue**: a review written up as its own issue and cross-linked from a PR
+  comment. Used when the review spans multiple PRs or needs its own discussion thread.
+- **In-repo review doc**: a file committed to the repo’s **default branch** (not the PR
+  branch), such as `docs/project/reviews/review-YYYY-MM-DD-<topic>.md`, linked from a PR
+  comment. Treated as an immutable audit trail: update it by appending dated addenda
+  (also on the default branch), never by rewriting findings.
+
+## Review Artifact Format
+
+A review must be parseable later by an agent who was not there when it was written.
+Every published review includes:
+
+- **Scope**: what was reviewed (PR number, diff range, file count) and how.
+- **Summary and verdict**: brief assessment with an explicit textual verdict.
+- **Findings**: numbered with stable IDs (1..N or R1..RN), each with a severity
+  (Blocker/High/Medium/Low), `file:line` references, and a concrete **Fix:** suggestion.
+  Use “Fix (pick one):” when several reasonable options exist.
+- **Suggestions**: optional, non-blocking improvements, clearly separated from findings.
+- **False positives / do not fix**: things checked and confirmed benign, so the
+  addressing agent does not “fix” them.
+- **CI status**: state of checks at review time.
+
+## The Two-Agent Handoff
+
+The common flow these shortcuts support:
+
+1. Agent A runs `tbd shortcut review-github-pr` on PR #N, compiles findings in the
+   artifact format, and publishes them to one channel (stages 2-3).
+2. Agent B—often a different agent in a later session—runs
+   `tbd shortcut address-pr-review` for PR #N: it locates the published review(s),
+   creates a parent bead plus one child bead per finding, fixes, rebuts, or defers each,
+   and closes the loop with an “Addressed” reply and green CI (stage 4).
+
+Nothing is lost between the two agents because findings carry stable IDs in the artifact
+and are tracked as beads while being addressed.
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/packages/tbd/docs/shortcuts/standard/review-code-python.md
+++ b/packages/tbd/docs/shortcuts/standard/review-code-python.md
@@ -9,6 +9,8 @@ practices, patterns, and antipatterns.
 
 For a **comprehensive review** that includes general coding rules, error handling,
 comment quality, and testing practices, use `tbd shortcut review-code` instead.
+For the full PR review lifecycle (publishing and addressing reviews), see
+`tbd shortcut pr-review-workflows`.
 
 Instructions:
 

--- a/packages/tbd/docs/shortcuts/standard/review-code-typescript.md
+++ b/packages/tbd/docs/shortcuts/standard/review-code-typescript.md
@@ -9,6 +9,8 @@ TypeScript-specific best practices, patterns, and antipatterns.
 
 For a **comprehensive review** that includes general coding rules, error handling,
 comment quality, and testing practices, use `tbd shortcut review-code` instead.
+For the full PR review lifecycle (publishing and addressing reviews), see
+`tbd shortcut pr-review-workflows`.
 
 Instructions:
 

--- a/packages/tbd/docs/shortcuts/standard/review-code.md
+++ b/packages/tbd/docs/shortcuts/standard/review-code.md
@@ -8,6 +8,10 @@ This is the **core code review** shortcut.
 It performs a comprehensive review of code changes using all general and
 language-specific guidelines.
 
+It is the review *engine*: it produces findings but does not publish or fix them.
+For where it sits in the PR review lifecycle (publishing reviews, addressing them), see
+`tbd shortcut pr-review-workflows`.
+
 ## Scope Options
 
 This shortcut supports three review scopes:
@@ -84,28 +88,34 @@ Create a to-do list with the following items then perform all of them:
 
    - If changes affect behavior documented in specs (`docs/project/specs/active/`), note
      any needed updates
-   - If changes affect `docs/development.md`, note any needed updates
+   - If changes affect the project’s development docs (e.g. `docs/development.md` or
+     `docs/contexts/development.md`), note any needed updates
    - If changes affect architecture (`docs/project/architecture/`), note any needed
      updates
 
 8. **Compile the review:**
 
-   Write a structured review with:
+   Write a structured review following the review artifact format in
+   `tbd shortcut pr-review-workflows`—verdict, findings numbered with stable IDs and
+   severities (Blocker/High/Medium/Low) and `file:line` references and a concrete
+   **Fix:** suggestion each, non-blocking suggestions, false positives confirmed
+   benign—so a later agent can address it.
+   Add two engine-specific sections:
 
-   - **Summary**: Brief assessment (1-2 sentences)
    - **Design assessment**: Review architecture and pros/cons/alternatives, how this
      design fits relative to other possible approaches, its strengths and weaknesses
      relative to alternatives
-   - **Issues**: Problems found, with `file:line` references and suggested fixes
-   - **Suggestions**: Optional improvements (not blockers)
    - **Documentation**: Any docs that need updating
 
 9. **Determine next action:**
 
    - If the user specified what to do next, follow those instructions
    - If this is a precommit review, proceed to fix any issues found
+   - If this review is of a pushed PR, publishing and fixing are separate lifecycle
+     stages: `tbd shortcut review-github-pr` publishes the review, and
+     `tbd shortcut address-pr-review` addresses a published review
    - Otherwise, present the review and ask:
-     - **Fix issues**: Create tbd beads for issues and begin fixing
+     - **Fix issues**: Create tbd beads for the findings and begin fixing
      - **Report only**: Just output the review (no changes)
 
 <!-- This document follows common-doc-guidelines.md.

--- a/packages/tbd/docs/shortcuts/standard/review-github-pr.md
+++ b/packages/tbd/docs/shortcuts/standard/review-github-pr.md
@@ -1,11 +1,15 @@
 ---
 title: Review GitHub PR
-description: Review a GitHub pull request with follow-up actions (comment, fix, CI check)
+description: Review a GitHub pull request and publish the review to a chosen channel (formal review, PR comment, GitHub issue, or in-repo review doc). To fix the findings, see address-pr-review.
 category: review
 author: Joshua Levy (github.com/jlevy) with LLM assistance
 ---
-This shortcut reviews a **GitHub pull request** and handles GitHub-specific follow-ups
-like commenting on the PR, checking CI status, and pushing fixes.
+This shortcut **reviews a GitHub pull request and publishes the review** as a durable
+artifact. It covers stages 2-3 of the PR review lifecycle (see
+`tbd shortcut pr-review-workflows`): it produces and posts the review, and it
+deliberately does NOT fix the findings.
+Addressing a review is a separate workflow, `tbd shortcut address-pr-review`, often run
+by a different agent.
 
 For reviewing **local changes** (uncommitted or branch work) without GitHub integration,
 use `tbd shortcut review-code` directly.
@@ -15,8 +19,7 @@ use `tbd shortcut review-code` directly.
 Create a to-do list with the following items then perform all of them:
 
 1. **GitHub CLI setup:**
-   - Verify: `gh auth status`
-   - If issues, run `tbd shortcut setup-github-cli`
+   - Verify: `gh auth status` (if issues, run `tbd shortcut setup-github-cli`)
    - Get repo:
      `REPO=$(git remote get-url origin | sed -E 's#.*/git/##; s#.*github.com[:/]##; s#\.git$##')`
    - Use `--repo $REPO` on all gh commands
@@ -29,116 +32,56 @@ Create a to-do list with the following items then perform all of them:
 
 3. **Check CI status:**
    - Run: `gh pr checks <PR_NUMBER> --repo $REPO`
-   - Note any failing or pending checks
+   - Note any failing or pending checks for the review’s CI status section
 
-4. **Perform code review:**
-   - Run `tbd shortcut review-code` using the **GitHub PR** scope
-   - The diff is obtained via: `gh pr diff <PR_NUMBER> --repo $REPO`
+4. **Check existing review context:**
+   - Prior reviews and comments: `gh pr view <PR_NUMBER> --repo $REPO --comments` and
+     `gh api repos/$REPO/pulls/<PR_NUMBER>/reviews`
+   - Note unresolved findings from earlier reviews so your review references them
+     instead of duplicating them
+   - If your actual task is to FIX an existing review rather than write a new one, stop
+     and run `tbd shortcut address-pr-review` instead
 
-5. **Check documentation consistency:**
-   - Review any specs referenced by the PR in `docs/project/specs/active/`
-   - Check if `docs/development.md` needs updates for behavioral changes
-   - Check if architecture docs in `docs/project/architecture/` need updates
-   - Note any documentation that is out of sync with the code changes
+5. **Perform the code review:**
+   - Run `tbd shortcut review-code` using the **GitHub PR** scope (diff via
+     `gh pr diff <PR_NUMBER> --repo $REPO`)
+   - This loads the general and language-specific guidelines and also checks
+     documentation consistency (specs, architecture docs)
 
-6. **Review existing PR comments:**
-   - Get PR comments: `gh pr view <PR_NUMBER> --repo $REPO --comments`
-   - For review comments: `gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments`
-   - Note any unresolved comments or requested changes
+6. **Compile the review:**
+   - Follow the review artifact format from `tbd shortcut pr-review-workflows` (scope,
+     verdict, findings with stable IDs and severities, suggestions, false positives, CI
+     status)
+   - Include any documentation gaps and unresolved earlier review comments
+   - Write the review body to a temp file so it can be posted with `--body-file`
 
-7. **Compile full review:** Combine the code review findings with GitHub-specific info:
+7. **Publish the review:**
 
-   - **Summary**: Brief assessment (1-2 sentences)
-   - **Strengths**: What’s done well (if any)
-   - **Issues**: Problems found with `file:line` references and suggested fixes
-   - **Documentation gaps**: Specs or docs that need updating
-   - **Unresolved comments**: Any PR comments still needing attention
-   - **Suggestions**: Optional improvements (not blockers)
-   - **CI Status**: Current state of checks (passing/failing/pending)
+   Post to the channel the user asked for; default to a formal GitHub review.
+   (If the user asked for “report only”, present the review and skip this step.)
 
-8. **Determine next action:**
-   - If the user already specified what to do (e.g., “review and comment”, “review and
-     fix”), follow those instructions
-   - Otherwise, present the review and ask the user:
-     - **Add as PR comment**: Post the review as a comment on the PR
-     - **Fix with beads**: Create tbd beads for every issue and systematically fix them
-     - **Report only**: Just output the review (no action)
+   - **Formal GitHub review** (default):
+     `gh pr review <PR_NUMBER> --repo $REPO --comment --body-file <file>`
+   - **PR comment**: `gh pr comment <PR_NUMBER> --repo $REPO --body-file <file>`
+   - **GitHub issue**:
+     `gh issue create --repo $REPO --title "Review: PR #<PR_NUMBER> — <topic>" --body-file <file>`,
+     then cross-link it with a short PR comment
+   - **In-repo review doc**: write the review as a committed doc following the project’s
+     conventions (e.g. `docs/project/reviews/review-YYYY-MM-DD-<topic>.md`), commit it
+     on the repo’s default branch (not the PR branch), and post a short PR comment
+     linking to it
 
-9. **Take the requested action:**
+8. **Hand off or stop:**
+   - Reviewing ends here—do not start fixing findings in this workflow
+   - If the user asked to review AND fix, now run `tbd shortcut address-pr-review` on
+     the review you just published
+   - Otherwise the published review is the handoff: any agent can later pick it up with
+     `tbd shortcut address-pr-review`
 
-   ### If adding as comment:
-
-   ```bash
-   gh pr review <PR_NUMBER> --repo $REPO --comment --body "<review>"
-   ```
-
-   ### If fixing with beads (comprehensive tracking):
-
-   This approach ensures **every issue is tracked** and nothing is lost:
-
-   a. **Create a parent bead** for the PR review:
-   ```bash
-   tbd create "Review PR #<NUMBER>: <title>" --type task --priority P1
-   ```
-
-   b. **Create child beads for EVERY issue found:**
-   ```bash
-   tbd create "<issue description>" --type bug --parent <parent-bead-id>
-   ```
-
-   Categories to track as beads:
-   - Code issues (bugs, antipatterns, missing error handling)
-   - Test gaps (missing tests, inadequate coverage)
-   - Documentation gaps (specs out of sync, missing updates)
-   - CI failures (each failing check)
-   - Unresolved PR comments
-
-   Each bead description should include:
-   - File and line number (e.g., `src/foo.ts:42`)
-   - Brief description of the issue
-   - Reference to the PR (e.g., `(PR #123)`)
-
-   c. **Check out the PR branch:**
-   ```bash
-   gh pr checkout <PR_NUMBER> --repo $REPO
-   ```
-
-   d. **Fix issues systematically:**
-   - Mark the parent bead as in_progress: `tbd update <id> --status in_progress`
-   - Work through each child bead in order:
-     - Mark as in_progress before starting
-     - Follow `tbd guidelines general-tdd-guidelines` for code fixes
-     - Run tests after each fix
-     - Mark as closed when complete: `tbd close <id>`
-   - Commit fixes with conventional commit messages
-
-   e. **Verify CI passes:**
-   - Push changes: `git push`
-   - Wait for CI: `gh pr checks <PR_NUMBER> --repo $REPO --watch 2>&1`
-   - **IMPORTANT**: Wait for the final summary—don’t stop at early “passing” output
-   - If CI fails: create a bead for the failure, fix it, restart this step
-
-   f. **Update PR description** to reflect what was fixed:
-   ```bash
-   gh pr edit <PR_NUMBER> --repo $REPO --body "..."
-   ```
-
-   g. **Close the parent bead:**
-   ```bash
-   tbd close <parent-bead-id> --reason "PR review complete, all issues resolved"
-   tbd sync
-   ```
-
-   ### If report only:
-
-   - Output the review
-   - No further action needed
-
-10. **Report to user:**
-    - Summarize what was reviewed (and fixed, if applicable)
-    - List any beads created (if fixing with beads)
-    - Confirm CI status
-    - Provide the PR URL
+9. **Report to user:**
+   - Summary and verdict, finding count by severity
+   - Where the review was published (URL)
+   - CI status and the PR URL
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/packages/tbd/docs/tbd-docs.md
+++ b/packages/tbd/docs/tbd-docs.md
@@ -976,9 +976,10 @@ tbd shortcut review-code
 tbd shortcut review-code
 # Then select "Branch work" scope
 
-# Review a specific GitHub PR
+# Review a specific GitHub PR and publish the review
 tbd shortcut review-github-pr
-# Supports commenting, CI checks, and follow-up fixes
+# Reviews and publishes only; to fix a published review:
+tbd shortcut address-pr-review
 
 # Language-specific reviews (when you want just the language rules)
 tbd shortcut review-code-typescript


### PR DESCRIPTION
The bundled review shortcuts conflate three lifecycle stages — producing a review, publishing it, and fixing the findings — in one workflow (`review-github-pr` step 8 "Determine next action"). In practice these stages are often run by *different agents in different sessions*, and the published review artifact is the handoff between them.

This PR restructures the review docs around that lifecycle:

- **`pr-review-workflows` (new)**: the map — the stages, which shortcut runs each, the four publish channels (formal GitHub review / PR comment / GitHub issue / in-repo review doc), and a review artifact format (verdict; findings with stable IDs, severities, `file:line` references, and a concrete **Fix:** each) so a later agent can address a review it didn't write.
- **`address-pr-review` (new)**: the addressing counterpart — every finding becomes a bead and gets an explicit disposition (fixed / rebutted / deferred), the reply is a per-finding disposition map, and the workflow ends with CI green.
- **`review-github-pr` (rewritten)**: reviews and *publishes* only; deliberately does not fix. Adds existing-review context gathering (so reviews reference prior findings instead of duplicating them), `--body-file` publishing, and redirects "actually fix it" requests to `address-pr-review`.
- **`review-code`**: framed as the review *engine* (produces findings; neither publishes nor fixes); compiles output in the shared artifact format. Also generalizes a hardcoded `docs/development.md` reference.
- Cross-links from `review-code-python` / `review-code-typescript` and an updated example in the `tbd-docs` manual.

No manifest changes needed — bundled docs are auto-scanned (`generateDefaultDocCacheConfig`).

Context: adopted downstream in a project where separate agents review and address PRs; the decoupling has been exercised across many PRs. Extracted via `tbd docs diff --base` / `tbd shortcut suggest-upstream-improvements`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to bundled agent shortcuts; no CLI or runtime behavior changes.
> 
> **Overview**
> **PR review docs are reorganized around a four-stage lifecycle** (prepare → review → publish → address) so reviewing and fixing can run in separate agent sessions, with the published review as the handoff.
> 
> **New shortcuts:** `pr-review-workflows` documents stages, four publish channels (formal review, PR comment, GitHub issue, in-repo review doc), and a shared **review artifact** format (stable finding IDs, severities, `file:line`, **Fix:**). `address-pr-review` is the counterpart to publishing: sweep channels, bead-track every finding, fix/rebut/defer each, reply with a disposition map, and get CI green.
> 
> **`review-github-pr` is narrowed** to review + publish only (`--body-file`, prior-review context, redirect fix requests to `address-pr-review`); the old combined “comment or fix with beads” flow is removed from this shortcut.
> 
> **`review-code`** is framed as the engine only (findings, shared artifact format); **README**, **`tbd-docs`**, and language review shortcuts are updated with cross-links and the new review table entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ec31bbb53b053feb8f97edae94e2d7e0f0d2763. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->