### PR TITLE
docs(shortcuts): session-closing discipline, branch-state checks, de-hardcode npm

### DIFF
--- a/packages/tbd/docs/shortcuts/standard/code-review-and-commit.md
+++ b/packages/tbd/docs/shortcuts/standard/code-review-and-commit.md
@@ -11,21 +11,15 @@ Instructions:
 
 Create a to-do list with the following items then perform all of them:
 
-1. Follow the `tbd shortcut precommit-process` steps to review and run pre-commit
-   checks.
+1. Follow the `tbd shortcut precommit-process` steps to review, test, and commit (it
+   ends with the commit).
+   If there are unresolved problems, ask for guidance; otherwise do NOT ask the user for
+   permission to commit.
 
-2. If there are problems, ask for guidance.
-   Otherwise, commit directly.
-   Do NOT ask the user for permission to commit unless there are problems.
-   Use conventional commit prefixes: `feat`, `fix`, `docs`, `style`, `refactor`, `test`,
-   `chore`, `plan`, `research`, `ops`, `process`. Scope is optional—only add when it
-   resolves an important ambiguity.
-   (See `tbd guidelines commit-conventions` for details.)
-
-3. If commit is successful, push to remote:
+2. If commit is successful, push to remote:
    - Run: `git push`
 
-4. If there is a PR already filed for this branch, update the PR description and **wait
+3. If there is a PR already filed for this branch, update the PR description and **wait
    for CI to pass**:
    - **GitHub CLI setup** (if issues, run `tbd shortcut setup-github-cli`):
      ```
@@ -42,6 +36,8 @@ Create a to-do list with the following items then perform all of them:
      CI watch.
    - Only proceed when you see all checks have passed.
    - Confirm to the user that CI has passed.
+
+4. Close or update beads for the committed work, then run `tbd sync`.
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/packages/tbd/docs/shortcuts/standard/create-or-update-pr-simple.md
+++ b/packages/tbd/docs/shortcuts/standard/create-or-update-pr-simple.md
@@ -20,16 +20,21 @@ Create a to-do list with the following items then perform all of them:
      ```
    - Use `--repo $REPO` on all gh commands (required for Claude Code Cloud)
 
-2. Check if a PR already exists for this branch:
+2. Check branch state: if this branch has uncommitted work, commit it first via
+   `tbd shortcut code-review-and-commit` (leave files that look like another agent’s
+   in-progress work); if the branch is behind its base with likely conflicts, run
+   `tbd shortcut merge-upstream` first.
+
+3. Check if a PR already exists for this branch:
    - Run: `gh pr view $BRANCH --repo $REPO --json number,url 2>/dev/null`
    - If it returns JSON, a PR exists (you’ll update it).
      If it errors, you’ll create one.
 
-3. Review all commits on this branch since it diverged from main:
+4. Review all commits on this branch since it diverged from main:
    - Run `git log main..HEAD --oneline` to see commits
    - Run `git diff main...HEAD` to see all changes
 
-4. Write a PR title and description:
+5. Write a PR title and description:
    - Title should be concise and describe the change (e.g., “Add user authentication”)
    - Description should have a brief summary of what changed and why
    - If you’re changing an existing PR, update the title to be current
@@ -38,14 +43,14 @@ Create a to-do list with the following items then perform all of them:
      when it resolves an important ambiguity.
      (See `tbd guidelines commit-conventions` for details.)
 
-5. Create or update the PR:
+6. Create or update the PR:
    - If creating:
      `gh pr create --repo $REPO --head $BRANCH --base main --title "..." --body "..."`
    - If updating: `gh pr edit $BRANCH --repo $REPO --title "..." --body "..."`
 
-6. Report the PR URL to the user and inform them you are now waiting for CI.
+7. Report the PR URL to the user and inform them you are now waiting for CI.
 
-7. **Wait for CI to pass (CRITICAL):**
+8. **Wait for CI to pass (CRITICAL):**
    - Run: `gh pr checks $BRANCH --repo $REPO --watch 2>&1`
    - **IMPORTANT**: The `--watch` flag blocks until ALL checks complete.
      Do NOT see “passing” in early output and move on—wait for the **final summary**
