### PR TITLE
docs(shortcuts): rewrite update-specs-status as a full tracking reconcile

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ tbd docs fork --all              # Or fork by name: tbd docs fork <name> [<name>
 |  | `plan-implementation-with-beads` | Break a spec into implementation beads |
 |  | `implement-beads` | Implement beads from a spec |
 |  | `new-validation-plan` | Create a test/validation plan |
-|  | `update-specs-status` | Review active specs and sync with tbd issues |
+|  | `update-specs-status` | Reconcile specs, the work index, and beads into one status map |
 | **Documentation** | `new-research-brief` | Create a research document |
 |  | `new-architecture-doc` | Create an architecture document |
 |  | `revise-architecture-doc` | Update an architecture doc to match current code |

--- a/packages/tbd/docs/shortcuts/standard/update-specs-status.md
+++ b/packages/tbd/docs/shortcuts/standard/update-specs-status.md
@@ -1,30 +1,95 @@
 ---
 title: Update Specs Status
-description: Review active specs and sync their status with tbd issues
+description: Reconcile active specs, the top-level work index (e.g. TODO.md), and tbd beads into one current status map
 category: planning
 author: Joshua Levy (github.com/jlevy) with LLM assistance
 ---
-Review all active specs and ensure tbd issues accurately reflect current progress.
+Reconcile the project tracking surfaces so future agents can see the same current status
+from the top-level work index, the plan specs, and tbd beads.
 
-## Steps
+## Sources of Truth
 
-1. **List active specs**: Find all specs in `docs/project/specs/active/*.md`
+- **tbd beads:** Current status and dependencies.
+- **Active plan specs:** Governing plan and implementation checklist for each active
+  workstream.
+- **Top-level work index, if the project keeps one (e.g. `TODO.md`):** Brief index
+  linking each active workstream to its governing spec and beads.
+  The steps below say `TODO.md`; substitute the project’s own index (and skip its steps
+  if there is none).
 
-2. **Ensure spec issues exist**: For each spec, verify there’s a parent issue tracking
-   it.
-   - Create if missing: `tbd create "Spec: <spec-title>" --type=epic`
-   - Create child issues for phases/milestones as dependencies if needed (without
-     “Spec:” prefix)
+## Process
 
-3. **Update issue status**: Review each spec against actual code/commits.
-   - Use `gh` CLI to check recent commits and PRs if unclear
-   - Update issues with `tbd update <id> --status <status>`
-   - Close completed issues with `tbd close <id> --reason "..."`
+1. **Load the current project state.**
+   - Run `tbd prime`.
+   - Load `tbd guidelines common-doc-guidelines`.
+   - Read `TODO.md`, `docs/project/specs/active/*.md`, and the relevant open or
+     in-progress beads from `tbd list --json`.
+   - Include `docs/project/specs/future/*.md`, `docs/project/specs/done/*.md`, or
+     `docs/project/reviews/*.md` only when the current work moved, completed, deferred,
+     or originated from those documents.
 
-4. **Move completed specs**: Move finished specs from `docs/project/specs/active/` to
-   `docs/project/specs/done/`
+2. **Build a workstream map.**
+   - Group beads under top-level features or epics.
+   - For every active feature, identify exactly one governing active spec unless the
+     work is intentionally future-only or done.
+   - For every active spec, identify the parent bead or epic tracking it.
+   - For every `TODO.md` line, identify the bead and governing spec it points to.
 
