### PR TITLE
docs(shortcuts): doc-fork fixes — correct project-shortcut location, collect local docs

### DIFF
--- a/packages/tbd/docs/shortcuts/standard/new-shortcut.md
+++ b/packages/tbd/docs/shortcuts/standard/new-shortcut.md
@@ -9,7 +9,10 @@ Create a new shortcut for `tbd shortcut <name>`.
 ## Locations
 
 - **Official** (bundled with tbd): `packages/tbd/docs/shortcuts/standard/<name>.md`
-- **Project-level** (custom): `.tbd/docs/shortcuts/standard/<name>.md`
+- **Project-level** (custom): `<fork-dir>/shortcuts/<name>.md` in the repo’s doc-fork
+  directory (default `docs/tbd/`). Keep files flat—subfolders are not scanned.
+  No registration is needed: the file is served and listed immediately; run
+  `tbd setup --auto` to refresh the generated skill directory.
 
 ## Format
 

--- a/packages/tbd/docs/shortcuts/standard/suggest-upstream-improvements.md
+++ b/packages/tbd/docs/shortcuts/standard/suggest-upstream-improvements.md
@@ -22,13 +22,16 @@ Create a to-do list with the following items then perform all of them:
 
 1. **Collect customizations**: Run `tbd docs status --json` and collect every doc in
    `customized` state (including customized docs that also have upstream updates
-   pending).
+   pending) **and every doc in `local` state** (new docs this project wrote that do not
+   exist upstream).
 
-2. **Review each diff**: For each doc, run `tbd docs diff <name> --base` (your file vs
-   its recorded base, exactly what this project changed).
-   Classify each hunk:
+2. **Review each change**: For each `customized` doc, run `tbd docs diff <name> --base`
+   (your file vs its recorded base, exactly what this project changed).
+   For each `local` doc there is no base: review the whole doc.
+   Classify each hunk (or, for local docs, the doc as a whole):
    - **Generally applicable**: fixes, clarifications, better examples, rules any project
      would benefit from. Candidates for upstreaming.
+     A generalizable `local` doc is proposed as a **new bundled doc**.
    - **Project-specific**: team conventions, internal links, stack-specific overrides.
      These stay in the fork; do not propose them.
 
@@ -54,6 +57,8 @@ Create a to-do list with the following items then perform all of them:
    converges and the doc returns to unmodified `forked` state, then a plain
    `tbd docs unfork <name>` (no `--force` needed) completes the cleanup, or keep the
    fork for future edits.
+   For a `local` doc adopted upstream, verify the copies match (`tbd docs diff <name>`)
+   once the bundled version exists; the file then tracks upstream like any other fork.
 
 ## Notes
 

--- a/packages/tbd/docs/shortcuts/standard/suggest-upstream-improvements.md
+++ b/packages/tbd/docs/shortcuts/standard/suggest-upstream-improvements.md
@@ -57,8 +57,12 @@ Create a to-do list with the following items then perform all of them:
    converges and the doc returns to unmodified `forked` state, then a plain
    `tbd docs unfork <name>` (no `--force` needed) completes the cleanup, or keep the
    fork for future edits.
-   For a `local` doc adopted upstream, verify the copies match (`tbd docs diff <name>`)
-   once the bundled version exists; the file then tracks upstream like any other fork.
+   For a `local` doc adopted upstream there is no automatic transition: once the bundled
+   version exists, run `tbd docs fork <name> --force` to convert your copy into a
+   tracked fork (this overwrites the file with the upstream version; `git diff` then
+   shows anything upstream changed relative to your copy).
+   If the copies match, a plain `tbd docs unfork <name>` completes the cleanup, or keep
+   the fork for future edits.
 
 ## Notes
 


### PR DESCRIPTION
Two small fixes to the doc-fork workflow docs, both found by using them:

1. **`new-shortcut` points authors at the wrong location.** It says project-level shortcuts go in `.tbd/docs/shortcuts/standard/` — but that's the gitignored sync cache, so a shortcut authored there is invisible to review and overwritten/lost on `tbd docs sync`. The right place is the repo's doc-fork directory (`<fork-dir>/shortcuts/<name>.md`, default `docs/tbd/`), kept flat, no registration needed.

2. **`suggest-upstream-improvements` skips `local` docs.** Step 1 only collects docs in `customized` state, so brand-new `local` docs — often the strongest upstream candidates, since they're whole new workflows rather than tweaks — are silently omitted. Downstream, the two best candidates for upstreaming (the new PR-review lifecycle shortcuts in #182) were both `local` and would have been missed. Now: step 1 also collects `local` docs, step 2 reviews a local doc as a whole and proposes it as a new bundled doc, and step 6 closes the loop once upstream ships it.

Extracted via `tbd docs diff --base` / `tbd shortcut suggest-upstream-improvements` (dogfooding: fix 2 is the workflow proposing an improvement to itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to meta shortcuts; no runtime or security impact.
> 
> **Overview**
> Fixes two doc-fork workflow gaps in bundled shortcut instructions.
> 
> **`new-shortcut`** now tells authors to put project shortcuts in the repo doc-fork (`<fork-dir>/shortcuts/<name>.md`, default `docs/tbd/`) instead of `.tbd/docs/shortcuts/standard/`. It notes flat layout only, no registration, and `tbd setup --auto` to refresh skills.
> 
> **`suggest-upstream-improvements`** extends the upstreaming workflow to **`local`** docs (new fork-only docs), not just **`customized`** ones. Step 1 collects both; step 2 uses `--base` diffs for customized docs and full-doc review for local docs, treating generalizable locals as **new bundled doc** proposals. Step 6 adds post-merge cleanup for adopted local docs via `tbd docs fork <name> --force` then optional `unfork`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9bae4d396974bbc96e5e70f881a0f71db97a8d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->