### PR TITLE
fix: Invoke closing-reminder hook via bash and harden generated script

### DIFF
--- a/.claude/hooks/tbd-closing-reminder.sh
+++ b/.claude/hooks/tbd-closing-reminder.sh
@@ -1,14 +1,23 @@
 #!/bin/bash
 # Remind about close protocol after git push
-# Installed by: tbd setup claude
+# Installed by: tbd setup --auto
 
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // empty')
 
 # Check if this is a git push command and .tbd exists
 if [[ "$command" == git\ push* ]] || [[ "$command" == *"&& git push"* ]] || [[ "$command" == *"; git push"* ]]; then
+  # The hook may start in a subdirectory; check .tbd at the repo root.
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) && cd "$repo_root"
   if [ -d ".tbd" ]; then
-    tbd closing
+    # Same local-first, version-pinned fallback as tbd-session.sh, so the
+    # reminder still fires when tbd is not on the hook's PATH.
+    export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
+    if command -v tbd &> /dev/null; then
+      tbd closing
+    elif command -v npx &> /dev/null; then
+      npx --yes get-tbd@0.3.0 closing
+    fi
   fi
 fi
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/tbd-closing-reminder.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/tbd-closing-reminder.sh"
           }
         ]
       }

--- a/.codex/tbd-closing-reminder.sh
+++ b/.codex/tbd-closing-reminder.sh
@@ -1,14 +1,23 @@
 #!/bin/bash
 # Remind about close protocol after git push
-# Installed by: tbd setup claude
+# Installed by: tbd setup --auto
 
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // empty')
 
 # Check if this is a git push command and .tbd exists
 if [[ "$command" == git\ push* ]] || [[ "$command" == *"&& git push"* ]] || [[ "$command" == *"; git push"* ]]; then
+  # The hook may start in a subdirectory; check .tbd at the repo root.
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) && cd "$repo_root"
   if [ -d ".tbd" ]; then
-    tbd closing
+    # Same local-first, version-pinned fallback as tbd-session.sh, so the
+    # reminder still fires when tbd is not on the hook's PATH.
+    export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
+    if command -v tbd &> /dev/null; then
+      tbd closing
+    elif command -v npx &> /dev/null; then
+      npx --yes get-tbd@0.3.0 closing
+    fi
   fi
 fi
 

--- a/packages/tbd/.claude/hooks/tbd-closing-reminder.sh
+++ b/packages/tbd/.claude/hooks/tbd-closing-reminder.sh
@@ -1,14 +1,23 @@
 #!/bin/bash
 # Remind about close protocol after git push
-# Installed by: tbd setup claude
+# Installed by: tbd setup --auto
 
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // empty')
 
 # Check if this is a git push command and .tbd exists
 if [[ "$command" == git\ push* ]] || [[ "$command" == *"&& git push"* ]] || [[ "$command" == *"; git push"* ]]; then
+  # The hook may start in a subdirectory; check .tbd at the repo root.
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) && cd "$repo_root"
   if [ -d ".tbd" ]; then
-    tbd closing
+    # Same local-first, version-pinned fallback as tbd-session.sh, so the
+    # reminder still fires when tbd is not on the hook's PATH.
+    export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
+    if command -v tbd &> /dev/null; then
+      tbd closing
+    elif command -v npx &> /dev/null; then
+      npx --yes get-tbd@0.3.0 closing
+    fi
   fi
 fi
 

--- a/packages/tbd/.claude/settings.json
+++ b/packages/tbd/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/tbd-closing-reminder.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/tbd-closing-reminder.sh"
           }
         ]
       }

--- a/packages/tbd/src/cli/commands/setup.ts
+++ b/packages/tbd/src/cli/commands/setup.ts
@@ -312,7 +312,9 @@ const CLAUDE_PROJECT_HOOKS = {
         hooks: [
           {
             type: 'command',
-            command: '"$CLAUDE_PROJECT_DIR"/.claude/hooks/tbd-closing-reminder.sh',
+            // Invoke via bash (like every other hook) so the hook still runs
+            // when a checkout drops the script's executable bit.
+            command: 'bash "$CLAUDE_PROJECT_DIR"/.claude/hooks/tbd-closing-reminder.sh',
           },
         ],
       },