-5. **Sync**: Run `tbd sync` to push all changes
+3. **Reconcile beads to reality.**
+   - Check code, docs, commits, PRs, CI, deploy state, or review docs as needed before
+     changing status.
+   - Close completed beads with a concrete reason that names what shipped and how it was
+     validated.
+   - Update partial beads with current notes, blockers, dependencies, and governing spec
+     paths.
+   - Create beads for untracked remaining work under the correct parent epic or spec; do
+     not leave orphan beads.
+   - Do not close or retarget another agent’s in-progress bead unless the user asked for
+     that workstream.
+
+4. **Reconcile plan specs.**
+   - Update each active spec’s status, checklist, milestone table, and validation notes
+     to match the beads and verified state.
+   - Move completed specs from `docs/project/specs/active/` to
+     `docs/project/specs/done/`.
+   - Move deferred or future-only plans to `docs/project/specs/future/`.
+   - Fix every link or bead `spec_path` affected by a move.
+   - Never silently shrink scope.
+     If reality changed the goal, state the scope change in the spec and track any
+     remaining work as beads.
+
+5. **Reconcile `TODO.md`.**
+   - Keep it short: one line per active workstream, grouped by area.
+   - Link to the governing spec and relevant bead or epic instead of duplicating detail.
+   - Remove closed or future-only work from active groups unless it remains a launch
+     blocker.
+   - Update sync metadata, counts, and checkboxes.
+
+6. **Validate consistency.**
+   - Every active top-level workstream appears in `TODO.md` once.
+   - Every `TODO.md` line maps to a real open or in-progress bead and an active spec, or
+     clearly says why no active spec applies.
+   - Every active spec has a matching open or in-progress parent bead.
+   - No done spec remains in `active/`; no future-only work remains in active launch
+     groups.
+   - Search for stale names, old paths, obsolete dependencies, and closed beads still
+     described as active.
+   - Run a Markdown link check for moved or edited docs.
+
+7. **Finish cleanly.**
+   - Format changed Markdown with `flowmark --auto`.
+   - Run `tbd sync`.
+   - Review `git diff` and stage only the files and tbd metadata you changed.
+   - Commit and push when the branch workflow expects it.
+
+## Useful Checks
+
+```bash
+tbd list --json
+tbd list --json | jq -r '.[] | [.id, .status, .title, (.spec_path // "")] | @tsv'
+tbd shortcut update-specs-status
+tbd shortcut --list
+```
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/packages/tbd/docs/shortcuts/standard/update-specs-status.md
+++ b/packages/tbd/docs/shortcuts/standard/update-specs-status.md
@@ -87,7 +87,6 @@ from the top-level work index, the plan specs, and tbd beads.
 ```bash
 tbd list --json
 tbd list --json | jq -r '.[] | [.id, .status, .title, (.spec_path // "")] | @tsv'
-tbd shortcut update-specs-status
 tbd shortcut --list
 ```
 


### PR DESCRIPTION
The bundled `update-specs-status` shortcut only syncs specs → issues. In practice the tracking surfaces drift apart in all directions: beads vs reality (code / CI / deploys), specs vs beads, and the top-level work index vs both. A future agent then trusts whichever surface it reads first.

This rewrites the shortcut as a three-surface reconcile:

- **Sources of truth stated up front**: beads = current status and dependencies; active plan specs = governing plan and checklist; the project's top-level work index (e.g. `TODO.md`, if it keeps one) = brief map.
- **Build a workstream map**: every active spec ↔ parent bead/epic ↔ index line, before changing anything.
- **Reconcile beads to *verified* reality**: check code/commits/PRs/CI/deploy state before status changes; close with concrete reasons naming what shipped and how it was validated; never retarget another agent's in-progress bead.
- **Reconcile specs**: status, checklists, `active/` → `done/` (or `future/`) moves, fix every link and bead `spec_path` a move breaks; never silently shrink scope.
- **Reconcile the index**, then **validate cross-surface consistency** (each surface maps 1:1 onto the others; stale-name sweep; link check).
- **Finish cleanly**: flowmark, `tbd sync`, explicit-path staging.

Context: this is how the shortcut has been run downstream for a while; the bundled version's scope (specs → issues only) kept leaving the other surfaces stale. Extracted via `tbd docs diff --base` / `tbd shortcut suggest-upstream-improvements`, with `TODO.md` generalized to "the project's top-level work index" for upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to a planning shortcut and README; no runtime or CLI behavior changes.
> 
> **Overview**
> The **`update-specs-status`** planning shortcut is expanded from a narrow “active specs ↔ tbd issues” sync into a **three-surface reconcile** (beads, active plan specs, and an optional top-level work index such as `TODO.md`).
> 
> The shortcut doc now names **sources of truth**, has agents **build a workstream map** before edits, **reconcile beads against verified reality** (with rules for closes, orphans, and other agents’ in-progress work), **reconcile specs** (including `active`/`done`/`future` moves and `spec_path`/link fixes without silent scope cuts), **reconcile the index**, **validate cross-surface consistency**, and **finish** with flowmark, `tbd sync`, and explicit staging. README’s shortcuts table description for the same command is updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64a45ac73c865ee42061333993294a41531963e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->