### PR TITLE
test: raise child-order e2e timeout for slow Windows CI spawns

### DIFF
--- a/packages/tbd/tests/child-order-e2e.test.ts
+++ b/packages/tbd/tests/child-order-e2e.test.ts
@@ -12,7 +12,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execSync, spawnSync } from 'node:child_process';
 
-describe('child ordering end-to-end', { timeout: 15000 }, () => {
+// Each test spawns several tbd CLI subprocesses; Windows CI runners spawn
+// slowly under parallel load, so use the same generous budget as the other
+// subprocess-heavy e2e suites (fork-cross-platform-e2e, docs-add-local-dirs-e2e).
+describe('child ordering end-to-end', { timeout: 120_000 }, () => {
   let tempDir: string;
   const tbdBin = join(__dirname, '..', 'dist', 'bin.mjs');
 


### PR DESCRIPTION
## Why

CI on `main` failed at commit 359dfa3 ([run 30586425726](https://github.com/jlevy/tbd/actions/runs/30586425726)): `tests/child-order-e2e.test.ts > preserves order through close and list` timed out at 15s on the `Test (windows-latest)` job. All other 1273 tests passed.

The suite's 15s describe-level budget covers tests that spawn up to 7 `tbd` CLI subprocesses each. Windows GitHub Actions runners spawn processes slowly under parallel load — the same run shows comparable single tests taking 13–18s — so the budget is occasionally exceeded. This is the same flake class already addressed in `vitest.config.ts` (Windows-specific `hookTimeout` bump) and in the other subprocess-heavy e2e suites (`fork-cross-platform-e2e`, `docs-add-local-dirs-e2e`, `git-env-isolation-e2e`), which all use 120s budgets.

## What

- Raise the `child ordering end-to-end` describe timeout from 15s to 120s, matching the convention of the other subprocess-heavy e2e suites, with a comment explaining why.

## Verification

- `vitest run tests/child-order-e2e.test.ts` passes locally (10/10, ~20s on Linux).
- Full pre-push suite (format, lint, typecheck, build, tests) passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dh6cSBYmse7myDnQJ5sdZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dh6cSBYmse7myDnQJ5sdZZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout and comment change; no runtime or application behavior affected.
> 
> **Overview**
> Raises the Vitest **describe** timeout for `child ordering end-to-end` from **15s** to **120s** so subprocess-heavy cases (e.g. `preserves order through close and list`) don’t flake on **windows-latest** when many `tbd` CLI spawns run in parallel.
> 
> Adds a short comment aligning this suite with other subprocess-heavy e2e tests (`fork-cross-platform-e2e`, `docs-add-local-dirs-e2e`). **No production or test logic changes**—only the timeout budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fa96139a35338218a62ba5bd2d5a6d11f9d7dbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->