@@ -325,15 +327,24 @@ const CLAUDE_PROJECT_HOOKS = {
  */
 const TBD_CLOSE_PROTOCOL_SCRIPT = `#!/bin/bash
 # Remind about close protocol after git push
-# Installed by: tbd setup claude
+# Installed by: tbd setup --auto
 
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // empty')
 
 # Check if this is a git push command and .tbd exists
 if [[ "$command" == git\\ push* ]] || [[ "$command" == *"&& git push"* ]] || [[ "$command" == *"; git push"* ]]; then
+  # The hook may start in a subdirectory; check .tbd at the repo root.
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) && cd "$repo_root"
   if [ -d ".tbd" ]; then
-    tbd closing
+    # Same local-first, version-pinned fallback as tbd-session.sh, so the
+    # reminder still fires when tbd is not on the hook's PATH.
+    export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
+    if command -v tbd &> /dev/null; then
+      tbd closing
+    elif command -v npx &> /dev/null; then
+      npx --yes get-tbd@${PINNED_NPM_VERSION} closing
+    fi
   fi
 fi
 
@@ -803,10 +814,19 @@ class SetupClaudeHandler extends BaseCommand {
         }
       }
 
-      // Merge PostToolUse hooks
+      // Merge PostToolUse hooks. Replace any existing tbd-closing-reminder
+      // entry (rather than skipping when present) so command fixes in the
+      // template propagate to already-configured repos on setup --auto.
       const projectHooks = CLAUDE_PROJECT_HOOKS.hooks as Record<string, unknown[]>;
       for (const [hookType, hookEntries] of Object.entries(projectHooks)) {
-        mergedHooks[hookType] ??= hookEntries;
+        if (mergedHooks[hookType]) {
+          const filtered = (mergedHooks[hookType] as { hooks?: { command?: string }[] }[]).filter(
+            (entry) => !entry.hooks?.some((h) => h.command?.includes('tbd-closing-reminder')),
+          );
+          mergedHooks[hookType] = [...filtered, ...hookEntries];
+        } else {
+          mergedHooks[hookType] = hookEntries;
+        }
       }
 
       settings.hooks = mergedHooks;

--- a/packages/tbd/tests/setup-flows.test.ts
+++ b/packages/tbd/tests/setup-flows.test.ts
@@ -628,6 +628,97 @@ describe('setup flows', { timeout: setupFlowTestTimeout }, () => {
     });
   });
 
+  describe('closing-reminder hook', () => {
+    it('invokes the hook via bash and hardens the generated script', async () => {
+      initGitRepo();
+      const result = runTbd(['setup', '--auto', '--prefix=test']);
+      expect(result.status).toBe(0);
+
+      // The PostToolUse entry must invoke via bash so the hook still runs
+      // when a checkout drops the script's executable bit.
+      const settings = JSON.parse(
+        await readFile(join(tempDir, '.claude', 'settings.json'), 'utf-8'),
+      );
+      const postToolUse = settings.hooks?.PostToolUse ?? [];
+      const commands = postToolUse.flatMap((h: { hooks?: { command?: string }[] }) =>
+        (h.hooks ?? []).map((hook) => hook.command),
+      );
+      expect(commands).toContain(
+        'bash "$CLAUDE_PROJECT_DIR"/.claude/hooks/tbd-closing-reminder.sh',
+      );
+
+      // Both generated scripts resolve the repo root before checking .tbd
+      // (the hook may start in a subdirectory) and fall back to a pinned npx
+      // runner when tbd is not on the hook's PATH.
+      for (const rel of [
+        '.claude/hooks/tbd-closing-reminder.sh',
+        '.codex/tbd-closing-reminder.sh',
+      ]) {
+        const script = await readFile(join(tempDir, rel), 'utf-8');
+        expect(script).toContain('git rev-parse --show-toplevel');
+        expect(script).toMatch(/npx --yes get-tbd@\d+\.\d+\.\d+ closing/);
+      }
+    });
+
+    it('upgrades a stale un-prefixed PostToolUse entry on repeated setup', async () => {
+      initGitRepo();
+
+      // Simulate a repo configured by an older tbd: direct-exec command plus a
+      // user-authored PostToolUse hook that must survive the upgrade.
+      const settingsDir = join(tempDir, '.claude');
+      await mkdir(settingsDir, { recursive: true });
+      await writeFile(
+        join(settingsDir, 'settings.json'),
+        JSON.stringify(
+          {
+            hooks: {
+              PostToolUse: [
+                {
+                  matcher: 'Bash',
+                  hooks: [
+                    {
+                      type: 'command',
+                      command: '"$CLAUDE_PROJECT_DIR"/.claude/hooks/tbd-closing-reminder.sh',
+                    },
+                  ],
+                },
+                {
+                  matcher: 'Bash',
+                  hooks: [{ type: 'command', command: 'echo custom-post-hook' }],
+                },
+              ],
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const result = runTbd(['setup', '--auto', '--prefix=test']);
+      expect(result.status).toBe(0);
+
+      const settings = JSON.parse(await readFile(join(settingsDir, 'settings.json'), 'utf-8'));
+      const postToolUse = settings.hooks?.PostToolUse ?? [];
+      const reminderCommands = postToolUse
+        .flatMap((h: { hooks?: { command?: string }[] }) =>
+          (h.hooks ?? []).map((hook) => hook.command),
+        )
+        .filter((c: string | undefined) => c?.includes('tbd-closing-reminder'));
+
+      // Exactly one entry, upgraded to the bash-prefixed command.
+      expect(reminderCommands).toEqual([
+        'bash "$CLAUDE_PROJECT_DIR"/.claude/hooks/tbd-closing-reminder.sh',
+      ]);
+
+      // The user's own PostToolUse hook is preserved.
+      expect(
+        postToolUse.some((h: { hooks?: { command?: string }[] }) =>
+          h.hooks?.some((hook) => hook.command === 'echo custom-post-hook'),
+        ),
+      ).toBe(true);
+    });
+  });
+
   describe('gh CLI setup', () => {
     it('installs ensure-gh-cli.sh script and SessionStart hook by default', async () => {
       initGitRepo();


### PR DESCRIPTION
## Summary

Bugbot review of a repo freshly configured by `tbd setup --auto` ([jlevy/skills-research#1](https://github.com/jlevy/skills-research/pull/1), fixed downstream in [8de07e0](https://github.com/jlevy/skills-research/commit/8de07e0a3d9a9419f8625937f48877f11576db9e)) surfaced defects that originate in tbd's hook templates, so every consumer repo gets them. This PR fixes the templates in `setup.ts`, makes `tbd setup --auto` upgrade already-configured repos, and regenerates this repo's own dogfooded hook files.

## Changes

- **Invoke the Claude PostToolUse hook via `bash`** (`CLAUDE_PROJECT_HOOKS`): the entry exec'd the script directly, so the hook silently broke when a checkout dropped the executable bit (`core.filemode=false`, archive checkouts). Every other generated hook (SessionStart, PreCompact, gh-cli, all Codex hooks) already invokes via `bash`.
- **Resolve the repo root before the `.tbd` check** (`TBD_CLOSE_PROTOCOL_SCRIPT`, shared by the `.claude` and `.codex` copies): the script checked `[ -d ".tbd" ]` in the hook's cwd, so the closing reminder never fired when the session started in a subdirectory. Now runs `git rev-parse --show-toplevel` and `cd`s there first.
- **Add the local-first, version-pinned fallback to the closing script**: it called bare `tbd closing`, which silently no-ops when tbd isn't on the hook's PATH. Now uses the same PATH setup and pinned `npx --yes get-tbd@<PINNED_NPM_VERSION>` fallback as `tbd-session.sh`.
- **Migrate existing installs**: the PostToolUse settings merge used `??=` (add only when absent), so already-configured repos would have kept the broken command forever. Setup now replaces any existing `tbd-closing-reminder` entry with the current template while preserving user-authored PostToolUse hooks (the hook *script* was already rewritten unconditionally, so script fixes self-propagate).
- **Regenerated dogfooded files** in this repo from the new templates: `.claude/settings.json`, `.claude/hooks/tbd-closing-reminder.sh`, `.codex/tbd-closing-reminder.sh`, and the nested `packages/tbd/.claude/` copies.

## Test Plan

- [x] New tests in `setup-flows.test.ts` (verified red against the pre-fix build, green after):
  - fresh `setup --auto` emits the `bash`-prefixed PostToolUse command, and both generated closing-reminder scripts contain the repo-root resolution and the pinned `npx get-tbd@<semver> closing` fallback
  - re-running `setup --auto` on a repo with the old un-prefixed entry upgrades it to exactly one `bash`-prefixed entry while preserving a user-authored PostToolUse hook
- [x] Full suite passes: 1330 tests / 85 files (`pnpm test`)
- [x] `pnpm build`, `pnpm typecheck`, `pnpm lint:check`, prettier clean on changed files
- [x] Manual: ran `node packages/tbd/dist/bin.mjs setup --auto` in this repo; the regenerated hook files in this PR are its verbatim output (incidental SKILL.md/`config.yml` churn excluded)
- [ ] Edge cases considered: user PostToolUse hooks are preserved by the new merge (covered by test); Codex `hooks.json` already replaced tbd-owned entries per-run, so it needed no merge change; `PINNED_NPM_VERSION` is always a clean semver (never a git-describe dev string), so generated files don't churn

## Related Beads

- tbd-zuk9 (closed): Harden generated closing-reminder hooks: bash invocation, repo-root cwd, pinned fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgL6hpU6ekeZzZfLjcV4Dq

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgL6hpU6ekeZzZfLjcV4Dq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to hook templates, settings merge logic, and tests; behavior is more reliable with no auth or data-path impact.
> 
> **Overview**
> Fixes **git push** closing reminders that often never ran in repos created by `tbd setup --auto`.
> 
> **Claude PostToolUse** now runs `tbd-closing-reminder.sh` through **`bash`** (matching other hooks) so a missing executable bit does not silently skip the hook. The generated **`.claude` and `.codex` closing scripts** `cd` to the git root before checking `.tbd`, and call **`tbd closing`** with the same PATH + pinned **`npx get-tbd@…`** fallback as `tbd-session.sh`.
> 
> **`setup --auto`** replaces existing `tbd-closing-reminder` PostToolUse entries instead of leaving stale direct-exec commands, while keeping user-authored hooks. Dogfooded hook files are regenerated; **`setup-flows.test.ts`** covers fresh install and upgrade paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8540b9b81e8c2b4720ad233e1e9bb97cc122c2e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->