### PR TITLE
process: Add cryptographic hash check rules and no-ceremony principle

### DIFF
--- a/.agents/skills/tbd/SKILL.md
+++ b/.agents/skills/tbd/SKILL.md
@@ -282,7 +282,7 @@ Load the **General engineering** group first, then the language or framework gro
 | error-handling-rules | Rules for handling errors, failures, and exceptional conditions |
 | general-coding-rules | Rules for constants, magic numbers, cryptographic hash checks, and general coding practices |
 | general-comment-rules | Language-agnostic rules for writing clean, maintainable comments |
-| general-eng-agent-principles | Core principles for AI agents acting as senior engineers—objectivity and communication conduct plus the engineering process (detailed understanding, verification, end-to-end ownership, scope discipline, tracking future work, and acting versus seeking clarification) |
+| general-eng-agent-principles | Core principles for AI agents acting as senior engineers—objectivity and communication conduct plus the engineering process (detailed understanding, verification, end-to-end ownership, scope discipline, tracking future work, acting versus seeking clarification, and no ceremony without benefit) |
 | general-tdd-guidelines | Test-Driven Development methodology and best practices |
 | general-testing-rules | Rules for writing minimal, effective tests with maximum coverage |
 | golden-testing-guidelines | Guidelines for implementing golden/snapshot testing for complex systems |

--- a/.agents/skills/tbd/SKILL.md
+++ b/.agents/skills/tbd/SKILL.md
@@ -280,7 +280,7 @@ Load the **General engineering** group first, then the language or framework gro
 | backward-compatibility-rules | Guidelines for maintaining backward compatibility across code, APIs, file formats, and database schemas |
 | commit-conventions | Conventional Commits format with extensions for agentic workflows |
 | error-handling-rules | Rules for handling errors, failures, and exceptional conditions |
-| general-coding-rules | Rules for constants, magic numbers, and general coding practices |
+| general-coding-rules | Rules for constants, magic numbers, cryptographic hash checks, and general coding practices |
 | general-comment-rules | Language-agnostic rules for writing clean, maintainable comments |
 | general-eng-agent-principles | Core principles for AI agents acting as senior engineers—objectivity and communication conduct plus the engineering process (detailed understanding, verification, end-to-end ownership, scope discipline, tracking future work, and acting versus seeking clarification) |
 | general-tdd-guidelines | Test-Driven Development methodology and best practices |

--- a/.claude/skills/tbd/SKILL.md
+++ b/.claude/skills/tbd/SKILL.md
@@ -282,7 +282,7 @@ Load the **General engineering** group first, then the language or framework gro
 | error-handling-rules | Rules for handling errors, failures, and exceptional conditions |
 | general-coding-rules | Rules for constants, magic numbers, cryptographic hash checks, and general coding practices |
 | general-comment-rules | Language-agnostic rules for writing clean, maintainable comments |
-| general-eng-agent-principles | Core principles for AI agents acting as senior engineers—objectivity and communication conduct plus the engineering process (detailed understanding, verification, end-to-end ownership, scope discipline, tracking future work, and acting versus seeking clarification) |
+| general-eng-agent-principles | Core principles for AI agents acting as senior engineers—objectivity and communication conduct plus the engineering process (detailed understanding, verification, end-to-end ownership, scope discipline, tracking future work, acting versus seeking clarification, and no ceremony without benefit) |
 | general-tdd-guidelines | Test-Driven Development methodology and best practices |
 | general-testing-rules | Rules for writing minimal, effective tests with maximum coverage |
 | golden-testing-guidelines | Guidelines for implementing golden/snapshot testing for complex systems |

--- a/.claude/skills/tbd/SKILL.md
+++ b/.claude/skills/tbd/SKILL.md
@@ -280,7 +280,7 @@ Load the **General engineering** group first, then the language or framework gro
 | backward-compatibility-rules | Guidelines for maintaining backward compatibility across code, APIs, file formats, and database schemas |
 | commit-conventions | Conventional Commits format with extensions for agentic workflows |
 | error-handling-rules | Rules for handling errors, failures, and exceptional conditions |
