### PR TITLE
docs: proxied remote-session guidance for gh CLI setup (validated in Claude Code cloud)

### DIFF
--- a/.claude/scripts/ensure-gh-cli.sh
+++ b/.claude/scripts/ensure-gh-cli.sh
@@ -17,6 +17,27 @@ export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
 # Pinned gh release (>=14 days old per supply-chain cool-off) and its checksums.
 GH_VERSION="2.92.0"
 
+# GitHub hosts to exempt from a session HTTPS proxy when that proxy intercepts
+# GitHub (proxied remote sessions, e.g. Claude Code cloud). Scoped and additive:
+# HTTPS_PROXY stays set for all other traffic. release-assets.githubusercontent.com
+# is the current release-binary host; objects.githubusercontent.com is its
+# predecessor and kept for compatibility.
+GITHUB_DIRECT_HOSTS="api.github.com,github.com,release-assets.githubusercontent.com,objects.githubusercontent.com,codeload.github.com,raw.githubusercontent.com,uploads.github.com"
+
+github_no_proxy() {
+    echo "${GITHUB_DIRECT_HOSTS}${NO_PROXY:+,$NO_PROXY}"
+}
+
+# Direct-egress probes can hang when the network policy blocks direct
+# connections; bound them where timeout(1) exists (absent on stock macOS).
+run_bounded() {
+    if command -v timeout &> /dev/null; then
+        timeout 20 "$@"
+    else
+        "$@"
+    fi
+}
+
 # SHA-256 checksums from gh_2.92.0_checksums.txt, keyed by asset suffix.
 checksum_for() {
     case "$1" in
@@ -64,7 +85,14 @@ else
     DOWNLOAD_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${ASSET}"
 
     echo "[gh] Downloading from ${DOWNLOAD_URL}..."
-    curl -fsSL -o "/tmp/${ASSET}" "$DOWNLOAD_URL"
+    if ! curl -fsSL -o "/tmp/${ASSET}" "$DOWNLOAD_URL"; then
+        # Proxied remote sessions can intercept GitHub downloads with a proxy 403.
+        # Retry once bypassing the proxy for GitHub hosts only; this succeeds when
+        # the environment's egress policy allows direct GitHub connections.
+        echo "[gh] Download failed (a session proxy may intercept GitHub); retrying with NO_PROXY for GitHub hosts..."
+        NP="$(github_no_proxy)"
+        NO_PROXY="$NP" no_proxy="$NP" curl -fsSL --connect-timeout 15 -o "/tmp/${ASSET}" "$DOWNLOAD_URL"
+    fi
 
     # Verify the download against the pinned checksum before extracting.
     if command -v sha256sum &> /dev/null; then
@@ -112,12 +140,32 @@ if [ -n "${GH_TOKEN:-}" ]; then
     if gh auth status &> /dev/null; then
         echo "[gh] Authenticated successfully"
     else
-        echo "[gh] WARNING: GH_TOKEN is set but authentication check failed"
-        echo "[gh] Token may be invalid or expired"
+        # A failed check does NOT prove the token is bad. In proxied remote
+        # sessions (HTTPS_PROXY set, e.g. Claude Code cloud) the proxy can
+        # intercept api.github.com, block the GraphQL query behind
+        # `gh auth status`, and even swap Authorization headers — gh then
+        # misreports a perfectly valid token as invalid. Retest on the direct
+        # channel (proxy bypassed for GitHub hosts only) before concluding.
+        NP="$(github_no_proxy)"
+        if [ -n "${HTTPS_PROXY:-}${https_proxy:-}" ] \
+            && NO_PROXY="$NP" no_proxy="$NP" run_bounded gh auth status &> /dev/null; then
+            echo "[gh] GH_TOKEN is VALID, but this session's proxy intercepts GitHub API calls"
+            echo "[gh] ('gh auth status' fails through the proxy and misreports the token as invalid)."
+            echo "[gh] To use gh in this session, bypass the proxy for GitHub hosts only"
+            echo "[gh] (keep HTTPS_PROXY set; never disable TLS verification):"
+            echo '[gh]   export NO_PROXY="'"${GITHUB_DIRECT_HOSTS}"'${NO_PROXY:+,$NO_PROXY}"'
+            echo '[gh]   export no_proxy="$NO_PROXY"'
+            echo "[gh] Details: tbd shortcut setup-github-cli (Proxied Remote Sessions)"
+        else
+            echo "[gh] WARNING: GH_TOKEN is set but could not be verified on any channel"
+            echo "[gh] Either the token is invalid/expired, or this session's network policy"
+            echo "[gh] blocks GitHub API access (git push and GitHub MCP tools may still work)."
+            echo "[gh] Diagnosis: tbd shortcut setup-github-cli (Proxied Remote Sessions)"
+        fi
     fi
 else
     echo "[gh] NOTE: GH_TOKEN not set - some operations may require authentication"
-    echo "[gh] See: docs/general/agent-setup/github-cli-setup.md"
+    echo "[gh] See: tbd shortcut setup-github-cli"
 fi
 
 exit 0

--- a/.codex/ensure-gh-cli.sh
+++ b/.codex/ensure-gh-cli.sh
@@ -17,6 +17,27 @@ export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
 # Pinned gh release (>=14 days old per supply-chain cool-off) and its checksums.
 GH_VERSION="2.92.0"
 
+# GitHub hosts to exempt from a session HTTPS proxy when that proxy intercepts
+# GitHub (proxied remote sessions, e.g. Claude Code cloud). Scoped and additive:
+# HTTPS_PROXY stays set for all other traffic. release-assets.githubusercontent.com
+# is the current release-binary host; objects.githubusercontent.com is its
+# predecessor and kept for compatibility.
+GITHUB_DIRECT_HOSTS="api.github.com,github.com,release-assets.githubusercontent.com,objects.githubusercontent.com,codeload.github.com,raw.githubusercontent.com,uploads.github.com"
+
+github_no_proxy() {
+    echo "${GITHUB_DIRECT_HOSTS}${NO_PROXY:+,$NO_PROXY}"
+}
+
+# Direct-egress probes can hang when the network policy blocks direct
+# connections; bound them where timeout(1) exists (absent on stock macOS).
+run_bounded() {
+    if command -v timeout &> /dev/null; then
+        timeout 20 "$@"
+    else
+        "$@"
+    fi
+}
+
 # SHA-256 checksums from gh_2.92.0_checksums.txt, keyed by asset suffix.
 checksum_for() {
     case "$1" in
@@ -64,7 +85,14 @@ else
     DOWNLOAD_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${ASSET}"
 
     echo "[gh] Downloading from ${DOWNLOAD_URL}..."
-    curl -fsSL -o "/tmp/${ASSET}" "$DOWNLOAD_URL"
+    if ! curl -fsSL -o "/tmp/${ASSET}" "$DOWNLOAD_URL"; then
+        # Proxied remote sessions can intercept GitHub downloads with a proxy 403.
+        # Retry once bypassing the proxy for GitHub hosts only; this succeeds when
+        # the environment's egress policy allows direct GitHub connections.
+        echo "[gh] Download failed (a session proxy may intercept GitHub); retrying with NO_PROXY for GitHub hosts..."
+        NP="$(github_no_proxy)"
+        NO_PROXY="$NP" no_proxy="$NP" curl -fsSL --connect-timeout 15 -o "/tmp/${ASSET}" "$DOWNLOAD_URL"
+    fi
 
     # Verify the download against the pinned checksum before extracting.
     if command -v sha256sum &> /dev/null; then
@@ -112,12 +140,32 @@ if [ -n "${GH_TOKEN:-}" ]; then
     if gh auth status &> /dev/null; then
         echo "[gh] Authenticated successfully"
     else
-        echo "[gh] WARNING: GH_TOKEN is set but authentication check failed"
-        echo "[gh] Token may be invalid or expired"
+        # A failed check does NOT prove the token is bad. In proxied remote
+        # sessions (HTTPS_PROXY set, e.g. Claude Code cloud) the proxy can
+        # intercept api.github.com, block the GraphQL query behind
+        # `gh auth status`, and even swap Authorization headers — gh then
+        # misreports a perfectly valid token as invalid. Retest on the direct
+        # channel (proxy bypassed for GitHub hosts only) before concluding.
+        NP="$(github_no_proxy)"
+        if [ -n "${HTTPS_PROXY:-}${https_proxy:-}" ] \
+            && NO_PROXY="$NP" no_proxy="$NP" run_bounded gh auth status &> /dev/null; then
+            echo "[gh] GH_TOKEN is VALID, but this session's proxy intercepts GitHub API calls"
+            echo "[gh] ('gh auth status' fails through the proxy and misreports the token as invalid)."
+            echo "[gh] To use gh in this session, bypass the proxy for GitHub hosts only"
+            echo "[gh] (keep HTTPS_PROXY set; never disable TLS verification):"
+            echo '[gh]   export NO_PROXY="'"${GITHUB_DIRECT_HOSTS}"'${NO_PROXY:+,$NO_PROXY}"'
+            echo '[gh]   export no_proxy="$NO_PROXY"'
+            echo "[gh] Details: tbd shortcut setup-github-cli (Proxied Remote Sessions)"
+        else
+            echo "[gh] WARNING: GH_TOKEN is set but could not be verified on any channel"
+            echo "[gh] Either the token is invalid/expired, or this session's network policy"
+            echo "[gh] blocks GitHub API access (git push and GitHub MCP tools may still work)."
+            echo "[gh] Diagnosis: tbd shortcut setup-github-cli (Proxied Remote Sessions)"
+        fi
     fi
 else
     echo "[gh] NOTE: GH_TOKEN not set - some operations may require authentication"
-    echo "[gh] See: docs/general/agent-setup/github-cli-setup.md"
+    echo "[gh] See: tbd shortcut setup-github-cli"
 fi
 
 exit 0

--- a/packages/tbd/docs/install/ensure-gh-cli.sh
+++ b/packages/tbd/docs/install/ensure-gh-cli.sh
@@ -17,6 +17,27 @@ export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
 # Pinned gh release (>=14 days old per supply-chain cool-off) and its checksums.
 GH_VERSION="2.92.0"
 
+# GitHub hosts to exempt from a session HTTPS proxy when that proxy intercepts
+# GitHub (proxied remote sessions, e.g. Claude Code cloud). Scoped and additive:
+# HTTPS_PROXY stays set for all other traffic. release-assets.githubusercontent.com
+# is the current release-binary host; objects.githubusercontent.com is its
+# predecessor and kept for compatibility.
+GITHUB_DIRECT_HOSTS="api.github.com,github.com,release-assets.githubusercontent.com,objects.githubusercontent.com,codeload.github.com,raw.githubusercontent.com,uploads.github.com"
+
+github_no_proxy() {
+    echo "${GITHUB_DIRECT_HOSTS}${NO_PROXY:+,$NO_PROXY}"
+}
+
+# Direct-egress probes can hang when the network policy blocks direct
+# connections; bound them where timeout(1) exists (absent on stock macOS).
+run_bounded() {
+    if command -v timeout &> /dev/null; then
+        timeout 20 "$@"
+    else
+        "$@"
+    fi
+}
+
 # SHA-256 checksums from gh_2.92.0_checksums.txt, keyed by asset suffix.
 checksum_for() {
     case "$1" in
@@ -64,7 +85,14 @@ else
     DOWNLOAD_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${ASSET}"
 
     echo "[gh] Downloading from ${DOWNLOAD_URL}..."
-    curl -fsSL -o "/tmp/${ASSET}" "$DOWNLOAD_URL"
+    if ! curl -fsSL -o "/tmp/${ASSET}" "$DOWNLOAD_URL"; then
+        # Proxied remote sessions can intercept GitHub downloads with a proxy 403.
+        # Retry once bypassing the proxy for GitHub hosts only; this succeeds when
+        # the environment's egress policy allows direct GitHub connections.
+        echo "[gh] Download failed (a session proxy may intercept GitHub); retrying with NO_PROXY for GitHub hosts..."
+        NP="$(github_no_proxy)"
+        NO_PROXY="$NP" no_proxy="$NP" curl -fsSL --connect-timeout 15 -o "/tmp/${ASSET}" "$DOWNLOAD_URL"
+    fi
 
     # Verify the download against the pinned checksum before extracting.
     if command -v sha256sum &> /dev/null; then
@@ -112,12 +140,32 @@ if [ -n "${GH_TOKEN:-}" ]; then
     if gh auth status &> /dev/null; then
         echo "[gh] Authenticated successfully"
     else
-        echo "[gh] WARNING: GH_TOKEN is set but authentication check failed"
-        echo "[gh] Token may be invalid or expired"
+        # A failed check does NOT prove the token is bad. In proxied remote
+        # sessions (HTTPS_PROXY set, e.g. Claude Code cloud) the proxy can
+        # intercept api.github.com, block the GraphQL query behind
+        # `gh auth status`, and even swap Authorization headers — gh then
+        # misreports a perfectly valid token as invalid. Retest on the direct
+        # channel (proxy bypassed for GitHub hosts only) before concluding.
+        NP="$(github_no_proxy)"
+        if [ -n "${HTTPS_PROXY:-}${https_proxy:-}" ] \
+            && NO_PROXY="$NP" no_proxy="$NP" run_bounded gh auth status &> /dev/null; then
+            echo "[gh] GH_TOKEN is VALID, but this session's proxy intercepts GitHub API calls"
+            echo "[gh] ('gh auth status' fails through the proxy and misreports the token as invalid)."
+            echo "[gh] To use gh in this session, bypass the proxy for GitHub hosts only"
+            echo "[gh] (keep HTTPS_PROXY set; never disable TLS verification):"
+            echo '[gh]   export NO_PROXY="'"${GITHUB_DIRECT_HOSTS}"'${NO_PROXY:+,$NO_PROXY}"'
+            echo '[gh]   export no_proxy="$NO_PROXY"'
+            echo "[gh] Details: tbd shortcut setup-github-cli (Proxied Remote Sessions)"
+        else
+            echo "[gh] WARNING: GH_TOKEN is set but could not be verified on any channel"
+            echo "[gh] Either the token is invalid/expired, or this session's network policy"
+            echo "[gh] blocks GitHub API access (git push and GitHub MCP tools may still work)."
+            echo "[gh] Diagnosis: tbd shortcut setup-github-cli (Proxied Remote Sessions)"
+        fi
     fi
 else
     echo "[gh] NOTE: GH_TOKEN not set - some operations may require authentication"
-    echo "[gh] See: docs/general/agent-setup/github-cli-setup.md"
+    echo "[gh] See: tbd shortcut setup-github-cli"
 fi
 
 exit 0

--- a/packages/tbd/docs/shortcuts/standard/setup-github-cli.md
+++ b/packages/tbd/docs/shortcuts/standard/setup-github-cli.md
@@ -88,9 +88,19 @@ the others.
 1. **git fetch/push through a local credential broker.** The origin remote is rewritten
    to a local endpoint (e.g. `http://local_proxy@127.0.0.1:<port>/git/owner/repo`) that
    injects its own credentials.
-   This channel works regardless of `GH_TOKEN`. Its credentials may be scoped: in some
-   sessions, pushes of tags or of unexpected refs are refused even though branch pushes
-   work.
+   This channel works regardless of `GH_TOKEN`, but it is ref-scoped (verified in a
+   Claude Code Cloud session):
+   - Pushes to `refs/heads/*` (any branch name) succeed.
+   - Pushes to `refs/tags/*` are refused with HTTP 403 at receive-pack.
+   - **`git push --dry-run` passes for refs the broker later refuses** (dry-run stops at
+     ref advertisement, before receive-pack), so a clean dry-run proves nothing.
+   - Ref deletions can silently no-op: the push reports “Everything up-to-date” while
+     the remote ref persists.
+     Always confirm deletions with `git ls-remote`.
+   - Remedy for all of these: do the ref operation on the direct channel instead, e.g.
+     `gh api repos/{owner}/{repo}/git/refs -f ref=refs/tags/NAME -f sha=SHA` to create a
+     tag and `gh api -X DELETE repos/{owner}/{repo}/git/refs/tags/NAME` to delete one
+     (both verified).
 
 2. **Proxied HTTPS to `api.github.com`.** The proxy may intercept GitHub and answer with
    its own 403s. Two intercept behaviors verified in Claude Code Cloud sessions:
@@ -123,8 +133,9 @@ gh auth status    # now tests your real token against real GitHub
 ```
 
 This recipe was verified end to end in an egress-enabled Claude Code Cloud session:
-`gh auth status`, `gh pr list`, `gh release list`, and the pinned-checksum binary
-download all succeed on the direct channel while the proxied channel 403s each of them.
+`gh auth status`, `gh pr list`, `gh release list`, tag creation and deletion via
+`gh api .../git/refs`, and the pinned-checksum binary download all succeed on the direct
+channel while the git broker or proxied channel refuses each of them.
 (`release-assets.githubusercontent.com` is the current release-download host;
 `objects.githubusercontent.com` is its predecessor, kept for compatibility.)
 
@@ -155,6 +166,8 @@ report the limitation — do not attempt to tunnel around network policy.
 | `Bad credentials` | Token expired or lacks permissions |
 | `Resource not accessible` | Token lacks required scopes (need repo, workflow) |
 | 403 with no `x-github-request-id` header | Proxy-manufactured response, not GitHub — see Proxied Remote Sessions |
+| Tag push 403s but branch push works | Session git broker blocks `refs/tags` — create the tag on the direct channel via `gh api .../git/refs` |
+| Ref delete reports “Everything up-to-date” but ref persists | Broker silently drops deletions — delete via `gh api -X DELETE .../git/refs/...` and confirm with `git ls-remote` |
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/packages/tbd/docs/shortcuts/standard/setup-github-cli.md
+++ b/packages/tbd/docs/shortcuts/standard/setup-github-cli.md
@@ -22,7 +22,9 @@ gh auth status
 
 **Expected output:** Shows “Logged in to github.com” with your account.
 
-If this fails for any reason, follow the steps below.
+If this fails, follow the steps below — but in a remote or cloud session where
+`HTTPS_PROXY` is set, do not take the failure message at face value.
+See [Proxied Remote Sessions](#proxied-remote-sessions) first.
 
 ## Corner Cases You May Encounter
 
@@ -38,6 +40,11 @@ If this fails for any reason, follow the steps below.
 4. **PATH issues**: gh installed but not in PATH
    - Solution: Ensure `~/.local/bin` is in PATH, or use full path
 
+5. **`gh auth status` says “The token in GH_TOKEN is invalid” in a proxied remote
+   session** (Claude Code Cloud and similar): the verdict may be manufactured by the
+   session’s proxy, not by GitHub — the token is often perfectly valid.
+   - Solution: See [Proxied Remote Sessions](#proxied-remote-sessions)
+
 ## Installation
 
 1. **Run the ensure script:**
@@ -45,6 +52,8 @@ If this fails for any reason, follow the steps below.
    bash .claude/scripts/ensure-gh-cli.sh
    ```
    This script installs gh to `~/.local/bin` and checks authentication.
+   If a session proxy blocks the download, it retries with a scoped `NO_PROXY` bypass
+   automatically.
 
 2. **If the script doesn’t exist:** Run `tbd setup --auto` to reinstall tbd hooks, which
    includes the gh CLI script.
@@ -69,15 +78,83 @@ Create a [Personal Access Token](https://github.com/settings/tokens?type=beta)
 permissions, then export it (e.g. add `export GH_TOKEN=...` to your shell profile or set
 it in your agent environment).
 
+## Proxied Remote Sessions
+
+Remote agent sessions (Claude Code Cloud and similar) usually route outbound HTTPS
+through a policy proxy (`HTTPS_PROXY`). In such sessions “GitHub access” is not one
+thing: it is several independent channels, and a failure on one says **nothing** about
+the others.
+
+1. **git fetch/push through a local credential broker.** The origin remote is rewritten
+   to a local endpoint (e.g. `http://local_proxy@127.0.0.1:<port>/git/owner/repo`) that
+   injects its own credentials.
+   This channel works regardless of `GH_TOKEN`. Its credentials may be scoped: in some
+   sessions, pushes of tags or of unexpected refs are refused even though branch pushes
+   work.
+
+2. **Proxied HTTPS to `api.github.com`.** The proxy may intercept GitHub and answer with
+   its own 403s. Two intercept behaviors verified in Claude Code Cloud sessions:
+   - *Path shaping*: only some REST paths pass through, and GraphQL may be limited to a
+     pinned set of operations.
+     `gh auth status` performs a GraphQL `viewer` query, so it can fail here — and gh
+     then reports “The token in GH_TOKEN is invalid” **even when the token is valid**.
+   - *Credential substitution*: the proxy replaces your `Authorization` header with its
+     own session credential.
+     Nothing observed through this channel tests *your* token: a bogus token can appear
+     to work, and a valid one can appear invalid.
+
+3. **GitHub MCP tools** (when the session provides them): a separate server-side
+   channel, scoped to the session’s configured repositories.
+
+4. **Direct egress, honoring `NO_PROXY`.** Governed by the environment’s network policy.
+   When the environment allows GitHub egress, this channel carries your real `GH_TOKEN`
+   untouched — and `gh` honors `NO_PROXY` natively, so no raw API calls are needed.
+
+### Verified recipe
+
+If `gh auth status` fails and `HTTPS_PROXY` is set, bypass the proxy **for GitHub hosts
+only**. Keep `HTTPS_PROXY` exported for all other traffic, and never disable TLS
+verification:
+
+```bash
+export NO_PROXY="api.github.com,github.com,release-assets.githubusercontent.com,objects.githubusercontent.com,codeload.github.com,raw.githubusercontent.com,uploads.github.com${NO_PROXY:+,$NO_PROXY}"
+export no_proxy="$NO_PROXY"
+gh auth status    # now tests your real token against real GitHub
+```
+
+This recipe was verified end to end in an egress-enabled Claude Code Cloud session:
+`gh auth status`, `gh pr list`, `gh release list`, and the pinned-checksum binary
+download all succeed on the direct channel while the proxied channel 403s each of them.
+(`release-assets.githubusercontent.com` is the current release-download host;
+`objects.githubusercontent.com` is its predecessor, kept for compatibility.)
+
+If direct connections **time out** instead, the environment’s network policy blocks
+GitHub egress. Stop there: use the git broker and MCP channels for what they can do, and
+report the limitation — do not attempt to tunnel around network policy.
+
+### Diagnosing 403s
+
+- **Read the body and headers.** A real GitHub response carries an `x-github-request-id`
+  header. Proxy-manufactured responses carry the proxy’s own message (often with the
+  provider’s `documentation_url`) and no GitHub request id.
+- **Retest across channels** — with and without the `NO_PROXY` exports — before drawing
+  conclusions. The same URL can 403 on one channel and succeed on another.
+- **Never conclude from an unauthenticated probe.** Unauthenticated calls from shared
+  cloud egress IPs can be rate-limited by GitHub itself, which mimics a policy block.
+- **Distrust secondhand verdicts.** “Token invalid” from `gh auth status` in a proxied
+  session is a channel symptom until proven on the direct channel.
+
 ## Quick Reference
 
 | Problem | Solution |
 | --- | --- |
 | `gh: command not found` | Run ensure script or add ~/.local/bin to PATH |
 | `gh --version` fails | gh is broken, reinstall via ensure script |
-| `gh auth status` shows errors | GH_TOKEN not set or invalid |
+| `gh auth status` errors and `HTTPS_PROXY` is set | Proxied session: apply the NO_PROXY recipe above before trusting the error |
+| `gh auth status` shows errors (no proxy) | GH_TOKEN not set or invalid |
 | `Bad credentials` | Token expired or lacks permissions |
 | `Resource not accessible` | Token lacks required scopes (need repo, workflow) |
+| 403 with no `x-github-request-id` header | Proxy-manufactured response, not GitHub — see Proxied Remote Sessions |
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.


### PR DESCRIPTION
Implements #193 after validating every claim empirically in a live Claude Code cloud session (egress-enabled environment). Closes #193.

## What changed

**`setup-github-cli.md` shortcut** — new "Proxied Remote Sessions" section:
- The four-channel model: git credential broker, proxied HTTPS, GitHub MCP tools, and direct egress via `NO_PROXY`. A failure on one channel says nothing about the others.
- The verified `NO_PROXY` recipe (scoped and additive; `HTTPS_PROXY` stays set, TLS verification stays on), with `release-assets.githubusercontent.com` added — the current release-asset host, which the issue's proposed list predates.
- 403-diagnosis discipline: real GitHub responses carry `x-github-request-id`; proxy-manufactured ones carry the provider's `documentation_url` and no request id.
- Explicit stop condition: if direct connections time out, the network policy blocks GitHub — use broker + MCP and report; don't tunnel around policy.

**`ensure-gh-cli.sh`** (bundled template + installed `.claude/scripts/` and `.codex/` copies, kept identical):
- The pinned, checksum-verified download retries once with the scoped `NO_PROXY` bypass when the proxied fetch 403s.
- On auth-check failure, retests on the direct channel and reports accurately: "GH_TOKEN is VALID, but this session's proxy intercepts GitHub API calls" (with copy-pasteable exports) instead of the old, misleading "Token may be invalid or expired".
- Fixes a dangling doc pointer (`docs/general/agent-setup/github-cli-setup.md` doesn't exist).

## Validation results (all live-tested in this session)

Confirmed from the issue:
- The relay intercepts `api.github.com` and manufactures 403s, including the verbatim "GitHub access is not enabled for this session" message.
- The gh binary download 403s through the proxy; the new fallback path was exercised end to end in a sandboxed `$HOME` (403 → `NO_PROXY` retry → checksum match → install).
- The `NO_PROXY` recipe restores full gh function: `gh auth status`, `gh pr list`, `gh release list`, tag create/delete via `gh api .../git/refs`.
- Tag pushes through the git broker are refused (HTTP 403 at receive-pack) — confirmed with a real push, after a `--dry-run` had *passed*. The doc now warns that a clean dry-run proves nothing (dry-run stops at ref advertisement).

Root-caused beyond the issue:
- `gh auth status` fails because its GraphQL `viewer` query is blocked by the relay ("only the pinned set of PR-review operations is served"), and gh translates that 403 into "The token in GH_TOKEN is invalid" — a false verdict for a valid token.
- The relay substitutes `Authorization` headers on the proxied channel (a deliberately bogus token returned the same 200 as the real one), so nothing observed through the proxy tests the configured token.
- The broker is ref-type-scoped, not branch-scoped: `refs/heads/*` pushes succeed for any branch name; `refs/tags/*` is refused; ref deletions silently no-op ("Everything up-to-date" while the ref persists).

Not observable from this session (documented as such): locked-egress behavior (connect timeouts) is described from reasoning, not observation. All temporary test refs were deleted and confirmed gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKGmc1HTnVTgMRrZi6GehH

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKGmc1HTnVTgMRrZi6GehH)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to agent setup scripts and documentation; pinned checksum verification on downloads is unchanged on the retry path.
> 
> **Overview**
> **Proxied remote sessions** (e.g. Claude Code Cloud with `HTTPS_PROXY`) often make `gh auth status` and GitHub downloads fail even when `GH_TOKEN` is valid. This PR documents that multi-channel model and hardens the shared **`ensure-gh-cli.sh`** copies (`.claude/scripts/`, `.codex/`, `packages/tbd/docs/install/`).
> 
> The ensure script now defines a scoped **`NO_PROXY`** list for GitHub hosts (including `release-assets.githubusercontent.com`), **retries pinned-checksum downloads** through that bypass after a proxied failure, and on auth failure **re-runs `gh auth status` on the direct channel** (with optional `timeout`) so it can report “token valid but proxy intercepts” plus copy-pasteable exports instead of blaming an expired token. Help text points at **`tbd shortcut setup-github-cli`** instead of a missing doc path.
> 
> **`setup-github-cli.md`** adds a **Proxied Remote Sessions** section: four channels (git broker, proxied API, MCP, direct egress), the verified `NO_PROXY` recipe, 403 diagnosis (`x-github-request-id`), broker limits on tags/ref deletes, and updated quick-reference rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb63613f4cfb0f5956be6a8c556cc3fcd3953cad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->