### PR TITLE
chore: refresh agent surfaces to the released v0.4.2

### DIFF
--- a/.claude/hooks/tbd-closing-reminder.sh
+++ b/.claude/hooks/tbd-closing-reminder.sh
@@ -16,7 +16,7 @@ if [[ "$command" == git\ push* ]] || [[ "$command" == *"&& git push"* ]] || [[ "
     if command -v tbd &> /dev/null; then
       tbd closing
     elif command -v npx &> /dev/null; then
-      npx --yes get-tbd@0.4.0 closing
+      npx --yes get-tbd@0.4.2 closing
     fi
   fi
 fi

--- a/.claude/scripts/tbd-session.sh
+++ b/.claude/scripts/tbd-session.sh
@@ -18,10 +18,10 @@ fi
 
 # Pinned zero-install fallback. Never use an unpinned runner here.
 if command -v npx &> /dev/null; then
-    npx --yes get-tbd@0.4.0 prime "$@"
+    npx --yes get-tbd@0.4.2 prime "$@"
     exit $?
 fi
 
 echo "[tbd] tbd CLI not found and npx is unavailable."
-echo "[tbd] Install it with: npm install -g get-tbd@0.4.0"
+echo "[tbd] Install it with: npm install -g get-tbd@0.4.2"
 exit 1

--- a/.codex/tbd-closing-reminder.sh
+++ b/.codex/tbd-closing-reminder.sh
@@ -16,7 +16,7 @@ if [[ "$command" == git\ push* ]] || [[ "$command" == *"&& git push"* ]] || [[ "
     if command -v tbd &> /dev/null; then
       tbd closing
     elif command -v npx &> /dev/null; then
-      npx --yes get-tbd@0.4.0 closing
+      npx --yes get-tbd@0.4.2 closing
     fi
   fi
 fi

--- a/.codex/tbd-session.sh
+++ b/.codex/tbd-session.sh
@@ -18,10 +18,10 @@ fi
 
 # Pinned zero-install fallback. Never use an unpinned runner here.
 if command -v npx &> /dev/null; then
-    npx --yes get-tbd@0.4.0 prime "$@"
+    npx --yes get-tbd@0.4.2 prime "$@"
     exit $?
 fi
 
 echo "[tbd] tbd CLI not found and npx is unavailable."
-echo "[tbd] Install it with: npm install -g get-tbd@0.4.0"
+echo "[tbd] Install it with: npm install -g get-tbd@0.4.2"
 exit 1

--- a/.tbd/config.yml
+++ b/.tbd/config.yml
@@ -1,5 +1,5 @@
 tbd_format: f06
-tbd_version: 0.4.0
+tbd_version: 0.4.2
 # tbd_upgrades: tbd versions that have run `tbd setup` in this repo (oldest first);
 # tbd_version above is the most recent. Informational; updated automatically by setup.
 tbd_upgrades:
@@ -12,6 +12,8 @@ tbd_upgrades:
     at: 2026-06-15T16:37:46.614Z
   - version: 0.4.0
     at: 2026-07-12T19:25:48.595Z
+  - version: 0.4.2
+    at: 2026-07-30T22:04:21.493Z
 display:
   id_prefix: tbd
 sync:
@@ -97,6 +99,7 @@ docs_cache:
     guidelines/tbd-sync-troubleshooting.md: internal:guidelines/tbd-sync-troubleshooting.md
     guidelines/typescript-cli-tool-rules.md: internal:guidelines/typescript-cli-tool-rules.md
     guidelines/typescript-code-coverage.md: internal:guidelines/typescript-code-coverage.md
+    guidelines/typescript-lint-format-rules.md: internal:guidelines/typescript-lint-format-rules.md
     guidelines/typescript-rules.md: internal:guidelines/typescript-rules.md
     guidelines/typescript-sorting-patterns.md: internal:guidelines/typescript-sorting-patterns.md
     guidelines/typescript-yaml-handling-rules.md: internal:guidelines/typescript-yaml-handling-rules.md


### PR DESCRIPTION
Post-release housekeeping for v0.4.2, generated by running `tbd setup --auto` with the CLI built at the `v0.4.2` tag:

- The npx zero-install fallbacks in the Claude and Codex hook scripts move from the `get-tbd@0.4.0` pin to `get-tbd@0.4.2` (the version they pin is now published).
- `.tbd/config.yml` records the 0.4.2 upgrade with a clean version stamp (no `-dev` suffix), and the docs cache lists the new `typescript-lint-format-rules` guideline shipped in this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tM5CPJodzEnFU1AwMbFWf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-pin and config/doc-cache updates only; no application runtime or security-sensitive logic changes.
> 
> **Overview**
> Post-release housekeeping from **`tbd setup --auto`** at **v0.4.2**.
> 
> The **Claude** and **Codex** session and git-push closing hooks now use **`get-tbd@0.4.2`** for the pinned `npx` fallback and in the global install hint (was **0.4.0**).
> 
> **`.tbd/config.yml`** sets **`tbd_version`** to **0.4.2**, appends a **0.4.2** entry to **`tbd_upgrades`**, and adds **`guidelines/typescript-lint-format-rules.md`** to the docs cache mapping shipped with this release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b25c07b7078e2c6dbe30ea4a00272064dd4d734. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->