-| general-coding-rules | Rules for constants, magic numbers, and general coding practices |
+| general-coding-rules | Rules for constants, magic numbers, cryptographic hash checks, and general coding practices |
 | general-comment-rules | Language-agnostic rules for writing clean, maintainable comments |
 | general-eng-agent-principles | Core principles for AI agents acting as senior engineers—objectivity and communication conduct plus the engineering process (detailed understanding, verification, end-to-end ownership, scope discipline, tracking future work, and acting versus seeking clarification) |
 | general-tdd-guidelines | Test-Driven Development methodology and best practices |

--- a/packages/tbd/docs/guidelines/general-coding-rules.md
+++ b/packages/tbd/docs/guidelines/general-coding-rules.md
@@ -40,42 +40,38 @@ category: general
 
 ## Cryptographic Hash Checks
 
-A cryptographic hash check (SHA-256 or similar) is a tool for verifying data across a
-trust boundary. A common agent antipattern is adding hash checks as process ceremony:
-they impose real costs in code, complexity, and failure modes while adding no assurance.
-NEVER add a hash check “for good luck”; if you cannot state what failure or tampering
-the check catches, remove it.
+Cryptographic hashes (SHA-256 and similar) verify data across a trust boundary.
+A common agent antipattern is hash checking as process ceremony: real costs in code,
+complexity, and failure modes, no benefit.
+NEVER add a hash check “for good luck”; if you cannot name the failure or tampering it
+catches, remove it.
 
-- **The test**: A hash comparison adds assurance only when the two values are computed
-  independently and the data passes outside your control in between—through another
-  party, an untrusted channel, or long-lived storage.
-  If the same trusted process computes both sides moments apart, the check can only
-  catch bugs in the check itself.
+- **The test**: A comparison adds assurance only if the two hashes are computed
+  independently, with the data outside your control in between (another party, an
+  untrusted channel, long-lived storage).
+  When one trusted process computes both sides moments apart, the check can only catch
+  bugs in the check itself.
 
-- **Appropriate uses**:
+- **Appropriate**:
 