@@ -54,7 +59,11 @@ Create a to-do list with the following items then perform all of them:
      restart from this step.
    - Only proceed when you see all checks have passed in the final summary.
 
-8. Confirm to the user that CI has passed and the PR is ready for review.
+9. Confirm to the user that CI has passed and the PR is ready for review.
+   The next lifecycle stages have their own shortcuts (see
+   `tbd shortcut pr-review-workflows`): `tbd shortcut review-github-pr` reviews and
+   publishes a review of the PR, and `tbd shortcut address-pr-review` addresses a review
+   the PR receives.
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/packages/tbd/docs/shortcuts/standard/create-or-update-pr-with-validation-plan.md
+++ b/packages/tbd/docs/shortcuts/standard/create-or-update-pr-with-validation-plan.md
@@ -20,17 +20,22 @@ Create a to-do list with the following items then perform all of them:
      ```
    - Use `--repo $REPO` on all gh commands (required for Claude Code Cloud)
 
-2. Check if a PR already exists for this branch:
+2. Check branch state: if this branch has uncommitted work, commit it first via
+   `tbd shortcut code-review-and-commit` (leave files that look like another agent’s
+   in-progress work); if the branch is behind its base with likely conflicts, run
+   `tbd shortcut merge-upstream` first.
+
+3. Check if a PR already exists for this branch:
    - Run: `gh pr view $BRANCH --repo $REPO --json number,url 2>/dev/null`
    - If it returns JSON, a PR exists (you’ll update it).
      If it errors, you’ll create one.
 
-3. Review all commits on this branch since it diverged from main:
+4. Review all commits on this branch since it diverged from main:
    - Run `git log main..HEAD --oneline` to see commits
    - Run `git diff main...HEAD` to see all changes
    - Review any related specs in docs/project/specs/active/
 
-4. Write a PR title and description with these sections.
+5. Write a PR title and description with these sections.
    Use conventional commit prefixes: `feat`, `fix`, `docs`, `style`, `refactor`, `test`,
    `chore`, `plan`, `research`, `ops`, `process`. Scope is optional—only add when it
    resolves an important ambiguity.
@@ -47,8 +52,8 @@ Create a to-do list with the following items then perform all of them:
    ## Test Plan
 
    Detailed validation checklist:
-   - [ ] Unit tests pass (`npm test`)
-   - [ ] Build succeeds (`npm run build`)
+   - [ ] Unit tests pass (run the project’s test command)
+   - [ ] Build succeeds (run the project’s build command)
    - [ ] Manual testing steps (list specific scenarios to test)
    - [ ] Edge cases considered (list any)
 
@@ -56,15 +61,15 @@ Create a to-do list with the following items then perform all of them:
 
    Link any related beads using their IDs.
 
-5. Create or update the PR:
+6. Create or update the PR:
    - If creating:
      `gh pr create --repo $REPO --head $BRANCH --base main --title "..." --body "..."`
    - If updating: `gh pr edit $BRANCH --repo $REPO --title "..." --body "..."`
 
-6. Report the PR URL to the user, summarize the validation plan, and inform them you are
+7. Report the PR URL to the user, summarize the validation plan, and inform them you are
    now waiting for CI.
 
-7. **Wait for CI to pass (CRITICAL):**
+8. **Wait for CI to pass (CRITICAL):**
    - Run: `gh pr checks $BRANCH --repo $REPO --watch 2>&1`
    - **IMPORTANT**: The `--watch` flag blocks until ALL checks complete.
      Do NOT see “passing” in early output and move on—wait for the **final summary**
@@ -73,7 +78,11 @@ Create a to-do list with the following items then perform all of them:
      restart from this step.
    - Only proceed when you see all checks have passed in the final summary.
 
-8. Confirm to the user that CI has passed and the PR is ready for review.
+9. Confirm to the user that CI has passed and the PR is ready for review.
+   The next lifecycle stages have their own shortcuts (see
+   `tbd shortcut pr-review-workflows`): `tbd shortcut review-github-pr` reviews and
+   publishes a review of the PR, and `tbd shortcut address-pr-review` addresses a review
+   the PR receives.
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/packages/tbd/docs/shortcuts/standard/implement-beads.md
+++ b/packages/tbd/docs/shortcuts/standard/implement-beads.md
@@ -29,6 +29,9 @@ Create a to-do list with the following items then perform all of them:
    If unsure about a bead, let the user know at the end of all work which beads had
    problems.
 
+5. When the batch is done, push the branch and create or update its PR
+   (`tbd shortcut create-or-update-pr-simple`), then run `tbd sync`.
+
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.
 -->

--- a/packages/tbd/docs/shortcuts/standard/merge-upstream.md
+++ b/packages/tbd/docs/shortcuts/standard/merge-upstream.md
@@ -1,33 +1,53 @@
 ---
 title: Merge Upstream
-description: Merge origin/main into current branch with conflict resolution
+description: Merge origin/main into the current branch with conflict resolution, then verify, push, and watch CI
 category: git
 author: Joshua Levy (github.com/jlevy) with LLM assistance
 ---
-Merge upstream changes from origin/main into the current branch.
+We track work as beads using tbd.
+Run `tbd prime` for more on using tbd and current status.
 
-## Steps
+Merge upstream changes from origin/main into the current branch and leave the branch
+pushed with CI green.
 
-1. **Check state**: Run `git status` and `git fetch --all`
-   - If uncommitted changes exist, ask user whether to commit first
+## Instructions
 
-2. **Review upstream changes**: Check commits on origin/main since branch diverged
+Create a to-do list with the following items then perform all of them:
+
+1. **Check state:**
+   - Run `git status` and `git fetch --all`
+   - If uncommitted changes exist, commit them first via
+     `tbd shortcut code-review-and-commit` (or ask the user if the changes look like
+     another agent’s in-progress work)
+
+2. **Review upstream changes:** commits on origin/main since the branch diverged
    - `git log HEAD..origin/main --oneline`
 
-3. **Review local changes**: Check commits on this branch since diverging
+3. **Review local changes:** commits on this branch since diverging
    - `git log origin/main..HEAD --oneline`
    - `git diff origin/main...HEAD --stat`
 
-4. **Evaluate conflicts**: Identify likely logical or structural conflicts before
-   merging
+4. **Evaluate conflicts:** identify likely logical or structural conflicts before
+   merging—including semantic conflicts merge cannot see (both sides touching the same
+   behavior, renamed symbols, regenerated files)
 
-5. **Merge**: Run `git merge origin/main`
+5. **Merge:** run `git merge origin/main`
    - Resolve all conflicts carefully with full context
-   - For each conflict, understand both sides before choosing resolution
+   - For each conflict, understand both sides before choosing a resolution
 
-6. **Verify**: Run formatting, linting, and tests
+6. **Verify and commit:** run formatting, linting, and tests (see project docs for the
+   exact commands)
    - Fix any issues introduced by the merge
    - Commit the merge result
+
+7. **Push and wait for CI (CRITICAL):**
+   - `git push`
+   - If the branch has a PR, run `gh pr checks <PR_NUMBER> --watch 2>&1` and wait for
+     the **final summary**—do not stop at early “passing” output
+   - If CI fails: analyze, fix, commit, push, and restart this step
+
+8. **Close out:** run `tbd sync`, then report the merge result to the user (commits
+   merged, conflicts resolved and how, CI status)
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/packages/tbd/docs/shortcuts/standard/merge-upstream.md
+++ b/packages/tbd/docs/shortcuts/standard/merge-upstream.md
@@ -42,8 +42,13 @@ Create a to-do list with the following items then perform all of them:
 
 7. **Push and wait for CI (CRITICAL):**
    - `git push`
-   - If the branch has a PR, run `gh pr checks <PR_NUMBER> --watch 2>&1` and wait for
-     the **final summary**—do not stop at early “passing” output
+   - If the branch has a PR, watch CI. **GitHub CLI setup** (if issues, run
+     `tbd shortcut setup-github-cli`):
+     ```
+     REPO=$(git remote get-url origin | sed -E 's#.*/git/##; s#.*github.com[:/]##; s#\.git$##')
+     ```
+   - Run `gh pr checks <PR_NUMBER> --repo $REPO --watch 2>&1` and wait for the **final
+     summary**—do not stop at early “passing” output
    - If CI fails: analyze, fix, commit, push, and restart this step
 
 8. **Close out:** run `tbd sync`, then report the merge result to the user (commits

--- a/packages/tbd/docs/shortcuts/standard/precommit-process.md
+++ b/packages/tbd/docs/shortcuts/standard/precommit-process.md
@@ -35,18 +35,9 @@ Create a to-do list with the following items then perform all of them:
 
 3. **Unit testing and integration testing:**
 
-   BE SURE YOU RUN ALL TESTS (npm run precommit) as this includes codegen, formatting,
-   linting, unit tests and integration tests.
-
-   Read docs/development.md for additional background on test workflows.
-
-   After any significant changes, ALWAYS run the precommit check:
-
-   ```
-   npm run precommit  # Runs: codegen, format, lint, test:unit, test:integration
-   ```
-
-   This will generate code, auto-format, lint, and run unit and integration tests.
+   Run the project’s full check suite—codegen, formatting, linting, unit tests, and
+   integration tests. See the project docs (e.g. CLAUDE.md or AGENTS.md) for the exact
+   commands.
 
    Then YOU MUST FIX all issues found.
 


### PR DESCRIPTION
Several workflow shortcuts stop before the work is actually durable: merged but not pushed, committed but beads left open, PR created from a branch with uncommitted or stale state. And two of them hardcode npm commands that are wrong for non-npm projects. This PR:

- **Session-closing discipline**: `merge-upstream`, `code-review-and-commit`, and `implement-beads` now end with the full close-out — push, watch CI to the *final summary* (`gh pr checks --watch`), close/update beads, `tbd sync`.
- **Branch-state pre-checks**: both `create-or-update-pr-*` shortcuts get a new step 2 — commit uncommitted work first (via `code-review-and-commit`), run `merge-upstream` if the branch is behind its base — with a concurrent-agents guard (leave files that look like another session's in-progress work alone).
- **De-hardcode npm**: `precommit-process` replaces `npm run precommit` with "the project's full check suite (see project docs)"; the validation-plan template replaces `npm test` / `npm run build` with the project's own commands.
- **Semantic conflicts**: `merge-upstream` now asks the agent to anticipate conflicts merge cannot see — both sides touching the same behavior, renamed symbols, regenerated files — not just textual ones.

Depends on #182 for the `pr-review-workflows` / `address-pr-review` cross-references in the two create-or-update-pr shortcuts (text-only references; nothing breaks if this lands first, the pointers just dangle until #182 lands).

Context: distilled from recurring failure modes in a downstream monorepo with multiple concurrent agent sessions. Extracted via `tbd docs diff --base` / `tbd shortcut suggest-upstream-improvements`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent shortcut markdown; no runtime code, auth, or data paths.
> 
> **Overview**
> Tightens **tbd** git/workflow shortcuts so agent sessions finish with durable state instead of stopping mid-flight.
> 
> **Session close-out:** `code-review-and-commit` now treats `precommit-process` as review-through-commit, then push, optional PR update + `gh pr checks --watch` to the final summary, and **close/update beads + `tbd sync`**. `merge-upstream` is expanded to the same bar—commit dirty work first, merge with verification, **push**, watch CI on an open PR, then **`tbd sync`** and report. `implement-beads` adds a final step to push and run **`create-or-update-pr-simple`**, then sync.
> 
> **PR hygiene:** Both `create-or-update-pr-*` shortcuts get a new **branch-state** step: commit via `code-review-and-commit` (skip files that look like another agent’s WIP), or **`merge-upstream`** if behind base. They also point reviewers to **`pr-review-workflows`** for post-CI review shortcuts (depends on #182 for those docs to exist).
> 
> **Project-agnostic checks:** `precommit-process` and the validation-plan template drop hardcoded **`npm run precommit` / `npm test` / `npm run build`** in favor of the repo’s documented check commands (e.g. CLAUDE.md / AGENTS.md).
> 
> **Merge guidance:** `merge-upstream` explicitly calls out **semantic** conflict risks (shared behavior, renames, generated files), not only textual merge markers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebae877d1926a105ba1461152ea644362000276a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->