### PR TITLE
fix: Retry transient EPERM from mkdir in Windows lock acquisition

### DIFF
--- a/packages/tbd/src/utils/lockfile.ts
+++ b/packages/tbd/src/utils/lockfile.ts
@@ -25,7 +25,9 @@
  *
  * ## Lock lifecycle
  *
- * 1. **Acquire**: `mkdir(lockDir)`; fails with EEXIST if held by another process
+ * 1. **Acquire**: `mkdir(lockDir)`; fails with EEXIST if held by another process.
+ *    On Windows, a concurrent release can instead surface as a transient EPERM
+ *    (NTFS delete-pending directory); this is treated as a busy lock and retried.
  * 2. **Hold**: Execute the critical section
  * 3. **Release**: `rmdir(lockDir)`, in a finally block, with a bounded retry to
  *    absorb transient Windows failures (EBUSY/EPERM from AV scanners or lingering
@@ -199,7 +201,19 @@ export async function withLockfile<T>(
       acquired = true;
       break;
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+      const code = (error as NodeJS.ErrnoException).code;
+
+      // On Windows, mkdir can transiently fail with EPERM instead of EEXIST when
+      // the lock directory is concurrently being removed (NTFS delete-pending
+      // state — the same behavior that leads rimraf/graceful-fs to retry EPERM
+      // there). Treat it as a busy lock and retry; a genuine permission problem
+      // is still bounded by the acquisition deadline.
+      if (code === 'EPERM' && process.platform === 'win32') {
+        await new Promise((resolve) => setTimeout(resolve, pollMs));
+        continue;
+      }
+
+      if (code !== 'EEXIST') {
         // Unexpected error (permissions, disk full, missing parent, etc.):
         // preserve the original failure instead of misreporting lock contention.
         throw error;

--- a/packages/tbd/src/utils/lockfile.ts
+++ b/packages/tbd/src/utils/lockfile.ts
@@ -27,7 +27,9 @@
  *
  * 1. **Acquire**: `mkdir(lockDir)`; fails with EEXIST if held by another process.
  *    On Windows, a concurrent release can instead surface as a transient EPERM
- *    (NTFS delete-pending directory); this is treated as a busy lock and retried.
+ *    (NTFS delete-pending directory); this is treated as a busy lock and retried
+ *    for a short window, after which the raw EPERM is rethrown (a persistent
+ *    EPERM is a genuine permission problem, not the delete-pending race).
  * 2. **Hold**: Execute the critical section
  * 3. **Release**: `rmdir(lockDir)`, in a finally block, with a bounded retry to
  *    absorb transient Windows failures (EBUSY/EPERM from AV scanners or lingering
@@ -108,6 +110,17 @@ export class LockAcquisitionError extends Error {
 
 /** Filesystem error codes that are transient on Windows and worth retrying. */
 const TRANSIENT_RMDIR_CODES = new Set(['EBUSY', 'EPERM', 'EACCES', 'ENOTEMPTY']);
+
+/**
+ * How long consecutive EPERM failures from the acquisition mkdir are retried on
+ * Windows before the error is rethrown. A delete-pending EPERM clears as soon as
+ * the concurrent rmdir completes (milliseconds); an EPERM that persists past this
+ * window is a genuine permission problem and must surface as the raw
+ * ErrnoException — callers translate it into actionable guidance (e.g.
+ * `SharedLockUnwritableError` in withSharedDataSyncLock) rather than letting it
+ * burn the whole acquisition timeout and misreport as lock contention.
+ */
+const WIN32_EPERM_RETRY_WINDOW_MS = 1_000;
 
 /**
  * Remove a lock directory, tolerating transient Windows failures.
@@ -193,6 +206,7 @@ export async function withLockfile<T>(
 
   const deadline = Date.now() + timeoutMs;
   let acquired = false;
+  let epermStreakStart: number | undefined;
 
   while (Date.now() < deadline) {
     try {
@@ -206,12 +220,18 @@ export async function withLockfile<T>(
       // On Windows, mkdir can transiently fail with EPERM instead of EEXIST when
       // the lock directory is concurrently being removed (NTFS delete-pending
       // state — the same behavior that leads rimraf/graceful-fs to retry EPERM
-      // there). Treat it as a busy lock and retry; a genuine permission problem
-      // is still bounded by the acquisition deadline.
+      // there). Treat it as a busy lock and retry, but only for a short window
+      // of consecutive EPERM failures: one that persists is a real permission
+      // problem and must be rethrown raw for callers to translate.
       if (code === 'EPERM' && process.platform === 'win32') {
+        epermStreakStart ??= Date.now();
+        if (Date.now() - epermStreakStart > WIN32_EPERM_RETRY_WINDOW_MS) {
+          throw error;
+        }
         await new Promise((resolve) => setTimeout(resolve, pollMs));
         continue;
       }
+      epermStreakStart = undefined;
 
       if (code !== 'EEXIST') {
         // Unexpected error (permissions, disk full, missing parent, etc.):

--- a/packages/tbd/tests/lockfile-win32-eperm.test.ts
+++ b/packages/tbd/tests/lockfile-win32-eperm.test.ts
@@ -36,6 +36,9 @@ function epermError(path: string): NodeJS.ErrnoException {
     `EPERM: operation not permitted, mkdir '${path}'`,
   ) as NodeJS.ErrnoException;
   error.code = 'EPERM';
+  // Real mkdir ErrnoExceptions carry .path; withSharedDataSyncLock keys its
+  // SharedLockUnwritableError translation on it.
+  error.path = path;
   return error;
 }
 
@@ -100,13 +103,17 @@ describe('withLockfile EPERM handling', () => {
     expect(executed).toBe(false);
   });
 
-  it('bounds persistent EPERM on win32 with LockAcquisitionError at the deadline', async () => {
+  it('rethrows persistent EPERM raw on win32 once the retry window elapses', async () => {
     stubPlatform('win32');
     const lockPath = join(tempDir, 'test.lock');
 
-    // A real permission problem (not delete-pending) never clears.
+    // A real permission problem (not delete-pending) never clears. It must
+    // surface as the raw ErrnoException — with .path intact — well before the
+    // acquisition timeout, so withSharedDataSyncLock can translate it into
+    // SharedLockUnwritableError instead of misreporting lock contention.
     vi.mocked(mkdir).mockRejectedValue(epermError(lockPath));
 
+    const start = Date.now();
     let executed = false;
     await expect(
       withLockfile(
@@ -115,10 +122,32 @@ describe('withLockfile EPERM handling', () => {
           executed = true;
           return Promise.resolve('should-not-run');
         },
-        { timeoutMs: 150, pollMs: 10 },
+        { timeoutMs: 60_000, pollMs: 25 },
       ),
-    ).rejects.toThrow(LockAcquisitionError);
+    ).rejects.toMatchObject({ code: 'EPERM', path: lockPath });
 
+    const elapsed = Date.now() - start;
     expect(executed).toBe(false);
+    // It retried through the window (not fail-fast) but gave up long before
+    // the 60s acquisition timeout.
+    expect(vi.mocked(mkdir).mock.calls.length).toBeGreaterThan(2);
+    expect(elapsed).toBeGreaterThanOrEqual(1000);
+    expect(elapsed).toBeLessThan(10_000);
+  });
+
+  it('bounds EPERM retries with LockAcquisitionError when the deadline is shorter than the window', async () => {
+    stubPlatform('win32');
+    const lockPath = join(tempDir, 'test.lock');
+
+    vi.mocked(mkdir).mockRejectedValue(epermError(lockPath));
+
+    // With timeoutMs below the EPERM retry window, the acquisition deadline
+    // still governs: the loop exits and reports a timeout.
+    await expect(
+      withLockfile(lockPath, () => Promise.resolve('should-not-run'), {
+        timeoutMs: 150,
+        pollMs: 10,
+      }),
+    ).rejects.toThrow(LockAcquisitionError);
   });
 });

--- a/packages/tbd/tests/lockfile-win32-eperm.test.ts
+++ b/packages/tbd/tests/lockfile-win32-eperm.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Windows-specific lockfile acquisition behavior.
+ *
+ * On Windows, mkdir can transiently fail with EPERM (instead of EEXIST) when the
+ * lock directory is concurrently being removed (an NTFS delete-pending directory —
+ * the same behavior that leads rimraf/graceful-fs to retry EPERM there). See
+ * https://github.com/jlevy/tbd/issues/186. withLockfile must treat this as a busy
+ * lock and retry, not throw.
+ *
+ * mkdir is mocked and process.platform is stubbed so both the win32 and non-win32
+ * paths are exercised deterministically on every host platform.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type * as fsPromises from 'node:fs/promises';
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof fsPromises>();
+  return {
+    ...actual,
+    mkdir: vi.fn(actual.mkdir),
+  };
+});
+
+// Import the mocked mkdir to queue failures per test.
+import { mkdir } from 'node:fs/promises';
+
+import { withLockfile, LockAcquisitionError } from '../src/utils/lockfile.js';
+
+function epermError(path: string): NodeJS.ErrnoException {
+  const error = new Error(
+    `EPERM: operation not permitted, mkdir '${path}'`,
+  ) as NodeJS.ErrnoException;
+  error.code = 'EPERM';
+  return error;
+}
+
+function stubPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+}
+
+describe('withLockfile EPERM handling', () => {
+  const realPlatform = process.platform;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    // Restores the real mkdir implementation wrapped by vi.fn above.
+    vi.mocked(mkdir).mockReset();
+    tempDir = await mkdtemp(join(tmpdir(), 'tbd-lockfile-eperm-'));
+  });
+
+  afterEach(async () => {
+    stubPlatform(realPlatform);
+    vi.mocked(mkdir).mockReset();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('retries transient EPERM on win32 and acquires once it clears', async () => {
+    stubPlatform('win32');
+    const lockPath = join(tempDir, 'test.lock');
+
+    // Two delete-pending failures, then the real mkdir succeeds.
+    vi.mocked(mkdir)
+      .mockRejectedValueOnce(epermError(lockPath))
+      .mockRejectedValueOnce(epermError(lockPath));
+
+    const result = await withLockfile(lockPath, () => Promise.resolve('acquired'), {
+      timeoutMs: 5000,
+      pollMs: 5,
+    });
+
+    expect(result).toBe('acquired');
+    expect(vi.mocked(mkdir)).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws EPERM immediately on non-Windows platforms', async () => {
+    stubPlatform('linux');
+    const lockPath = join(tempDir, 'test.lock');
+
+    vi.mocked(mkdir).mockRejectedValue(epermError(lockPath));
+
+    let executed = false;
+    await expect(
+      withLockfile(
+        lockPath,
+        () => {
+          executed = true;
+          return Promise.resolve('should-not-run');
+        },
+        { timeoutMs: 5000, pollMs: 5 },
+      ),
+    ).rejects.toMatchObject({ code: 'EPERM' });
+
+    // A genuine POSIX permission error must fail fast, without retries.
+    expect(vi.mocked(mkdir)).toHaveBeenCalledTimes(1);
+    expect(executed).toBe(false);
+  });
+
+  it('bounds persistent EPERM on win32 with LockAcquisitionError at the deadline', async () => {
+    stubPlatform('win32');
+    const lockPath = join(tempDir, 'test.lock');
+
+    // A real permission problem (not delete-pending) never clears.
+    vi.mocked(mkdir).mockRejectedValue(epermError(lockPath));
+
+    let executed = false;
+    await expect(
+      withLockfile(
+        lockPath,
+        () => {
+          executed = true;
+          return Promise.resolve('should-not-run');
+        },
+        { timeoutMs: 150, pollMs: 10 },
+      ),
+    ).rejects.toThrow(LockAcquisitionError);
+
+    expect(executed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #186 — the flaky `tests/lockfile.test.ts > serializes concurrent access within a single process` failure on windows-latest CI (`EPERM: operation not permitted, mkdir '...\test.lock'`).

`withLockfile` acquires its lock with `mkdir` and expects `EEXIST` when the lock is held. On Windows, `mkdir` can instead fail with a transient `EPERM` when the lock directory is concurrently being removed (an NTFS delete-pending directory — the same long-standing Win32 behavior that leads rimraf/graceful-fs to retry `EPERM` there). The acquisition loop rethrew any non-`EEXIST` error, so the concurrent-access test raced to `EPERM` under CI contention.

## Changes

- `src/utils/lockfile.ts`: in the acquisition loop, treat `EPERM` on `win32` as a busy lock and retry on the normal poll interval. A genuine permission problem is still bounded by the acquisition deadline (`LockAcquisitionError`), and non-Windows platforms still fail fast on `EPERM` (a real POSIX permission error).
- `tests/lockfile-win32-eperm.test.ts`: new tests that mock `fs.mkdir` and stub `process.platform` so both paths are exercised deterministically on every host platform: transient `EPERM` on win32 is retried until acquisition succeeds, persistent `EPERM` on win32 ends in `LockAcquisitionError` at the deadline, and `EPERM` on non-Windows throws immediately with no retries.

## Testing

- `pnpm test`: 1327 tests pass (85 files), including the 3 new tests and the existing lockfile suite.
- `pnpm typecheck`, `pnpm lint:check`, `pnpm format:check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9GENLGBGFWd4PCSt5MDB9

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9GENLGBGFWd4PCSt5MDB9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mutual-exclusion acquisition used across sync/init paths; behavior change is scoped to win32 EPERM with bounded retries and explicit tests.
> 
> **Overview**
> Fixes flaky Windows CI lock contention where concurrent `mkdir` during lock release could throw **EPERM** (NTFS delete-pending) instead of **EEXIST**, causing `withLockfile` to fail immediately.
> 
> On **win32**, acquisition now treats **EPERM** like a busy lock: poll and retry for up to **1s** of consecutive failures, then rethrow the raw `ErrnoException` (with `.path`) so callers such as `withSharedDataSyncLock` can map real permission errors instead of burning the full timeout as `LockAcquisitionError`. Non-Windows **EPERM** still fails fast on the first attempt.
> 
> Adds **`lockfile-win32-eperm.test.ts`** with mocked `mkdir` and stubbed `process.platform` to cover transient win32 retry, persistent win32 EPERM, short-timeout `LockAcquisitionError`, and immediate non-Windows EPERM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 403690b9f5e63f112ea379af3c5c9662282b1c85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->