-  - Verifying untrusted external data against a fixed, known, trusted value, such as
-    checking a downloaded artifact against a checksum pinned in your repo (see
+  - Verifying untrusted external data against a fixed, known, trusted value, such as a
+    downloaded artifact against a checksum pinned in your repo (see
     `supply-chain-hardening`).
 
-  - A hash table or content-addressed store that must be tamper-resistant, where
-    collisions must be infeasible even for adversarial inputs.
+  - A hash table or content-addressed store that must resist adversarial collisions (an
+    ordinary hash table needs only a fast non-cryptographic hash).
 
-  - Integrity manifests for large numbers of files written to disk and persisted for
-    long periods, when external verification is genuinely needed later.
+  - Integrity manifests for many files persisted long-term, when external verification
+    is genuinely needed later.
 
-- **Inappropriate uses (ceremony)**:
+- **Ceremony**:
 
-  - A trusted application saves a file, immediately reads it back, and hashes both sides
-    of its own round trip.
-    The comparison verifies nothing.
-    If corruption or truncation on disk is a real operational risk, address it
-    operationally instead: write output files atomically (write to a temp file, then
-    rename).
+  - Hashing both sides of your own save-then-read-back round trip: the comparison
+    verifies nothing. If disk corruption or truncation is a real risk, write files
+    atomically (temp file, then rename) instead of adding checks.
 
   - Content-hashing a reference to an external resource, such as a file in a GitHub
-    repository, when an exact release tag or Git revision identifies it more clearly and
-    maintainably.
+    repository, when an exact release or Git revision is the clearer, maintainable pin.
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/packages/tbd/docs/guidelines/general-coding-rules.md
+++ b/packages/tbd/docs/guidelines/general-coding-rules.md
@@ -1,6 +1,6 @@
 ---
 title: General Coding Rules
-description: Rules for constants, magic numbers, and general coding practices
+description: Rules for constants, magic numbers, cryptographic hash checks, and general coding practices
 author: Joshua Levy (github.com/jlevy) with LLM assistance
 category: general
 ---
@@ -37,6 +37,45 @@ category: general
   // Usage:
   const tradeCount = Math.min(trades.length, EXECUTION_STATS_LIMITS.maxTradeCount);
   ```
+
+## Cryptographic Hash Checks
+
+A cryptographic hash check (SHA-256 or similar) is a tool for verifying data across a
+trust boundary. A common agent antipattern is adding hash checks as process ceremony:
+they impose real costs in code, complexity, and failure modes while adding no assurance.
+NEVER add a hash check “for good luck”; if you cannot state what failure or tampering
+the check catches, remove it.
+
+- **The test**: A hash comparison adds assurance only when the two values are computed
+  independently and the data passes outside your control in between—through another
+  party, an untrusted channel, or long-lived storage.
+  If the same trusted process computes both sides moments apart, the check can only
+  catch bugs in the check itself.
+
+- **Appropriate uses**:
+
+  - Verifying untrusted external data against a fixed, known, trusted value, such as
+    checking a downloaded artifact against a checksum pinned in your repo (see
+    `supply-chain-hardening`).
+
+  - A hash table or content-addressed store that must be tamper-resistant, where
+    collisions must be infeasible even for adversarial inputs.
+
+  - Integrity manifests for large numbers of files written to disk and persisted for
+    long periods, when external verification is genuinely needed later.
+
+- **Inappropriate uses (ceremony)**:
+
+  - A trusted application saves a file, immediately reads it back, and hashes both sides
+    of its own round trip.
+    The comparison verifies nothing.
+    If corruption or truncation on disk is a real operational risk, address it
+    operationally instead: write output files atomically (write to a temp file, then
+    rename).
+
+  - Content-hashing a reference to an external resource, such as a file in a GitHub
+    repository, when an exact release tag or Git revision identifies it more clearly and
+    maintainably.
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/packages/tbd/docs/guidelines/general-eng-agent-principles.md
+++ b/packages/tbd/docs/guidelines/general-eng-agent-principles.md
@@ -1,6 +1,6 @@
 ---
 title: Engineering Agent Principles
-description: Core principles for AI agents acting as senior engineers—objectivity and communication conduct plus the engineering process (detailed understanding, verification, end-to-end ownership, scope discipline, tracking future work, and acting versus seeking clarification)
+description: Core principles for AI agents acting as senior engineers—objectivity and communication conduct plus the engineering process (detailed understanding, verification, end-to-end ownership, scope discipline, tracking future work, acting versus seeking clarification, and no ceremony without benefit)
 author: Joshua Levy (github.com/jlevy) with LLM assistance
 category: general
 ---
@@ -121,6 +121,15 @@ Therefore:
    *Always* find the appropriate documentation.
    Also check the code whenever uncertain.
    *Code is the definitive source of information for APIs.*
+
+10. **Add no ceremony without a named benefit:** Every check, guard, or process step you
+    add must catch a failure you can name; steps that merely look rigorous add cost and
+    obscure real risks. This applies in every language.
+    A common case is the needless cryptographic hash check; see the Cryptographic Hash
+    Checks rules in `general-coding-rules`.
+    - NEVER: “I added SHA-256 verification when saving and re-reading the file, for
+      extra safety.” (Safety from what?
+      A check whose benefit you cannot state is ceremony to remove.)
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.


### PR DESCRIPTION
## Summary

Codifies a principle agents often get wrong: cryptographic hash checks added as process ceremony, imposing costs (code, complexity, failure modes) with no benefit. Two docs change, so the principle sits in both routine loading paths:

- **`general-coding-rules`** gains a **Cryptographic Hash Checks** section with the detailed rules. This doc is loaded unconditionally by `review-code` (step 4, before any language-specific rules), so every code review references it regardless of language.
  - The test: a comparison adds assurance only if the two hashes are computed independently, with the data outside your control in between. One process hashing both sides of its own round trip can only catch bugs in the check itself.
  - Appropriate: untrusted data vs. a pinned trusted checksum (cross-referenced to `supply-chain-hardening`), collision-resistant hash tables/content addressing, integrity manifests for long-persisted files.
  - Ceremony: hashing your own save-then-read-back round trip (write atomically instead), content-hashing external resources better pinned by release or Git revision.
- **`general-eng-agent-principles`** gains engineering process principle 10, **add no ceremony without a named benefit**, generalizing the rule and referencing the section above. This doc is required reading before any engineering work per this repo's CLAUDE.md.

Frontmatter descriptions updated in both docs; tracked `SKILL.md` surfaces regenerated via `pnpm build` + local `setup --auto`.

## Testing

- `pnpm format:check`, `pnpm lint:check`, `pnpm typecheck` clean
- `pnpm test`: 100 files, 1452 tests passed
- Verified both docs load via `node packages/tbd/dist/bin.mjs guidelines <name>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1ZKUwPKGjLbMNGGv4LqyX