### PR TITLE
feat: finalize release readiness and live bead viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ You just talk naturally.
   shares the CLI’s filters and stays current as local bead state changes.
   It is a viewer, not an editor: ask your agent to change beads with ordinary `tbd`
   commands, and the open page updates automatically.
-  Counted label filters, relative update times, bounded title summaries, and composable
-  column sorting keep large boards scannable without changing bead semantics.
+  Cross-filtered facet tallies, relative update times, bounded title summaries, and
+  two-key column sorting keep large boards scannable without changing bead semantics.
   It never contacts a remote; explicit `tbd sync` remains the exchange step.
 - **Beads alternative:** Largely compatible with `bd` at the CLI level, but with a
   simpler architecture: no JSONL merge conflicts, no daemon modifying your working tree,
@@ -413,15 +413,20 @@ When you ask an agent to show your beads in a browser, the agent should run
 The browser’s controls only change the view; ask the agent to create, update, close,
 label, or sync beads with ordinary `tbd` commands.
 Their local results appear on the open page automatically.
-The label chooser shows the 32 most common labels with bead counts; selecting more than
-one retains the CLI’s repeatable `--label` behavior, so every selected label is
-required.
-Collapsed titles use at most four lines and expand in full, while Updated shows
-a compact relative age with the exact timestamp on hover.
-Clicking a data-column header makes it the primary sort and retains earlier columns as
-tie-breakers. Because global table order conflicts with parent-first hierarchy, a header
-sort switches Pretty off; re-enabling Pretty clears that stack and restores the CLI
-tree. Changing a filter, sort, display mode, or page closes expanded row details.
+Status, Type, Priority, and the 32-label chooser show counts after every other active
+filter. Zero-result unselected choices disappear.
+Label choices iteratively show the next intersection; selecting more than one retains
+the CLI’s repeatable `--label` behavior, so every selected label is required.
+Collapsed titles use at most four lines and expand in full, while Updated shows a
+compact sans relative age with the exact timestamp in a fast tooltip.
+The board defaults to Pretty with Updated descending, then Priority ascending.
+Clicking a data-column header makes it primary and retains only the previous primary as
+its tie-breaker; Reset sort restores the default.
+Sorting never disables Pretty.
+In Pretty mode it reorders only outermost visible parent groups, using the latest
+Updated timestamp in each complete visible subtree while preserving official child
+order. Flat mode applies the sort stack to individual rows.
+Changing a filter, sort, display mode, or page closes expanded row details.
 During a live update, only rows still present in the bounded response remain expanded,
 with any display-ID change reconciled before their bodies reload.
 It never fetches automatically; run `tbd sync` and the resulting local changes appear

--- a/README.md
+++ b/README.md
@@ -426,6 +426,8 @@ Sorting never disables Pretty.
 In Pretty mode it reorders only outermost visible parent groups, using the latest
 Updated timestamp in each complete visible subtree while preserving official child
 order. Flat mode applies the sort stack to individual rows.
+Each non-root row uses one `└──` elbow at its hierarchy indentation; deeper levels use
+spaces rather than ancestor bars, and sibling position never introduces a tee.
 Changing a filter, sort, display mode, or page closes expanded row details.
 During a live update, only rows still present in the bounded response remain expanded,
 with any display-ID change reconciled before their bodies reload.

--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ tbd close proj-a7k2 --reason="Fixed in commit abc123"
 tbd close proj-a7k2 proj-b3m9 --reason="Sprint done"  # Bulk close (one call, no loops)
 tbd sync                       # Sync with remote (auto-commits and pushes)
 tbd web --open                 # Open the live, read-only browser viewer
+tbd web ../another-repo --open # View another initialized repository
 tbd watch --ready --json       # Block until a bead newly becomes ready
 tbd watch --bead proj-a7k2     # Block until one bead changes on the remote
 tbd changes --since <commit>   # What changed since a sync-branch commit
@@ -408,6 +409,11 @@ local browser. It binds loopback only, has no write route, and does not open a b
 unless you pass `--open`. Large results support up to 10,000 rows and render in
 5,000-row pages. Native local file events normally update it immediately, with a
 one-second reconciliation fallback for missed events.
+An optional path may name an initialized repository or any directory inside one, so the
+viewer can be started from elsewhere.
+An initialized repository with no beads shows a normal empty board.
+A missing path or a directory that has not been initialized reports the same clear
+repository error as other tbd commands.
 When you ask an agent to show your beads in a browser, the agent should run
 `tbd web --open`, wait for the URL, give it to you, and keep the process running.
 The browser’s controls only change the view; ask the agent to create, update, close,

--- a/README.md
+++ b/README.md
@@ -413,19 +413,23 @@ When you ask an agent to show your beads in a browser, the agent should run
 The browser’s controls only change the view; ask the agent to create, update, close,
 label, or sync beads with ordinary `tbd` commands.
 Their local results appear on the open page automatically.
-Status, Type, Priority, and the 32-label chooser show counts after every other active
+Status, Type, Priority, and the label chooser show counts after every other active
 filter. Zero-result unselected choices disappear.
+The label menu shows up to 32 choices at once; searching it queries the complete label
+vocabulary, so lower-ranked labels remain reachable.
 Label choices iteratively show the next intersection; selecting more than one retains
 the CLI’s repeatable `--label` behavior, so every selected label is required.
 Collapsed titles use at most four lines and expand in full, while Updated shows a
 compact sans relative age with the exact timestamp in a fast tooltip.
 The board defaults to Pretty with Updated descending, then Priority ascending.
 Clicking a data-column header makes it primary and retains only the previous primary as
-its tie-breaker; Reset sort restores the default.
+its tie-breaker; Reset sort restores the default stack without changing Pretty.
 Sorting never disables Pretty.
 In Pretty mode it reorders only outermost visible parent groups, using the latest
 Updated timestamp in each complete visible subtree while preserving official child
 order. Flat mode applies the sort stack to individual rows.
+The equivalent-command tooltip identifies browser-only ordering that the displayed CLI
+command does not reproduce.
 Each non-root row uses one `└──` elbow at its hierarchy indentation; deeper levels use
 spaces rather than ancestor bars, and sibling position never introduces a tee.
 Changing a filter, sort, display mode, or page closes expanded row details.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ You just talk naturally.
   shares the CLI’s filters and stays current as local bead state changes.
   It is a viewer, not an editor: ask your agent to change beads with ordinary `tbd`
   commands, and the open page updates automatically.
+  Counted label filters, relative update times, bounded title summaries, and composable
+  column sorting keep large boards scannable without changing bead semantics.
   It never contacts a remote; explicit `tbd sync` remains the exchange step.
 - **Beads alternative:** Largely compatible with `bd` at the CLI level, but with a
   simpler architecture: no JSONL merge conflicts, no daemon modifying your working tree,
@@ -411,7 +413,15 @@ When you ask an agent to show your beads in a browser, the agent should run
 The browser’s controls only change the view; ask the agent to create, update, close,
 label, or sync beads with ordinary `tbd` commands.
 Their local results appear on the open page automatically.
-Changing a filter, sort, display mode, or page closes expanded row details.
+The label chooser shows the 32 most common labels with bead counts; selecting more than
+one retains the CLI’s repeatable `--label` behavior, so every selected label is
+required.
+Collapsed titles use at most four lines and expand in full, while Updated shows
+a compact relative age with the exact timestamp on hover.
+Clicking a data-column header makes it the primary sort and retains earlier columns as
+tie-breakers. Because global table order conflicts with parent-first hierarchy, a header
+sort switches Pretty off; re-enabling Pretty clears that stack and restores the CLI
+tree. Changing a filter, sort, display mode, or page closes expanded row details.
 During a live update, only rows still present in the bounded response remain expanded,
 with any display-ID change reconciled before their bodies reload.
 It never fetches automatically; run `tbd sync` and the resulting local changes appear

--- a/docs/development.md
+++ b/docs/development.md
@@ -109,6 +109,10 @@ Preserve the agent interaction contract across those surfaces: a natural request
 beads in a browser routes the installed skill to `tbd web --open`; the agent owns the
 foreground process and all ordinary tbd mutations; the page is a live viewer, not an
 editor; and starting it never performs remote exchange.
+When the target project is outside the agent’s current working directory, the skill must
+use `tbd web <path> --open`. The CLI accepts a repository or subdirectory, supports an
+initialized repository with no beads, and applies the standard initialization error to
+an existing non-tbd directory.
 The source skill tiers, `welcome-user`, README, CLI manual, design, setup output,
 command startup output, and browser copy must state that contract consistently.
 `integration-files.test.ts`, `setup-flows.test.ts`, `golden-output.test.ts`,

--- a/docs/development.md
+++ b/docs/development.md
@@ -101,6 +101,9 @@ The server implementation lives in `packages/tbd/src/cli/web/`, the Commander ha
 `packages/tbd/src/cli/commands/web.ts`, and the strict browser client in
 `packages/tbd/src/web/`. `packages/tbd/scripts/stitch-web.mjs` inlines the browser IIFE
 and CSS into the single published `dist/web/index.html` artifact.
+The component, typography, color, tree, label-facet, and ordered-column-sort rules are
+documented beside their implementations in the authoritative design-system inventory at
+the top of `packages/tbd/src/web/styles.css`.
 
 Preserve the agent interaction contract across those surfaces: a natural request to see
 beads in a browser routes the installed skill to `tbd web --open`; the agent owns the

--- a/docs/development.md
+++ b/docs/development.md
@@ -101,9 +101,9 @@ The server implementation lives in `packages/tbd/src/cli/web/`, the Commander ha
 `packages/tbd/src/cli/commands/web.ts`, and the strict browser client in
 `packages/tbd/src/web/`. `packages/tbd/scripts/stitch-web.mjs` inlines the browser IIFE
 and CSS into the single published `dist/web/index.html` artifact.
-The component, typography, color, tree, label-facet, and ordered-column-sort rules are
-documented beside their implementations in the authoritative design-system inventory at
-the top of `packages/tbd/src/web/styles.css`.
+The component, typography, color, tree, conditional-facet, tooltip, and bounded-sort
+rules are documented beside their implementations in the authoritative design-system
+inventory at the top of `packages/tbd/src/web/styles.css`.
 
 Preserve the agent interaction contract across those surfaces: a natural request to see
 beads in a browser routes the installed skill to `tbd web --open`; the agent owns the

--- a/docs/project/specs/active/plan-2026-08-10-tbd-web-live-bead-view.md
+++ b/docs/project/specs/active/plan-2026-08-10-tbd-web-live-bead-view.md
@@ -211,6 +211,9 @@ Payload shape matters more than raw speed:
 - The table receives light rows only: ids, title, status, kind, priority, labels, spec,
   assignee, readiness, and the tree prefix.
   Descriptions and notes are excluded.
+- Each board response carries at most 32 label facets ranked by full-snapshot bead count
+  and name, retaining selected values within that bound.
+  Repeated label filters remain ANDed exactly like repeatable CLI `--label` flags.
 - Bodies are served per bead on demand from the in-memory snapshot, so an open row costs
   one small request and a graph of long descriptions never inflates the table payload.
 - SSE frames carry local-observer state only: changed ids, update count, phase, mode,
@@ -223,6 +226,13 @@ Payload shape matters more than raw speed:
   Event-frame size is independent of graph size.
 - Filtering runs server-side so semantics come from the shared module.
   On loopback this is sub-millisecond and keystroke-responsive.
+- Collapsed titles use at most four lines and restore their full text on expansion.
+  Updated values use compact relative ages with exact timestamp hover.
+  Every displayed data column is an ordered sort key: the latest click becomes primary
+  and prior keys remain tie-breakers.
+  A global order uses the flat list because it cannot preserve the parent-first tree
+  simultaneously; re-enabling Pretty clears the custom stack and restores CLI
+  priority/tree order.
 - The server returns at most 10,000 light rows while preserving the unsliced match
   count. The browser renders the response in 5,000-row pages, so all served rows remain
   reachable without making every refresh lay out a six-figure DOM tree.
@@ -248,6 +258,8 @@ on the review machine.
 The high end is the full parallel test-suite run; the isolated focused case supplied the
 low end. The final concurrency gate measured 16.44 ms initial load, 29.39 ms one-change
 refresh, and 53.71 ms response construction.
+The final facet-and-sort slice measured a 10,001-issue, 2.85 MiB bounded response at
+38.70 ms and a two-column composition over the same board at 13.63 ms.
 That fixture injects already-parsed issues, so it is not presented as a disk benchmark.
 A separate one-off check on 2026-08-11 wrote 10,000 representative files through
 production `writeIssue` and then read them twice through production `listIssues`; the
@@ -1039,6 +1051,11 @@ liveness decision:
 
 - The query, statistics, tree, and JSON-output fixes ride PR #207; remote-watch and sync
   internals stay unchanged because the viewer no longer consumes them.
+
+- Dense-board presentation uses counted label facets, four-line collapsed titles,
+  relative update ages, and ordered header sorts.
+  Column sorts select the flat view; Pretty restores the exact CLI hierarchy and default
+  priority order.
 
 ## References
 

--- a/docs/project/specs/active/plan-2026-08-10-tbd-web-live-bead-view.md
+++ b/docs/project/specs/active/plan-2026-08-10-tbd-web-live-bead-view.md
@@ -211,9 +211,11 @@ Payload shape matters more than raw speed:
 - The table receives light rows only: ids, title, status, kind, priority, labels, spec,
   assignee, readiness, and the tree prefix.
   Descriptions and notes are excluded.
-- Each board response carries at most 32 label facets ranked by full-snapshot bead count
-  and name, retaining selected values within that bound.
-  Repeated label filters remain ANDed exactly like repeatable CLI `--label` flags.
+- Each board response carries conditional Status, Type, and Priority facets plus at most
+  32 label facets. Counts apply search and all other active dimensions rather than global
+  standalone totals; unselected zero-count values are omitted.
+  Label candidates additionally apply the current repeated-label intersection, retaining
+  selected values for removal and preserving CLI `--label` AND semantics.
 - Bodies are served per bead on demand from the in-memory snapshot, so an open row costs
   one small request and a graph of long descriptions never inflates the table payload.
 - SSE frames carry local-observer state only: changed ids, update count, phase, mode,
@@ -227,16 +229,23 @@ Payload shape matters more than raw speed:
 - Filtering runs server-side so semantics come from the shared module.
   On loopback this is sub-millisecond and keystroke-responsive.
 - Collapsed titles use at most four lines and restore their full text on expansion.
-  Updated values use compact relative ages with exact timestamp hover.
-  Every displayed data column is an ordered sort key: the latest click becomes primary
-  and prior keys remain tie-breakers.
-  A global order uses the flat list because it cannot preserve the parent-first tree
-  simultaneously; re-enabling Pretty clears the custom stack and restores CLI
-  priority/tree order.
+  Updated values use compact sans relative ages with exact monospace timestamp tooltips.
+  The default is Pretty with Updated descending then Priority ascending.
+  Every displayed data column is an ordered sort key: the latest click becomes primary,
+  the prior primary is the sole tie-breaker, and sorting never clears Pretty.
+  Pretty sorts outermost visible parent groups only; Updated rolls up the latest
+  timestamp in each complete visible subtree for every parent kind, while children keep
+  official `child_order_hints` order.
+  Flat mode applies the stack globally, and Reset restores the complete default.
+  Filtered-out ancestors are never reinserted; matching descendants become roots,
+  exactly as in `tbd list --pretty`.
+- Expanded updated beads show 80-character middle-ellipsis previews for each scalar
+  before/after value while Copy retains bounded full data.
+  Before is muted, after is normal text, and created beads suppress redundant
+  null-to-current-value deltas.
 - The server returns at most 10,000 light rows while preserving the unsliced match
   count. The browser renders the response in 5,000-row pages, so all served rows remain
   reachable without making every refresh lay out a six-figure DOM tree.
-  Pretty-tree context ids and their count describe only those returned rows.
   Sticky and end-of-page controls navigate the pages and return the viewport to the
   first row.
 - Bulk expansion is available only when the visible page has 100 rows or fewer.
@@ -305,7 +314,10 @@ replaces roughly 4,060 per-target listeners with three shared listeners.
 The pagination threshold was then reconsidered from first principles against the
 production bundle rather than retained at 1,000 by convention.
 A separate loopback fixture exercised the complete stitched UI with long titles,
-semantic states, labels, ready markers, copy controls, and nested pretty prefixes:
+semantic states, labels, quiet derived-ready markers, copy controls, and nested pretty
+prefixes. Ready remains the exact open + unassigned + unblocked `tbd ready` predicate;
+the filter is a primary work-discovery control, while the row marker is deliberately
+unboxed so it cannot be mistaken for a user label:
 
 | Visible rows | Total elements | Copy buttons | Paint-ready navigation |
 | ---: | ---: | ---: | ---: |
@@ -627,7 +639,7 @@ Signatures are the intended shape; adjust mechanically in review, not structural
   diff with complete motion plus bounded detail, `getObservationPaths()` exposing only
   the constant-size local marker inputs, `computeIssueStats`, the served `RepoStatus`,
   and `buildBoardResponse(params)` translating query strings to `IssueQuery` and calling
-  `selectIssues`/`describeQuery` plus the tree/context-row walk over `buildIssueTree`.
+  `selectIssues`/`describeQuery` plus the filter-exact tree walk over `buildIssueTree`.
 - **`src/file/data-sync-epoch.ts`** + **`src/file/common-dir-layout.ts`**: the central
   shared writer wrapper atomically publishes `active:<uuid>` before a critical section
   and `quiescent:<uuid>` before unlocking.
@@ -683,10 +695,10 @@ Signatures are the intended shape; adjust mechanically in review, not structural
 - `tests/issue-query.test.ts` — parity oracle: legacy filter/sort logic captured as a
   test-local oracle, property-style corpus compared against `selectIssues`.
 - `tests/tree-view.test.ts` — depth-3 golden (tbd-5hh1).
-- `tests/web-board.test.ts` — light rows, shared queries, tree context, movement,
-  metadata-only updates, bounded delta detail, body lookup, canonical display-id
-  alphabets, FIFO reloads, writer overlap, unchanged-metadata epoch races, context
-  changes, and strict candidate rejection.
+- `tests/web-board.test.ts` — light rows, shared queries, exact-filter trees and root
+  roll-up ordering, movement, metadata-only updates, bounded delta detail, body lookup,
+  canonical display-id alphabets, FIFO reloads, writer overlap, unchanged-metadata epoch
+  races, repository context changes, and strict candidate rejection.
 - `tests/data-sync-epoch.test.ts` — active/quiescent writer ordering, lock lifetime,
   failed critical sections, and corrupt-epoch fail-closed behavior.
 - `tests/web-http.test.ts` — GET-only routing, Host/Origin security, detail isolation,
@@ -906,7 +918,7 @@ display ids or consume the detail cap.
 | `tbd-wx19` (R14) | P1 | `scripts/validate-web-package.mjs`: `packArchive` | Keep direct `execFile` on POSIX; on Windows run the `pnpm.cmd` shim through `ComSpec` before continuing the exact packed-artifact proof. |
 | `tbd-z3o9` (R15) | P2 | `src/web/core.ts`: `Store.toggle`, `setExpanded`, `cacheBody`, `receiveState`; `src/web/client.ts`: `renderBoard` | Limit open details to 100, cached bodies to 200, deletion ghosts to 100, and replace scale-sensitive row-class array scans with set lookup. |
 | `tbd-et3a` (R16) | P2 | `tests/performance.test.ts`: 10,001-issue boundary fixture | Prove that 10,000 rows are returned without exceeding the response ceiling and that `truncated` retains the full over-limit count. |
-| `tbd-6pjo` (R17) | P2 | `src/cli/web/board.ts`: `BoardState.buildBoardResponse`; `tests/web-board.test.ts` | Derive pretty-tree context ids and their count from the capped response rows, with an over-limit hierarchy regression. |
+| `tbd-6pjo` (R17) | P2 | Superseded pretty-tree ancestor context | Historical capped-context fix was validated; the final exact-filter design removes injected ancestor rows entirely, so Active and every other filter match `tbd list --pretty`. |
 | `tbd-wmdo` (R18) | P2 | `src/cli/web/board.ts`: `BoardState.buildBoardResponse`; `src/web/core.ts`: `caveatsFor` | Mark every capped response command-inexact and explain in the tooltip that only the returned prefix is shown. |
 | `tbd-ihyx` (R19) | P1 | `src/cli/web/{board,local-observer}.ts`; `commands/web.ts`; `web/{core,client}.ts`; all web docs/tests | Make the viewer local-only, remove the poll flag, observe native changes immediately, reconcile missed events once per second, bound local detail without losing motion, recover across observer restarts, and prove explicit `tbd sync` is the only remote path. |
 | `tbd-xp1v` (R20) | P2 | `src/cli/web/http.ts`: `SseHub.attach`, `SseHub.write`; `tests/web-http.test.ts` | Check ended streams, catch a write-time close race, and install a per-response error handler so one disconnected client cannot escape a publish or heartbeat into the server process. |
@@ -1052,10 +1064,13 @@ liveness decision:
 - The query, statistics, tree, and JSON-output fixes ride PR #207; remote-watch and sync
   internals stay unchanged because the viewer no longer consumes them.
 
-- Dense-board presentation uses counted label facets, four-line collapsed titles,
-  relative update ages, and ordered header sorts.
-  Column sorts select the flat view; Pretty restores the exact CLI hierarchy and default
-  priority order.
+- Dense-board presentation uses cross-filtered categorical facets, four-line collapsed
+  titles, relative update ages, fast delegated tooltips, and bounded two-key header
+  sorts defaulting to Updated descending then Priority ascending.
+  Sorting never changes Pretty.
+  Pretty reorders only outermost visible groups using each complete visible subtree’s
+  maximum Updated timestamp while preserving official child order; Flat applies the same
+  bounded stack to individual rows.
 
 ## References
 

--- a/docs/project/specs/active/plan-2026-08-10-tbd-web-live-bead-view.md
+++ b/docs/project/specs/active/plan-2026-08-10-tbd-web-live-bead-view.md
@@ -214,6 +214,8 @@ Payload shape matters more than raw speed:
 - Each board response carries conditional Status, Type, and Priority facets plus at most
   32 label facets. Counts apply search and all other active dimensions rather than global
   standalone totals; unselected zero-count values are omitted.
+  Label search queries the complete vocabulary before the response cap, so lower-ranked
+  labels remain reachable.
   Label candidates additionally apply the current repeated-label intersection, retaining
   selected values for removal and preserving CLI `--label` AND semantics.
 - Bodies are served per bead on demand from the in-memory snapshot, so an open row costs
@@ -238,7 +240,10 @@ Payload shape matters more than raw speed:
   official `child_order_hints` order.
   Each non-root browser row renders one `└──` elbow at its hierarchy indentation;
   ancestor levels are spaces, never vertical bars, and sibling position never selects a
-  tee. Flat mode applies the stack globally, and Reset restores the complete default.
+  tee. Flat mode applies the stack globally, and Reset restores the default sort stack
+  without changing Pretty.
+  The equivalent-command tooltip names browser-only ordering that the adjacent CLI
+  command does not reproduce.
   Filtered-out ancestors are never reinserted; matching descendants become roots,
   exactly as in `tbd list --pretty`.
 - Expanded updated beads show 80-character middle-ellipsis previews for each scalar
@@ -1073,6 +1078,12 @@ liveness decision:
   Pretty reorders only outermost visible groups using each complete visible subtree’s
   maximum Updated timestamp while preserving official child order; Flat applies the same
   bounded stack to individual rows.
+
+- Live rendering delegates row expansion to one table-body listener, ignores clicks that
+  finish a non-collapsed text selection, restores keyboard focus by stable identity, and
+  dismisses tooltips whose anchors were replaced.
+  A board-refresh failure retains the last successful rows and remains visible in the
+  observer indicator until recovery.
 
 ## References
 

--- a/docs/project/specs/active/plan-2026-08-10-tbd-web-live-bead-view.md
+++ b/docs/project/specs/active/plan-2026-08-10-tbd-web-live-bead-view.md
@@ -434,10 +434,17 @@ Revisit as its own proposal if real usage asks for it.
 ### CLI surface
 
 ```bash
-tbd web [--port <n>] [--open]
+tbd web [path] [--port <n>] [--open]
 ```
 
 Binding is `127.0.0.1` only, and there is deliberately no flag to change that.
+
+`path` may identify an initialized repository or any directory inside one and is
+resolved relative to the caller before ordinary repository discovery.
+This makes the viewer usable from an unrelated working directory without changing its
+data model. An initialized repository with zero beads is a valid empty board.
+A missing path is a usage error, while an existing directory without tbd metadata uses
+the same `NotInitializedError` contract as other repository commands.
 
 `tbd web` is a long-running foreground command, which is unusual for this CLI, so it
 follows the existing conventions rather than inventing server-specific ones.
@@ -1082,6 +1089,8 @@ liveness decision:
 - Live rendering delegates row expansion to one table-body listener, ignores clicks that
   finish a non-collapsed text selection, restores keyboard focus by stable identity, and
   dismisses tooltips whose anchors were replaced.
+  Label-search drafts survive intervening live renders until their debounce lands, and
+  Home/End preserve native caret movement while that field owns focus.
   A board-refresh failure retains the last successful rows and remains visible in the
   observer indicator until recovery.
 

--- a/docs/project/specs/active/plan-2026-08-10-tbd-web-live-bead-view.md
+++ b/docs/project/specs/active/plan-2026-08-10-tbd-web-live-bead-view.md
@@ -236,7 +236,9 @@ Payload shape matters more than raw speed:
   Pretty sorts outermost visible parent groups only; Updated rolls up the latest
   timestamp in each complete visible subtree for every parent kind, while children keep
   official `child_order_hints` order.
-  Flat mode applies the stack globally, and Reset restores the complete default.
+  Each non-root browser row renders one `└──` elbow at its hierarchy indentation;
+  ancestor levels are spaces, never vertical bars, and sibling position never selects a
+  tee. Flat mode applies the stack globally, and Reset restores the complete default.
   Filtered-out ancestors are never reinserted; matching descendants become roots,
   exactly as in `tbd list --pretty`.
 - Expanded updated beads show 80-character middle-ellipsis previews for each scalar

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -134,11 +134,11 @@
   centralized engine configuration backed by the existing `yaml` package and rejects
   explicit non-YAML language markers before parser dispatch.
   This preserves gray-matter’s delimiter behavior, keeps date-looking YAML scalars as
-  strings, keeps its default `js-yaml` resolver out of every tbd parsing path, and makes
-  the library’s built-in JavaScript evaluator unreachable from synchronized issue or
-  document files. The shipped `gray-matter → js-yaml` advisory is availability-only and
-  remains visible to package audits, but its vulnerable `!!omap` resolver is not
-  reachable through tbd.
+  strings across LF and CRLF checkouts, keeps its default `js-yaml` resolver out of
+  every tbd parsing path, and makes the library’s built-in JavaScript evaluator
+  unreachable from synchronized issue or document files.
+  The shipped `gray-matter → js-yaml` advisory is availability-only and remains visible
+  to package audits, but its vulnerable `!!omap` resolver is not reachable through tbd.
 
 ## 0.4.2
 

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -130,6 +130,15 @@
   accepts no mutation route, never performs network synchronization, serves a
   restrictive Content Security Policy, caps SSE frames and replay buffers, drops
   backpressured clients, and closes open streams on a bounded shutdown.
+- **YAML-only front-matter boundary**: every tbd gray-matter call now uses one
+  centralized engine configuration backed by the existing `yaml` package and rejects
+  explicit non-YAML language markers before parser dispatch.
+  This preserves gray-matter’s delimiter behavior, keeps date-looking YAML scalars as
+  strings, keeps its default `js-yaml` resolver out of every tbd parsing path, and makes
+  the library’s built-in JavaScript evaluator unreachable from synchronized issue or
+  document files. The shipped `gray-matter → js-yaml` advisory is availability-only and
+  remains visible to package audits, but its vulnerable `!!omap` resolver is not
+  reachable through tbd.
 
 ## 0.4.2
 

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -24,12 +24,17 @@
   The page and startup output explicitly identify it as a viewer, not an editor.
   It never contacts a remote; ordinary `tbd sync` remains the explicit
   fetch/merge/publish contract, and its local result appears automatically.
-  Its filters, sorting, readiness rules, hierarchy, statistics, and displayed command
-  line come from the same implementations as the CLI. Native filesystem events normally
-  redraw immediately; a one-second constant-size metadata check repairs missed events
-  without reloading an unchanged graph.
+  Its filters, default priority order, readiness rules, hierarchy, statistics, and
+  displayed command line come from the same implementations as the CLI; browser-only
+  column composition is identified as inexact beside that command.
+  Native filesystem events normally redraw immediately; a one-second constant-size
+  metadata check repairs missed events without reloading an unchanged graph.
   The client lazy-loads bead bodies and bounds requests and rendered rows for large
-  repositories. `--open` is opt-in; JSON and dry-run modes support agents and CI.
+  repositories. Counted multi-label filtering, relative update ages, four-line collapsed
+  titles, and composable sortable column headers keep dense boards scannable; entering a
+  global column sort switches from the hierarchy to a flat view, and Pretty restores the
+  CLI tree and default priority order.
+  `--open` is opt-in; JSON and dry-run modes support agents and CI.
 
 ### Documentation
 

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -32,8 +32,13 @@
   The client lazy-loads bead bodies and bounds requests and rendered rows for large
   repositories. Counted multi-label filtering, relative update ages, four-line collapsed
   titles, and composable sortable column headers keep dense boards scannable.
+  Label-menu search drafts survive live rerenders, and Home/End retain native
+  text-editing behavior while the search field owns focus.
   Sorting never disables Pretty: it reorders outermost tree groups while official child
   order remains intact; flat mode applies the same stack to individual rows.
+  An optional repository-or-subdirectory path makes the viewer usable from any working
+  directory. Initialized repositories with zero beads render a normal empty board;
+  missing or uninitialized bases fail with the standard clear CLI errors.
   `--open` is opt-in; JSON and dry-run modes support agents and CI.
 
 ### Documentation

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -31,9 +31,9 @@
   metadata check repairs missed events without reloading an unchanged graph.
   The client lazy-loads bead bodies and bounds requests and rendered rows for large
   repositories. Counted multi-label filtering, relative update ages, four-line collapsed
-  titles, and composable sortable column headers keep dense boards scannable; entering a
-  global column sort switches from the hierarchy to a flat view, and Pretty restores the
-  CLI tree and default priority order.
+  titles, and composable sortable column headers keep dense boards scannable.
+  Sorting never disables Pretty: it reorders outermost tree groups while official child
+  order remains intact; flat mode applies the same stack to individual rows.
   `--open` is opt-in; JSON and dry-run modes support agents and CI.
 
 ### Documentation
@@ -142,6 +142,9 @@
   strings across LF and CRLF checkouts, keeps its default `js-yaml` resolver out of
   every tbd parsing path, and makes the library’s built-in JavaScript evaluator
   unreachable from synchronized issue or document files.
+  On document and skill paths, YAML 1.2 keeps date-looking and sexagesimal-looking
+  scalars as strings, interprets leading-zero integers as decimal rather than legacy
+  octal, and continues to keep `yes`/`no`/`on`/`off` as strings.
   The shipped `gray-matter → js-yaml` advisory is availability-only and remains visible
   to package audits, but its vulnerable `!!omap` resolver is not reachable through tbd.
 

--- a/packages/tbd/docs/guidelines/typescript-yaml-handling-rules.md
+++ b/packages/tbd/docs/guidelines/typescript-yaml-handling-rules.md
@@ -7,10 +7,9 @@ category: typescript
 ---
 # TypeScript YAML Handling Rules
 
-**Last Updated**: 2026-05-21
+**Last Updated**: 2026-08-12
 
-**Tracks**: `yaml@^2.8.4` (latest stable; 2026-05-02). The `yaml@3.0.0-1` release is
-tagged `next` (pre-release)—do not adopt yet.
+**Tracks**: `yaml` 2.x. Follow the package-age rule before adopting a newer release.
 Zod 4.x is the recommended validation companion.
 
 **Related**:
@@ -180,13 +179,43 @@ const config = ConfigSchema.parse(parse(content));
 import matter from 'gray-matter';
 const output = matter.stringify(body, frontmatter);
 
-// Good: Use gray-matter for parsing, yaml package for serialization
+// Good: Centralize gray-matter and route both parsing and serialization through yaml
 import matter from 'gray-matter';
+import { parse } from 'yaml';
 import { stringifyYaml } from './yaml-utils.js';
 
-const { data, content } = matter(input);
+const matterOptions = {
+  engines: {
+    yaml: {
+      parse,
+      stringify: stringifyYaml,
+    },
+  },
+};
+
+function parseMarkdownMatter(input: string) {
+  if (matter.test(input, matterOptions)) {
+    const language = matter.language(input, matterOptions).name.toLowerCase();
+    if (language !== '' && language !== 'yaml' && language !== 'yml') {
+      throw new Error(`Unsupported front-matter language: ${language}`);
+    }
+  }
+  return matter(input, matterOptions);
+}
+
+const { data, content } = parseMarkdownMatter(input);
 const output = `---\n${stringifyYaml(data)}---\n\n${content}`;
 ```
+
+Keep this option object and the gray-matter call in one wrapper module.
+Direct calls silently fall back to gray-matter’s legacy `js-yaml` engine, which changes
+YAML semantics such as converting date-looking scalars to `Date` objects and can
+reintroduce advisories in that transitive parser.
+gray-matter also includes a JavaScript engine that evaluates explicit `---javascript`
+front matter; a YAML-only application must reject non-YAML language markers before
+calling gray-matter.
+A wrapper preserves gray-matter’s delimiter handling without allowing call sites to
+select inconsistent YAML engines.
 
 ## Testing YAML Output
 

--- a/packages/tbd/docs/guidelines/typescript-yaml-handling-rules.md
+++ b/packages/tbd/docs/guidelines/typescript-yaml-handling-rules.md
@@ -187,7 +187,7 @@ import { stringifyYaml } from './yaml-utils.js';
 const matterOptions = {
   engines: {
     yaml: {
-      parse,
+      parse: (input: string) => parse(input.replace(/\r\n?/g, '\n')),
       stringify: stringifyYaml,
     },
   },
@@ -214,6 +214,10 @@ reintroduce advisories in that transitive parser.
 gray-matter also includes a JavaScript engine that evaluates explicit `---javascript`
 front matter; a YAML-only application must reject non-YAML language markers before
 calling gray-matter.
+A gray-matter closing delimiter on CRLF input can leave the preceding carriage return in
+the extracted YAML block.
+Normalize line endings in the engine input, not the Markdown body, so final plain
+scalars stay exact without rewriting body bytes.
 A wrapper preserves gray-matter’s delimiter handling without allowing call sites to
 select inconsistent YAML engines.
 

--- a/packages/tbd/docs/shortcuts/standard/welcome-user.md
+++ b/packages/tbd/docs/shortcuts/standard/welcome-user.md
@@ -60,6 +60,9 @@ Here are examples of things you can say and what happens:
 | “Track this as a task” | Creates a task bead (`tbd create`) |
 | “Show my beads in a browser” | Opens the live, read-only viewer (`tbd web --open`) |
 
+For a project outside the agent’s current working directory, it can use
+`tbd web <path> --open`; the path may be the repository or one of its subdirectories.
+
 ### Shortcuts and Workflows
 
 | What You Can Say | What Happens |

--- a/packages/tbd/docs/shortcuts/system/skill-baseline.md
+++ b/packages/tbd/docs/shortcuts/system/skill-baseline.md
@@ -51,6 +51,8 @@ That’s your job.
 **Live browser requests:** When the user asks to see, show, open, or view beads in a
 browser, start `tbd web --open` yourself with the agent platform’s long-running process
 facility. Do not merely print the command.
+If the requested project is outside your current working directory, start
+`tbd web <path> --open`; the path may be its repository root or any subdirectory.
 Wait for the startup descriptor, give the user its loopback URL, and leave the process
 running until they ask you to stop it or the session environment requires cleanup.
 

--- a/packages/tbd/docs/shortcuts/system/skill-brief.md
+++ b/packages/tbd/docs/shortcuts/system/skill-brief.md
@@ -15,6 +15,8 @@ Users speak naturally; you run tbd for them rather than returning commands for t
 execute. For “Show my beads in a browser,” start `tbd web --open` with the agent
 platform’s long-running process facility, wait for its loopback URL, report that URL,
 and keep the process running.
+For a project outside the current working directory, use `tbd web <path> --open`; the
+path may be the repository or one of its subdirectories.
 The browser is a live, read-only viewer, not an editor.
 Make every bead change yourself with ordinary `tbd` commands; the page updates from the
 resulting local state.

--- a/packages/tbd/docs/shortcuts/system/skill-minimal.md
+++ b/packages/tbd/docs/shortcuts/system/skill-minimal.md
@@ -19,6 +19,8 @@ tbd helps humans and agents ship code with greater speed, quality, and disciplin
 Users speak naturally; run tbd commands for them rather than telling them what to run.
 For “Show my beads in a browser,” start `tbd web --open`, wait for its loopback URL,
 report that URL, and keep the long-running process alive.
+For a project outside the current working directory, use `tbd web <path> --open`; the
+path may be the repository or one of its subdirectories.
 The browser is a live, read-only viewer, not an editor.
 Make requested changes yourself with ordinary `tbd` commands; the page updates from
 local state. Never sync merely because the viewer started.

--- a/packages/tbd/docs/tbd-design.md
+++ b/packages/tbd/docs/tbd-design.md
@@ -4083,7 +4083,16 @@ Board queries run against one in-memory snapshot and call the shared `selectIssu
 `describeQuery` functions.
 Responses include the equivalent CLI invocation and carry light rows only; descriptions
 and notes are fetched per bead when expanded.
-Liveness is strictly local.
+The response also carries at most 32 label facets ranked by bead count and name, while
+retaining selected values within that bound.
+Repeated labels keep the CLI’s AND semantics.
+The client clamps collapsed titles at four lines, renders exact-hover relative update
+ages, and exposes every data column as an ordered sort key.
+The newest clicked key is primary and earlier keys remain tie-breakers.
+Since global order and parent-first tree order cannot both hold, column sorting selects
+the flat list; selecting Pretty clears the custom stack and restores the CLI hierarchy
+and priority order. These component and semantic rules are maintained in the co-located
+design-system inventory in `src/web/styles.css`. Liveness is strictly local.
 A recursive Node `fs.watch` over the hidden data-sync worktree maps to native
 operating-system notifications on supported local filesystems.
 Events are trailing-debounced and trigger one serialized snapshot reload.

--- a/packages/tbd/docs/tbd-design.md
+++ b/packages/tbd/docs/tbd-design.md
@@ -4089,10 +4089,13 @@ Rows expose the derived state as quiet unboxed text after their real labels; it 
 useful scan information, but is neither a lifecycle status nor a user label and must not
 be styled as either.
 The response carries conditional Status, Type, and Priority facets plus at most 32 label
-facets.
-Every tally applies search and all other active dimensions; unselected zero-count
-values are omitted. Label candidates additionally apply every selected label, retaining
-selected values for removal and preserving the CLI’s repeated-label AND semantics.
+facets per response.
+An empty label search returns the highest-ranked choices; a search queries the complete
+label vocabulary before applying the response cap, so every label remains reachable.
+Every tally applies search and all other active dimensions; unselected zero-count values
+are omitted.
+Label candidates additionally apply every selected label, retaining selected
+values for removal and preserving the CLI’s repeated-label AND semantics.
 The client clamps collapsed titles at four lines, renders sans relative update ages with
 exact literal tooltips, and exposes every data column as an ordered sort key.
 The default is Pretty with Updated descending then Priority ascending.
@@ -4105,7 +4108,9 @@ The browser deliberately uses a simpler visual grammar than terminal tree output
 non-root row has exactly one `└──` elbow at its hierarchy indentation, with spaces for
 ancestor levels and no tee or vertical-bar variants.
 Flat mode applies the stack globally.
-Reset restores the complete default.
+Reset restores the default sort stack without changing Pretty.
+Because browser ordering is not an exact CLI filter, the response supplies a concise
+ordering caveat beside the equivalent command.
 Pretty never reinserts a bead excluded by Status, labels, search, or another filter; a
 matching descendant whose parent is absent becomes a root, exactly as in
 `tbd list --pretty`.
@@ -4114,6 +4119,13 @@ Expanded updated beads show field deltas with an 80-character middle-ellipsis pr
 per scalar side. Copy preserves the bounded full values, before is muted historical
 context, and after uses normal text.
 Created beads omit null-to-current-value deltas as redundant with the expanded body.
+The client delegates row expansion to one table-body listener and ignores clicks that
+finish a non-collapsed text selection.
+Each render restores keyboard focus by stable bead ID and control role, or by label
+value inside the chooser.
+A failed board refresh keeps the last successful rows visible and changes the persistent
+observer indicator to an error state until a successful response clears it.
+Render completion also dismisses any tooltip whose anchor was replaced.
 These component and semantic rules are maintained in the co-located design-system
 inventory in `src/web/styles.css`. Status-panel field names use standard-size sans
 chrome and literal values use standard-size monospace; neither side shrinks merely

--- a/packages/tbd/docs/tbd-design.md
+++ b/packages/tbd/docs/tbd-design.md
@@ -4083,16 +4083,39 @@ Board queries run against one in-memory snapshot and call the shared `selectIssu
 `describeQuery` functions.
 Responses include the equivalent CLI invocation and carry light rows only; descriptions
 and notes are fetched per bead when expanded.
-The response also carries at most 32 label facets ranked by bead count and name, while
-retaining selected values within that bound.
-Repeated labels keep the CLI’s AND semantics.
-The client clamps collapsed titles at four lines, renders exact-hover relative update
-ages, and exposes every data column as an ordered sort key.
-The newest clicked key is primary and earlier keys remain tie-breakers.
-Since global order and parent-first tree order cannot both hold, column sorting selects
-the flat list; selecting Pretty clears the custom stack and restores the CLI hierarchy
-and priority order. These component and semantic rules are maintained in the co-located
-design-system inventory in `src/web/styles.css`. Liveness is strictly local.
+Ready retains one definition on every surface: open, unassigned, and without an open
+blocker. The checkbox selects that exact `tbd ready` set.
+Rows expose the derived state as quiet unboxed text after their real labels; it is
+useful scan information, but is neither a lifecycle status nor a user label and must not
+be styled as either.
+The response carries conditional Status, Type, and Priority facets plus at most 32 label
+facets.
+Every tally applies search and all other active dimensions; unselected zero-count
+values are omitted. Label candidates additionally apply every selected label, retaining
+selected values for removal and preserving the CLI’s repeated-label AND semantics.
+The client clamps collapsed titles at four lines, renders sans relative update ages with
+exact literal tooltips, and exposes every data column as an ordered sort key.
+The default is Pretty with Updated descending then Priority ascending.
+The newest clicked key is primary, only the prior primary remains as a tie-breaker, and
+sorting never clears Pretty.
+In Pretty, the stack orders only outermost visible parent groups; Updated compares the
+maximum timestamp across each entire visible subtree for every parent kind, while
+children retain `child_order_hints` order and its deterministic fallback.
+Flat mode applies the stack globally.
+Reset restores the complete default.
+Pretty never reinserts a bead excluded by Status, labels, search, or another filter; a
+matching descendant whose parent is absent becomes a root, exactly as in
+`tbd list --pretty`.
+
+Expanded updated beads show field deltas with an 80-character middle-ellipsis preview
+per scalar side. Copy preserves the bounded full values, before is muted historical
+context, and after uses normal text.
+Created beads omit null-to-current-value deltas as redundant with the expanded body.
+These component and semantic rules are maintained in the co-located design-system
+inventory in `src/web/styles.css`. Status-panel field names use standard-size sans
+chrome and literal values use standard-size monospace; neither side shrinks merely
+because the panel is narrow.
+Liveness is strictly local.
 A recursive Node `fs.watch` over the hidden data-sync worktree maps to native
 operating-system notifications on supported local filesystems.
 Events are trailing-debounced and trigger one serialized snapshot reload.
@@ -4367,8 +4390,7 @@ canonical board state at the same version after a bounded event frame, and accep
 restarted observer’s lower counters.
 A delayed duplicate event at an already-adopted version cannot replace that canonical
 state. Board responses carry at most 10,000 light rows and retain the full match count
-when truncated. Pretty-tree context metadata is derived from those returned rows, so it
-cannot name or serialize context that was cut off by the response ceiling.
+when truncated. Pretty never bypasses filters by serializing ancestors as extra context.
 The browser renders those rows in 5,000-row pages, exposes sticky and end-of-page
 navigation, and allows bulk detail expansion only when 100 rows or fewer are visible on
 the page. This threshold is empirical rather than round-number preference: a production

--- a/packages/tbd/docs/tbd-design.md
+++ b/packages/tbd/docs/tbd-design.md
@@ -4101,6 +4101,9 @@ sorting never clears Pretty.
 In Pretty, the stack orders only outermost visible parent groups; Updated compares the
 maximum timestamp across each entire visible subtree for every parent kind, while
 children retain `child_order_hints` order and its deterministic fallback.
+The browser deliberately uses a simpler visual grammar than terminal tree output: every
+non-root row has exactly one `└──` elbow at its hierarchy indentation, with spaces for
+ancestor levels and no tee or vertical-bar variants.
 Flat mode applies the stack globally.
 Reset restores the complete default.
 Pretty never reinserts a bead excluded by Status, labels, search, or another filter; a

--- a/packages/tbd/docs/tbd-design.md
+++ b/packages/tbd/docs/tbd-design.md
@@ -4070,8 +4070,16 @@ local state. The server is therefore a presentation surface, not an editor or an
 alternate agent API.
 
 ```bash
-tbd web [--port <n>] [--open]
+tbd web [path] [--port <n>] [--open]
 ```
+
+The optional path is a repository or any subdirectory within it and is resolved from the
+caller’s current directory to a canonical repository root before startup.
+Omitting it preserves the normal current-directory discovery contract.
+An initialized repository with no beads is a valid empty snapshot.
+Missing/non-directory paths are usage errors; existing paths without tbd metadata flow
+through the shared `requireInit` error path so `web` does not invent a different
+repository contract.
 
 The server binds only `127.0.0.1`. With no explicit port it searches the bounded range
 7777–7786; `--port` pins one port, and `--open` launches a browser only after an HTTP
@@ -4092,6 +4100,10 @@ The response carries conditional Status, Type, and Priority facets plus at most 
 facets per response.
 An empty label search returns the highest-ranked choices; a search queries the complete
 label vocabulary before applying the response cap, so every label remains reachable.
+While the search field owns focus, its live draft remains authoritative across observer
+and request renders until the debounce publishes it.
+Home and End retain native caret movement there; the same keys navigate to the first and
+last choices only when focus is elsewhere in the menu.
 Every tally applies search and all other active dimensions; unselected zero-count values
 are omitted.
 Label candidates additionally apply every selected label, retaining selected

--- a/packages/tbd/docs/tbd-design.md
+++ b/packages/tbd/docs/tbd-design.md
@@ -5621,7 +5621,9 @@ We adopt this approach.
 
 **Mitigations**:
 
-- Use established libraries (gray-matter, js-yaml)
+- Use gray-matter for front-matter delimiters and the `yaml` package for all YAML
+  parsing and serialization, behind one wrapper that rejects non-YAML language markers
+  before gray-matter can select its built-in JavaScript evaluator
 
 - Canonical serialization rules ensure consistency
 

--- a/packages/tbd/docs/tbd-docs.md
+++ b/packages/tbd/docs/tbd-docs.md
@@ -665,9 +665,19 @@ in-session Claude Code and Codex patterns.
 ### web
 
 Serve a live, read-only view of the bead graph in a local browser.
-The page uses the same local bead state, filters, default sorting, readiness rules,
-hierarchy, and statistics as the CLI, and displays the equivalent `tbd list` or
-`tbd ready` command for the current view.
+The page uses the same local bead state, filter semantics, readiness rules, hierarchy,
+and statistics as the CLI, and displays the equivalent `tbd list` or `tbd ready` command
+for the current view.
+The Ready checkbox is the exact `tbd ready` predicate—open, unassigned, and with no open
+blocker. A quiet unboxed row marker exposes that derived state while scanning; it is
+intentionally distinct from user labels.
+Pretty is on by default and never changes when a column sort changes.
+In Pretty mode, the two-key sort moves only outermost visible parent groups.
+Updated is rolled up to the latest timestamp in each complete visible subtree for every
+parent kind; children keep their official `child_order_hints` order.
+Flat mode applies the stack to individual rows.
+Filters remain exact in both modes: a filtered-out parent is not reinserted, and a
+matching child simply becomes a root.
 Browser-only column composition is identified as inexact beside that command.
 In an agent session, ask naturally: “Show my beads in a browser.”
 The agent should run `tbd web --open`, wait for the startup URL, give you that URL, and
@@ -678,6 +688,15 @@ with ordinary `tbd` commands, and their local results appear automatically.
 It never contacts a remote.
 Run the ordinary `tbd sync` command when you want to fetch, merge, or publish bead
 state; the page observes the resulting local changes automatically.
+
+Expanded updated beads show compact field deltas.
+Each scalar before/after side uses an 80-character middle-ellipsis preview so both the
+start and appended tail remain useful; the copy control retains the bounded full values.
+Historical before text is muted and the after text is normal.
+Newly created beads omit the redundant null-to-current-value delta because their
+expanded body already shows the current data.
+Status-panel field names use normal-size sans text, and literal values use normal-size
+monospace, keeping their baseline readable and consistent with board rows.
 
 ```bash
 tbd web                         # Serve on the first free port in 7777-7786
@@ -726,16 +745,22 @@ Descriptions and notes load only when a row is expanded, so the board remains bo
 large repositories. A response can carry up to 10,000 rows; the browser paints them in
 5,000-row pages with sticky and end-of-page navigation.
 Above 10,000 rows, the page reports the complete count and asks for a narrower query.
-The label chooser ranks the 32 most common labels by bead count and preserves the CLI’s
-AND semantics for repeated `--label` filters.
+Status, Type, Priority, and the bounded 32-label chooser show conditional tallies after
+every other active filter.
+Unselected zero-count choices are hidden; a selected zero-count value remains visible so
+it can be removed. Label candidates additionally show the next repeated-label
+intersection and preserve the CLI’s AND semantics.
 Collapsed titles use at most four lines and expand in full.
-The Updated column shows a compact relative age in monospace and exposes the exact
-timestamp on hover. Every data-column header is sortable.
-A click makes that column primary and retains prior columns as ordered tie-breakers;
-clicking the current primary reverses it.
-Global column ordering is a flat-table operation, so it clears Pretty.
-Re-enabling Pretty clears the custom sort stack and restores the CLI hierarchy and
-default priority order.
+The Updated column shows a compact sans relative age and exposes the exact monospace ISO
+timestamp in the shared fast tooltip.
+Every data-column header is sortable.
+Pretty is enabled by default with Updated descending, then Priority ascending.
+A click makes that column primary and retains only the previous primary as its
+tie-breaker; clicking the current primary reverses it without changing Pretty.
+Pretty moves whole outermost visible groups, rolling Updated up from every visible
+descendant while retaining official child order.
+Flat mode applies the stack to rows.
+Reset sort restores Pretty and the default two-key stack.
 Changing a query control, display mode, or page closes expanded details.
 A live graph update retains and remaps an expansion only while that bead remains in the
 current bounded response, so an off-board or obsolete display ID cannot consume the

--- a/packages/tbd/docs/tbd-docs.md
+++ b/packages/tbd/docs/tbd-docs.md
@@ -703,6 +703,7 @@ monospace, keeping their baseline readable and consistent with board rows.
 ```bash
 tbd web                         # Serve on the first free port in 7777-7786
 tbd web --open                  # Open the page after it is HTTP-ready
+tbd web ../another-repo --open  # View a repository from another directory
 tbd web --port 9000             # Bind exactly 127.0.0.1:9000
 tbd --json web                  # Print the machine-readable startup descriptor
 tbd --dry-run web               # Resolve the repo and port without binding
@@ -710,15 +711,23 @@ tbd --dry-run web               # Resolve the repo and port without binding
 
 Options:
 
+- `[path]` - Resolve this repository or subdirectory instead of the current directory.
+  Relative paths are resolved from the caller’s current directory; the startup
+  descriptor reports the canonical repository root.
+
 - `--port <n>` - Bind exactly this loopback port.
   Without it, tbd searches the bounded range 7777-7786 and reports the port it selected.
+
 - `--open` - Open the default browser after the page passes an HTTP readiness check.
   The default is not to launch a browser, which is safe for agents and CI.
 
 The command stays in the foreground; press Ctrl+C to stop it.
-SIGINT exits 130 and a normal or SIGTERM shutdown exits 0. It binds only `127.0.0.1`,
-exposes no write route, and serves one self-contained page with same-origin and
-security-header checks.
+An initialized repository with zero beads is valid and renders the ordinary empty board.
+A missing or non-directory path is a usage error; an existing directory outside an
+initialized tbd repository reports the standard “Not a tbd repository” error used by
+other commands. SIGINT exits 130 and a normal or SIGTERM shutdown exits 0. It binds only
+`127.0.0.1`, exposes no write route, and serves one self-contained page with same-origin
+and security-header checks.
 It is a local development and observation surface, not a remotely reachable service.
 
 The browser opens its live event stream before loading the board and refreshes whenever
@@ -750,6 +759,8 @@ Above 10,000 rows, the page reports the complete count and asks for a narrower q
 Status, Type, Priority, and the label chooser show conditional tallies after every other
 active filter. The menu shows up to 32 labels at once; its search field queries the
 complete label vocabulary and retains selected labels.
+Typing is stable across live updates; Home and End move the search caret while that
+field has focus and navigate the choices otherwise.
 Unselected zero-count choices are hidden; a selected zero-count value remains visible so
 it can be removed. Label candidates additionally show the next repeated-label
 intersection and preserve the CLI’s AND semantics.

--- a/packages/tbd/docs/tbd-docs.md
+++ b/packages/tbd/docs/tbd-docs.md
@@ -665,9 +665,10 @@ in-session Claude Code and Codex patterns.
 ### web
 
 Serve a live, read-only view of the bead graph in a local browser.
-The page uses the same local bead state, filters, sorting, readiness rules, hierarchy,
-and statistics as the CLI, and displays the equivalent `tbd list` or `tbd ready` command
-for the current view.
+The page uses the same local bead state, filters, default sorting, readiness rules,
+hierarchy, and statistics as the CLI, and displays the equivalent `tbd list` or
+`tbd ready` command for the current view.
+Browser-only column composition is identified as inexact beside that command.
 In an agent session, ask naturally: “Show my beads in a browser.”
 The agent should run `tbd web --open`, wait for the startup URL, give you that URL, and
 keep the foreground process alive.
@@ -725,6 +726,16 @@ Descriptions and notes load only when a row is expanded, so the board remains bo
 large repositories. A response can carry up to 10,000 rows; the browser paints them in
 5,000-row pages with sticky and end-of-page navigation.
 Above 10,000 rows, the page reports the complete count and asks for a narrower query.
+The label chooser ranks the 32 most common labels by bead count and preserves the CLI’s
+AND semantics for repeated `--label` filters.
+Collapsed titles use at most four lines and expand in full.
+The Updated column shows a compact relative age in monospace and exposes the exact
+timestamp on hover. Every data-column header is sortable.
+A click makes that column primary and retains prior columns as ordered tie-breakers;
+clicking the current primary reverses it.
+Global column ordering is a flat-table operation, so it clears Pretty.
+Re-enabling Pretty clears the custom sort stack and restores the CLI hierarchy and
+default priority order.
 Changing a query control, display mode, or page closes expanded details.
 A live graph update retains and remaps an expansion only while that bead remains in the
 current bounded response, so an off-board or obsolete display ID cannot consume the

--- a/packages/tbd/docs/tbd-docs.md
+++ b/packages/tbd/docs/tbd-docs.md
@@ -675,6 +675,8 @@ Pretty is on by default and never changes when a column sort changes.
 In Pretty mode, the two-key sort moves only outermost visible parent groups.
 Updated is rolled up to the latest timestamp in each complete visible subtree for every
 parent kind; children keep their official `child_order_hints` order.
+Every non-root browser row uses one `└──` elbow at its hierarchy indentation.
+Deeper levels use spaces instead of ancestor bars, and siblings never switch to a tee.
 Flat mode applies the stack to individual rows.
 Filters remain exact in both modes: a filtered-out parent is not reinserted, and a
 matching child simply becomes a root.

--- a/packages/tbd/docs/tbd-docs.md
+++ b/packages/tbd/docs/tbd-docs.md
@@ -747,8 +747,9 @@ Descriptions and notes load only when a row is expanded, so the board remains bo
 large repositories. A response can carry up to 10,000 rows; the browser paints them in
 5,000-row pages with sticky and end-of-page navigation.
 Above 10,000 rows, the page reports the complete count and asks for a narrower query.
-Status, Type, Priority, and the bounded 32-label chooser show conditional tallies after
-every other active filter.
+Status, Type, Priority, and the label chooser show conditional tallies after every other
+active filter. The menu shows up to 32 labels at once; its search field queries the
+complete label vocabulary and retains selected labels.
 Unselected zero-count choices are hidden; a selected zero-count value remains visible so
 it can be removed. Label candidates additionally show the next repeated-label
 intersection and preserve the CLI’s AND semantics.
@@ -762,7 +763,9 @@ tie-breaker; clicking the current primary reverses it without changing Pretty.
 Pretty moves whole outermost visible groups, rolling Updated up from every visible
 descendant while retaining official child order.
 Flat mode applies the stack to rows.
-Reset sort restores Pretty and the default two-key stack.
+Reset sort restores the default two-key stack without changing Pretty.
+The equivalent-command tooltip names browser-only ordering that the displayed CLI
+command does not reproduce.
 Changing a query control, display mode, or page closes expanded details.
 A live graph update retains and remaps an expansion only while that bead remains in the
 current bounded response, so an off-board or obsolete display ID cannot consume the

--- a/packages/tbd/src/cli/commands/web.ts
+++ b/packages/tbd/src/cli/commands/web.ts
@@ -1,6 +1,8 @@
 /** `tbd web` - serve the local bead graph on loopback until interrupted. */
 
 import { Command } from 'commander';
+import { realpath, stat } from 'node:fs/promises';
+import { resolve } from 'node:path';
 
 import { readConfig } from '../../file/config.js';
 import type { OperationLogger } from '../../lib/types.js';
@@ -38,10 +40,35 @@ function parsePort(value: string | undefined): number | undefined {
   return port;
 }
 
+async function resolveBaseDirectory(value: string | undefined): Promise<string> {
+  const requested = resolve(value ?? '.');
+  try {
+    const canonical = await realpath(requested);
+    if (!(await stat(canonical)).isDirectory()) {
+      throw new ValidationError(`Base path is not a directory: ${requested}`);
+    }
+    return canonical;
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      throw error;
+    }
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error.code === 'ENOENT' || error.code === 'ENOTDIR')
+    ) {
+      throw new ValidationError(`Base directory does not exist: ${requested}`);
+    }
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new ValidationError(`Cannot access base directory ${requested}: ${detail}`);
+  }
+}
+
 class WebHandler extends BaseCommand {
-  async run(options: WebOptions): Promise<void> {
+  async run(baseDir: string | undefined, options: WebOptions): Promise<void> {
     const port = parsePort(options.port);
-    const repo = await requireInit();
+    const repo = await requireInit(await resolveBaseDirectory(baseDir));
     const serverModule = await import('../web/server.js');
 
     if (this.ctx.dryRun) {
@@ -173,9 +200,10 @@ class WebHandler extends BaseCommand {
 
 export const webCommand = new Command('web')
   .description('Serve a live, read-only bead view on loopback')
+  .argument('[path]', 'Repository or subdirectory to view (default: current directory)')
   .option('--port <n>', 'Bind exactly this loopback port (default: search from 7777)')
   .option('--open', 'Open the page in the default browser after HTTP readiness')
-  .action(async (options, command) => {
+  .action(async (path: string | undefined, options: WebOptions, command: Command) => {
     const handler = new WebHandler(command);
-    await handler.run(options);
+    await handler.run(path, options);
   });

--- a/packages/tbd/src/cli/web/board.ts
+++ b/packages/tbd/src/cli/web/board.ts
@@ -71,6 +71,7 @@ export interface BoardRow {
   spec_path: string | null;
   assignee: string | null;
   ready: boolean;
+  updated_at: string;
   /** Tree guide string, empty in flat mode. */
   prefix: string;
 }
@@ -984,6 +985,7 @@ export class BoardState {
       spec_path: issue.spec_path ?? null,
       assignee: issue.assignee ?? null,
       ready: this.snapshot.readyIds.has(issue.id),
+      updated_at: issue.updated_at,
       prefix,
     };
   }

--- a/packages/tbd/src/cli/web/board.ts
+++ b/packages/tbd/src/cli/web/board.ts
@@ -206,6 +206,7 @@ export interface BoardResponse {
   kindFacets: ValueFacet<IssueKindType>[];
   priorityFacets: ValueFacet<number>[];
   labelFacets: LabelFacet[];
+  orderingCaveat: string | null;
   rows: BoardRow[];
   truncated: number;
   state: WebState;
@@ -235,6 +236,7 @@ interface ParsedBoardQuery {
   parentDisplayId: string | null;
   pretty: boolean;
   search: string;
+  labelSearch: string;
   sorts: BoardSort[];
 }
 
@@ -547,8 +549,27 @@ function parseBoardQuery(params: URLSearchParams, context: TbdDataContext): Pars
     parentDisplayId,
     pretty: flag(params, 'pretty'),
     search: params.get('q')?.trim() ?? '',
+    labelSearch: params.get('labelq')?.trim() ?? '',
     sorts: parseBoardSorts(params),
   };
+}
+
+function describeBoardOrdering(sorts: readonly BoardSort[], pretty: boolean): string | null {
+  if (sorts.length === 0) {
+    return null;
+  }
+  const title = (key: BoardSortKey): string =>
+    key === 'id' ? 'ID' : `${key[0]!.toUpperCase()}${key.slice(1)}`;
+  const stack = sorts
+    .map((sort) => `${title(sort.key)} ${sort.direction === 'asc' ? '↑' : '↓'}`)
+    .join(' then ');
+  if (!pretty) {
+    return `Browser column sort: ${stack}; flat mode applies the stack to individual rows`;
+  }
+  const groupRule = sorts.some((sort) => sort.key === 'updated')
+    ? "Pretty orders outermost groups by each visible subtree's latest update and keeps children in official order"
+    : 'Pretty orders outermost groups and keeps children in official order';
+  return `Browser column sort: ${stack}; ${groupRule}`;
 }
 
 function compareText(left: string, right: string): number {
@@ -727,11 +748,12 @@ export class BoardState {
     const prettySupported = !pretty || !parsed.query.ready;
     const command =
       pretty && !parsed.query.ready ? `${described.command} --pretty` : described.command;
-    const filtersExact = described.exact && prettySupported && parsed.sorts.length === 0;
+    const filtersExact = described.exact && prettySupported;
 
     return {
       command,
-      commandExact: filtersExact && parsed.search === '' && truncated === 0,
+      commandExact:
+        filtersExact && parsed.sorts.length === 0 && parsed.search === '' && truncated === 0,
       filtersExact,
       search: parsed.search,
       total: this.snapshot.issues.length,
@@ -744,7 +766,8 @@ export class BoardState {
         PRIORITY_VALUES,
         (issue) => issue.priority,
       ),
-      labelFacets: this.buildLabelFacets(labelFacetPool, parsed.query.labels),
+      labelFacets: this.buildLabelFacets(labelFacetPool, parsed.query.labels, parsed.labelSearch),
+      orderingCaveat: describeBoardOrdering(parsed.sorts, pretty),
       rows: responseRows,
       truncated,
       state,
@@ -1092,6 +1115,7 @@ export class BoardState {
   private buildLabelFacets(
     candidates: readonly Issue[],
     selectedLabels: readonly string[],
+    labelSearch: string,
   ): LabelFacet[] {
     const selected = new Set(selectedLabels.filter(Boolean));
     const intersection = candidates.filter((issue) =>
@@ -1109,7 +1133,16 @@ export class BoardState {
     const ranked = [...counts].map(([label, count]) => ({ label, count }));
     ranked.sort((left, right) => right.count - left.count || compareText(left.label, right.label));
 
-    const kept = ranked.slice(0, MAX_LABEL_FACETS);
+    const normalizedSearch = labelSearch.normalize('NFKC').toLocaleLowerCase('en-US');
+    const discoverable =
+      normalizedSearch === ''
+        ? ranked
+        : ranked.filter(
+            (facet) =>
+              selected.has(facet.label) ||
+              facet.label.normalize('NFKC').toLocaleLowerCase('en-US').includes(normalizedSearch),
+          );
+    const kept = discoverable.slice(0, MAX_LABEL_FACETS);
     const keptLabels = new Set(kept.map((facet) => facet.label));
     const rank = new Map(ranked.map((facet, index) => [facet.label, index]));
     const selectedFacets = [...selected]

--- a/packages/tbd/src/cli/web/board.ts
+++ b/packages/tbd/src/cli/web/board.ts
@@ -67,10 +67,8 @@ const BOARD_SORT_KEYS = new Set<BoardSortKey>([
   'labels',
 ]);
 const TREE_CHARS = {
-  branch: '├── ',
-  last: '└── ',
-  vertical: '│   ',
-  space: '    ',
+  child: '└── ',
+  indent: '    ',
 } as const;
 
 export interface BoardRow {
@@ -1258,20 +1256,18 @@ export class BoardState {
     }
 
     const rows: BoardRow[] = [];
-    const walk = (node: TreeNode, prefix: string, connector: string, isLast: boolean): void => {
+    const walk = (node: TreeNode, depth: number): void => {
       const issue = issueByDisplayId.get(node.issue.id);
       if (issue !== undefined) {
-        rows.push(this.toRow(issue, prefix + connector));
+        const prefix = depth === 0 ? '' : TREE_CHARS.indent.repeat(depth - 1) + TREE_CHARS.child;
+        rows.push(this.toRow(issue, prefix));
       }
-      const childPrefix =
-        connector === '' ? '' : prefix + (isLast ? TREE_CHARS.space : TREE_CHARS.vertical);
-      node.children.forEach((child, index) => {
-        const last = index === node.children.length - 1;
-        walk(child, childPrefix, last ? TREE_CHARS.last : TREE_CHARS.branch, last);
+      node.children.forEach((child) => {
+        walk(child, depth + 1);
       });
     };
     for (const root of roots) {
-      walk(root, '', '', true);
+      walk(root, 0);
     }
     return rows;
   }

--- a/packages/tbd/src/cli/web/board.ts
+++ b/packages/tbd/src/cli/web/board.ts
@@ -39,6 +39,8 @@ import { pathExists, readMetadataMarker } from './snapshot-consistency.js';
 
 /** Hard response ceiling; the browser pages these rows into smaller render windows. */
 export const MAX_BOARD_ROWS = 10_000;
+/** Keep dynamic label menus bounded while retaining every selected value. */
+export const MAX_LABEL_FACETS = 32;
 /** Detail is diagnostic; board motion remains complete through movedIds/removedIds. */
 export const MAX_LOCAL_CHANGE_DETAILS = 100;
 export const MAX_LOCAL_CHANGE_DETAIL_BYTES = 256 * 1024;
@@ -52,6 +54,15 @@ const PUBLIC_ID = /^[A-Za-z][A-Za-z0-9._]{0,19}-[0-9a-z._-]+$/u;
 const STATUSES = new Set<IssueStatusType>(['open', 'in_progress', 'blocked', 'deferred', 'closed']);
 const KINDS = new Set<IssueKindType>(['bug', 'feature', 'task', 'epic', 'chore']);
 const SORTS = new Set<IssueSort>(['priority', 'created', 'updated']);
+const BOARD_SORT_KEYS = new Set<BoardSortKey>([
+  'id',
+  'priority',
+  'status',
+  'kind',
+  'title',
+  'updated',
+  'labels',
+]);
 const TREE_CHARS = {
   branch: '├── ',
   last: '└── ',
@@ -74,6 +85,19 @@ export interface BoardRow {
   updated_at: string;
   /** Tree guide string, empty in flat mode. */
   prefix: string;
+}
+
+export type BoardSortKey = 'id' | 'priority' | 'status' | 'kind' | 'title' | 'updated' | 'labels';
+export type BoardSortDirection = 'asc' | 'desc';
+
+export interface BoardSort {
+  key: BoardSortKey;
+  direction: BoardSortDirection;
+}
+
+export interface LabelFacet {
+  label: string;
+  count: number;
 }
 
 export interface BeadBody {
@@ -173,6 +197,7 @@ export interface BoardResponse {
   total: number;
   matched: number;
   closedHidden: number;
+  labelFacets: LabelFacet[];
   rows: BoardRow[];
   truncated: number;
   contextIds: string[];
@@ -203,6 +228,7 @@ interface ParsedBoardQuery {
   parentDisplayId: string | null;
   pretty: boolean;
   search: string;
+  sorts: BoardSort[];
 }
 
 interface BoardSnapshot {
@@ -443,6 +469,31 @@ function parseLimit(value: string | null): number | null {
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
+function parseBoardSorts(params: URLSearchParams): BoardSort[] {
+  const sorts: BoardSort[] = [];
+  const seen = new Set<BoardSortKey>();
+  for (const value of params.getAll('order')) {
+    const [rawKey, rawDirection, ...remainder] = value.split(':');
+    if (
+      remainder.length > 0 ||
+      rawKey === undefined ||
+      !BOARD_SORT_KEYS.has(rawKey as BoardSortKey) ||
+      (rawDirection !== 'asc' && rawDirection !== 'desc')
+    ) {
+      continue;
+    }
+    const key = rawKey as BoardSortKey;
+    if (!seen.has(key)) {
+      sorts.push({ key, direction: rawDirection });
+      seen.add(key);
+    }
+    if (sorts.length >= BOARD_SORT_KEYS.size) {
+      break;
+    }
+  }
+  return sorts;
+}
+
 function parseBoardQuery(params: URLSearchParams, context: TbdDataContext): ParsedBoardQuery {
   const statusValue = optional(params, 'status');
   const kindValue = optional(params, 'type');
@@ -489,7 +540,19 @@ function parseBoardQuery(params: URLSearchParams, context: TbdDataContext): Pars
     parentDisplayId,
     pretty: flag(params, 'pretty'),
     search: params.get('q')?.trim() ?? '',
+    sorts: parseBoardSorts(params),
   };
+}
+
+function compareText(left: string, right: string): number {
+  const normalizedLeft = left.normalize('NFKC').toLocaleLowerCase('en-US');
+  const normalizedRight = right.normalize('NFKC').toLocaleLowerCase('en-US');
+  if (normalizedLeft !== normalizedRight) {
+    return normalizedLeft < normalizedRight ? -1 : 1;
+  }
+  const exactLeft = left.normalize('NFKC');
+  const exactRight = right.normalize('NFKC');
+  return exactLeft < exactRight ? -1 : exactLeft > exactRight ? 1 : 0;
 }
 
 function matchesSearch(issue: Issue, displayId: string, search: string): boolean {
@@ -594,7 +657,10 @@ export class BoardState {
         parsed.search,
       ),
     );
-    const limited = parsed.query.limit === null ? selected : selected.slice(0, parsed.query.limit);
+    const orderedSelected =
+      parsed.sorts.length === 0 ? selected : this.sortIssuesByColumns(selected, parsed.sorts);
+    const limited =
+      parsed.query.limit === null ? orderedSelected : orderedSelected.slice(0, parsed.query.limit);
 
     let closedHidden = 0;
     if (!parsed.query.includeClosed && parsed.query.status !== 'closed') {
@@ -613,7 +679,8 @@ export class BoardState {
 
     let rows: BoardRow[];
     let contextIds: string[] = [];
-    if (parsed.pretty) {
+    const pretty = parsed.pretty && parsed.sorts.length === 0;
+    if (pretty) {
       const ordered = sortIssues(this.snapshot.issues, parsed.query.sort);
       const context = this.withAncestors(limited, ordered);
       rows = this.orderAsTree(context.issues);
@@ -630,10 +697,10 @@ export class BoardState {
     const truncated = rows.length > MAX_BOARD_ROWS ? rows.length : 0;
 
     const described = describeQuery(parsed.query, parsed.parentDisplayId ?? undefined);
-    const prettySupported = !parsed.pretty || !parsed.query.ready;
+    const prettySupported = !pretty || !parsed.query.ready;
     const command =
-      parsed.pretty && !parsed.query.ready ? `${described.command} --pretty` : described.command;
-    const filtersExact = described.exact && prettySupported;
+      pretty && !parsed.query.ready ? `${described.command} --pretty` : described.command;
+    const filtersExact = described.exact && prettySupported && parsed.sorts.length === 0;
 
     return {
       command,
@@ -645,6 +712,7 @@ export class BoardState {
       total: this.snapshot.issues.length,
       matched: limited.length,
       closedHidden,
+      labelFacets: this.buildLabelFacets(parsed.query.labels),
       rows: responseRows,
       truncated,
       contextIds,
@@ -988,6 +1056,87 @@ export class BoardState {
       updated_at: issue.updated_at,
       prefix,
     };
+  }
+
+  private buildLabelFacets(selectedLabels: readonly string[]): LabelFacet[] {
+    const counts = new Map<string, number>();
+    for (const issue of this.snapshot.issues) {
+      for (const label of new Set(issue.labels)) {
+        counts.set(label, (counts.get(label) ?? 0) + 1);
+      }
+    }
+    const ranked = [...counts].map(([label, count]) => ({ label, count }));
+    ranked.sort((left, right) => right.count - left.count || compareText(left.label, right.label));
+
+    const selected = new Set(selectedLabels.filter(Boolean));
+    const kept = ranked.slice(0, MAX_LABEL_FACETS);
+    const keptLabels = new Set(kept.map((facet) => facet.label));
+    const rank = new Map(ranked.map((facet, index) => [facet.label, index]));
+    const selectedFacets = [...selected]
+      .map((label) => ({ label, count: counts.get(label) ?? 0 }))
+      .sort(
+        (left, right) =>
+          (rank.get(left.label) ?? Number.MAX_SAFE_INTEGER) -
+            (rank.get(right.label) ?? Number.MAX_SAFE_INTEGER) ||
+          compareText(left.label, right.label),
+      );
+    for (const facet of selectedFacets) {
+      if (keptLabels.has(facet.label)) {
+        continue;
+      }
+      const eviction = kept.findLastIndex((candidate) => !selected.has(candidate.label));
+      if (eviction < 0) {
+        break;
+      }
+      keptLabels.delete(kept[eviction]!.label);
+      kept.splice(eviction, 1, facet);
+      keptLabels.add(facet.label);
+    }
+    kept.sort(
+      (left, right) =>
+        (rank.get(left.label) ?? Number.MAX_SAFE_INTEGER) -
+          (rank.get(right.label) ?? Number.MAX_SAFE_INTEGER) ||
+        compareText(left.label, right.label),
+    );
+    return kept;
+  }
+
+  private sortIssuesByColumns(issues: readonly Issue[], sorts: readonly BoardSort[]): Issue[] {
+    const displayId = (issue: Issue): string =>
+      this.snapshot.displayIdByInternalId.get(issue.id) ?? issue.id;
+    const labels = (issue: Issue): string => [...issue.labels].sort(compareText).join('\u0000');
+    const textValue = (issue: Issue, key: Exclude<BoardSortKey, 'priority'>): string => {
+      switch (key) {
+        case 'id':
+          return displayId(issue);
+        case 'status':
+          return issue.status;
+        case 'kind':
+          return issue.kind;
+        case 'title':
+          return issue.title;
+        case 'updated':
+          return issue.updated_at;
+        case 'labels':
+          return labels(issue);
+        default: {
+          const exhaustive: never = key;
+          throw new Error('Unsupported board sort key', { cause: exhaustive });
+        }
+      }
+    };
+    return [...issues].sort((left, right) => {
+      for (const sort of sorts) {
+        const compared =
+          sort.key === 'priority'
+            ? left.priority - right.priority
+            : compareText(textValue(left, sort.key), textValue(right, sort.key));
+        if (compared !== 0) {
+          return sort.direction === 'asc' ? compared : -compared;
+        }
+      }
+      return compareText(displayId(left), displayId(right));
+    });
   }
 
   private orderAsTree(issues: Issue[]): BoardRow[] {

--- a/packages/tbd/src/cli/web/board.ts
+++ b/packages/tbd/src/cli/web/board.ts
@@ -555,6 +555,15 @@ function compareText(left: string, right: string): number {
   return exactLeft < exactRight ? -1 : exactLeft > exactRight ? 1 : 0;
 }
 
+function compareTimestamps(left: string, right: string): number {
+  const leftTime = Date.parse(left);
+  const rightTime = Date.parse(right);
+  if (Number.isFinite(leftTime) && Number.isFinite(rightTime)) {
+    return leftTime - rightTime;
+  }
+  return compareText(left, right);
+}
+
 function matchesSearch(issue: Issue, displayId: string, search: string): boolean {
   if (search === '') {
     return true;
@@ -1105,7 +1114,10 @@ export class BoardState {
     const displayId = (issue: Issue): string =>
       this.snapshot.displayIdByInternalId.get(issue.id) ?? issue.id;
     const labels = (issue: Issue): string => [...issue.labels].sort(compareText).join('\u0000');
-    const textValue = (issue: Issue, key: Exclude<BoardSortKey, 'priority'>): string => {
+    const textValue = (
+      issue: Issue,
+      key: Exclude<BoardSortKey, 'priority' | 'updated'>,
+    ): string => {
       switch (key) {
         case 'id':
           return displayId(issue);
@@ -1115,8 +1127,6 @@ export class BoardState {
           return issue.kind;
         case 'title':
           return issue.title;
-        case 'updated':
-          return issue.updated_at;
         case 'labels':
           return labels(issue);
         default: {
@@ -1130,7 +1140,9 @@ export class BoardState {
         const compared =
           sort.key === 'priority'
             ? left.priority - right.priority
-            : compareText(textValue(left, sort.key), textValue(right, sort.key));
+            : sort.key === 'updated'
+              ? compareTimestamps(left.updated_at, right.updated_at)
+              : compareText(textValue(left, sort.key), textValue(right, sort.key));
         if (compared !== 0) {
           return sort.direction === 'asc' ? compared : -compared;
         }

--- a/packages/tbd/src/cli/web/board.ts
+++ b/packages/tbd/src/cli/web/board.ts
@@ -24,8 +24,8 @@ import type {
 import {
   defaultIssueQuery,
   describeQuery,
+  filterIssues,
   selectIssues,
-  sortIssues,
 } from '../../lib/issue-query.js';
 import type { IssueQuery, IssueSort } from '../../lib/issue-query.js';
 import { readyIssueIds } from '../../lib/issue-selection.js';
@@ -51,8 +51,11 @@ const MAX_LOCAL_HUNK_LINE_CHARS = 500;
 // Prefixes allow dot/underscore, and imported ShortIds also allow dot, underscore,
 // and hyphen. Requiring the leading prefix letter still rejects option-shaped input.
 const PUBLIC_ID = /^[A-Za-z][A-Za-z0-9._]{0,19}-[0-9a-z._-]+$/u;
-const STATUSES = new Set<IssueStatusType>(['open', 'in_progress', 'blocked', 'deferred', 'closed']);
-const KINDS = new Set<IssueKindType>(['bug', 'feature', 'task', 'epic', 'chore']);
+const STATUS_VALUES = ['open', 'in_progress', 'blocked', 'deferred', 'closed'] as const;
+const KIND_VALUES = ['bug', 'feature', 'task', 'epic', 'chore'] as const;
+const PRIORITY_VALUES = [0, 1, 2, 3, 4] as const;
+const STATUSES = new Set<IssueStatusType>(STATUS_VALUES);
+const KINDS = new Set<IssueKindType>(KIND_VALUES);
 const SORTS = new Set<IssueSort>(['priority', 'created', 'updated']);
 const BOARD_SORT_KEYS = new Set<BoardSortKey>([
   'id',
@@ -97,6 +100,11 @@ export interface BoardSort {
 
 export interface LabelFacet {
   label: string;
+  count: number;
+}
+
+export interface ValueFacet<T extends string | number> {
+  value: T;
   count: number;
 }
 
@@ -192,15 +200,16 @@ export interface BoardResponse {
   command: string;
   commandExact: boolean;
   filtersExact: boolean;
-  contextCount: number;
   search: string;
   total: number;
   matched: number;
   closedHidden: number;
+  statusFacets: ValueFacet<IssueStatusType>[];
+  kindFacets: ValueFacet<IssueKindType>[];
+  priorityFacets: ValueFacet<number>[];
   labelFacets: LabelFacet[];
   rows: BoardRow[];
   truncated: number;
-  contextIds: string[];
   state: WebState;
 }
 
@@ -659,6 +668,14 @@ export class BoardState {
     const context = this.requireContext();
     const parsed = parseBoardQuery(params, context);
     const queryWithoutLimit = { ...parsed.query, limit: null };
+    const filterFacetPool = (query: IssueQuery): Issue[] =>
+      filterIssues(this.snapshot.issues, query).filter((issue) =>
+        matchesSearch(
+          issue,
+          this.snapshot.displayIdByInternalId.get(issue.id) ?? issue.id,
+          parsed.search,
+        ),
+      );
     const selected = selectIssues(this.snapshot.issues, queryWithoutLimit).filter((issue) =>
       matchesSearch(
         issue,
@@ -666,6 +683,14 @@ export class BoardState {
         parsed.search,
       ),
     );
+    const labelFacetPool = filterFacetPool({ ...queryWithoutLimit, labels: [] });
+    const statusFacetPool = filterFacetPool({
+      ...queryWithoutLimit,
+      status: null,
+      includeClosed: true,
+    });
+    const kindFacetPool = filterFacetPool({ ...queryWithoutLimit, kind: null });
+    const priorityFacetPool = filterFacetPool({ ...queryWithoutLimit, priority: null });
     const orderedSelected =
       parsed.sorts.length === 0 ? selected : this.sortIssuesByColumns(selected, parsed.sorts);
     const limited =
@@ -687,22 +712,17 @@ export class BoardState {
     }
 
     let rows: BoardRow[];
-    let contextIds: string[] = [];
-    const pretty = parsed.pretty && parsed.sorts.length === 0;
+    const pretty = parsed.pretty;
     if (pretty) {
-      const ordered = sortIssues(this.snapshot.issues, parsed.query.sort);
-      const context = this.withAncestors(limited, ordered);
-      rows = this.orderAsTree(context.issues);
-      contextIds = rows.filter((row) => !context.matched.has(row.internalId)).map((row) => row.id);
+      // A filtered-out parent stays out, exactly as in `tbd list --pretty`; its
+      // matching descendants become roots. Column sorts order only those outermost
+      // visible groups, while buildIssueTree retains official ordering within them.
+      rows = this.orderAsTree(limited, parsed.sorts);
     } else {
       rows = limited.map((issue) => this.toRow(issue, ''));
     }
 
     const responseRows = rows.slice(0, MAX_BOARD_ROWS);
-    if (contextIds.length > 0) {
-      const responseIds = new Set(responseRows.map((row) => row.id));
-      contextIds = contextIds.filter((id) => responseIds.has(id));
-    }
     const truncated = rows.length > MAX_BOARD_ROWS ? rows.length : 0;
 
     const described = describeQuery(parsed.query, parsed.parentDisplayId ?? undefined);
@@ -713,18 +733,22 @@ export class BoardState {
 
     return {
       command,
-      commandExact:
-        filtersExact && contextIds.length === 0 && parsed.search === '' && truncated === 0,
+      commandExact: filtersExact && parsed.search === '' && truncated === 0,
       filtersExact,
-      contextCount: contextIds.length,
       search: parsed.search,
       total: this.snapshot.issues.length,
       matched: limited.length,
       closedHidden,
-      labelFacets: this.buildLabelFacets(parsed.query.labels),
+      statusFacets: this.buildValueFacets(statusFacetPool, STATUS_VALUES, (issue) => issue.status),
+      kindFacets: this.buildValueFacets(kindFacetPool, KIND_VALUES, (issue) => issue.kind),
+      priorityFacets: this.buildValueFacets(
+        priorityFacetPool,
+        PRIORITY_VALUES,
+        (issue) => issue.priority,
+      ),
+      labelFacets: this.buildLabelFacets(labelFacetPool, parsed.query.labels),
       rows: responseRows,
       truncated,
-      contextIds,
       state,
     };
   }
@@ -1067,17 +1091,26 @@ export class BoardState {
     };
   }
 
-  private buildLabelFacets(selectedLabels: readonly string[]): LabelFacet[] {
+  private buildLabelFacets(
+    candidates: readonly Issue[],
+    selectedLabels: readonly string[],
+  ): LabelFacet[] {
+    const selected = new Set(selectedLabels.filter(Boolean));
+    const intersection = candidates.filter((issue) =>
+      [...selected].every((label) => issue.labels.includes(label)),
+    );
     const counts = new Map<string, number>();
-    for (const issue of this.snapshot.issues) {
+    for (const issue of intersection) {
       for (const label of new Set(issue.labels)) {
         counts.set(label, (counts.get(label) ?? 0) + 1);
       }
     }
+    for (const label of selected) {
+      counts.set(label, intersection.length);
+    }
     const ranked = [...counts].map(([label, count]) => ({ label, count }));
     ranked.sort((left, right) => right.count - left.count || compareText(left.label, right.label));
 
-    const selected = new Set(selectedLabels.filter(Boolean));
     const kept = ranked.slice(0, MAX_LABEL_FACETS);
     const keptLabels = new Set(kept.map((facet) => facet.label));
     const rank = new Map(ranked.map((facet, index) => [facet.label, index]));
@@ -1110,7 +1143,25 @@ export class BoardState {
     return kept;
   }
 
-  private sortIssuesByColumns(issues: readonly Issue[], sorts: readonly BoardSort[]): Issue[] {
+  private buildValueFacets<T extends string | number>(
+    candidates: readonly Issue[],
+    values: readonly T[],
+    select: (issue: Issue) => T,
+  ): ValueFacet<T>[] {
+    const counts = new Map<T, number>();
+    for (const issue of candidates) {
+      const value = select(issue);
+      counts.set(value, (counts.get(value) ?? 0) + 1);
+    }
+    return values.map((value) => ({ value, count: counts.get(value) ?? 0 }));
+  }
+
+  private compareIssuesByColumns(
+    left: Issue,
+    right: Issue,
+    sorts: readonly BoardSort[],
+    effectiveUpdatedAt?: ReadonlyMap<string, string>,
+  ): number {
     const displayId = (issue: Issue): string =>
       this.snapshot.displayIdByInternalId.get(issue.id) ?? issue.id;
     const labels = (issue: Issue): string => [...issue.labels].sort(compareText).join('\u0000');
@@ -1135,23 +1186,28 @@ export class BoardState {
         }
       }
     };
-    return [...issues].sort((left, right) => {
-      for (const sort of sorts) {
-        const compared =
-          sort.key === 'priority'
-            ? left.priority - right.priority
-            : sort.key === 'updated'
-              ? compareTimestamps(left.updated_at, right.updated_at)
-              : compareText(textValue(left, sort.key), textValue(right, sort.key));
-        if (compared !== 0) {
-          return sort.direction === 'asc' ? compared : -compared;
-        }
+    for (const sort of sorts) {
+      const compared =
+        sort.key === 'priority'
+          ? left.priority - right.priority
+          : sort.key === 'updated'
+            ? compareTimestamps(
+                effectiveUpdatedAt?.get(left.id) ?? left.updated_at,
+                effectiveUpdatedAt?.get(right.id) ?? right.updated_at,
+              )
+            : compareText(textValue(left, sort.key), textValue(right, sort.key));
+      if (compared !== 0) {
+        return sort.direction === 'asc' ? compared : -compared;
       }
-      return compareText(displayId(left), displayId(right));
-    });
+    }
+    return compareText(displayId(left), displayId(right));
   }
 
-  private orderAsTree(issues: Issue[]): BoardRow[] {
+  private sortIssuesByColumns(issues: readonly Issue[], sorts: readonly BoardSort[]): Issue[] {
+    return [...issues].sort((left, right) => this.compareIssuesByColumns(left, right, sorts));
+  }
+
+  private orderAsTree(issues: Issue[], sorts: readonly BoardSort[]): BoardRow[] {
     const forTree: IssueForTree[] = issues.map((issue) => ({
       id: this.snapshot.displayIdByInternalId.get(issue.id) ?? issue.id,
       internalId: issue.id as InternalIssueId,
@@ -1168,6 +1224,39 @@ export class BoardState {
     const issueByDisplayId = new Map(
       issues.map((issue) => [this.snapshot.displayIdByInternalId.get(issue.id) ?? issue.id, issue]),
     );
+    const roots = buildIssueTree(forTree);
+    if (sorts.length > 0) {
+      // Sorting a pretty tree moves whole outermost groups. Every parent kind rolls
+      // Updated up from its complete visible subtree; child arrays remain untouched so
+      // buildIssueTree's official child_order_hints contract always wins within a group.
+      const effectiveUpdatedAt = new Map<string, string>();
+      const rollUpUpdatedAt = (node: TreeNode): string => {
+        const issue = issueByDisplayId.get(node.issue.id);
+        let latest = issue?.updated_at ?? '';
+        for (const child of node.children) {
+          const childLatest = rollUpUpdatedAt(child);
+          if (latest === '' || compareTimestamps(childLatest, latest) > 0) {
+            latest = childLatest;
+          }
+        }
+        if (issue !== undefined) {
+          effectiveUpdatedAt.set(issue.id, latest);
+        }
+        return latest;
+      };
+      for (const root of roots) {
+        rollUpUpdatedAt(root);
+      }
+      roots.sort((left, right) =>
+        this.compareIssuesByColumns(
+          issueByDisplayId.get(left.issue.id)!,
+          issueByDisplayId.get(right.issue.id)!,
+          sorts,
+          effectiveUpdatedAt,
+        ),
+      );
+    }
+
     const rows: BoardRow[] = [];
     const walk = (node: TreeNode, prefix: string, connector: string, isLast: boolean): void => {
       const issue = issueByDisplayId.get(node.issue.id);
@@ -1181,32 +1270,9 @@ export class BoardState {
         walk(child, childPrefix, last ? TREE_CHARS.last : TREE_CHARS.branch, last);
       });
     };
-    for (const root of buildIssueTree(forTree)) {
+    for (const root of roots) {
       walk(root, '', '', true);
     }
     return rows;
-  }
-
-  private withAncestors(
-    matched: Issue[],
-    ordered: Issue[],
-  ): { issues: Issue[]; matched: Set<string> } {
-    const matchedIds = new Set(matched.map((issue) => issue.id));
-    const keep = new Set(matchedIds);
-    for (const issue of matched) {
-      let cursor: Issue | undefined = issue;
-      while (cursor?.parent_id != null && !keep.has(cursor.parent_id)) {
-        const parent = this.snapshot.byInternalId.get(cursor.parent_id);
-        if (parent === undefined) {
-          break;
-        }
-        keep.add(parent.id);
-        cursor = parent;
-      }
-    }
-    return {
-      issues: ordered.filter((issue) => keep.has(issue.id)),
-      matched: matchedIds,
-    };
   }
 }

--- a/packages/tbd/src/file/doc-cache.ts
+++ b/packages/tbd/src/file/doc-cache.ts
@@ -12,11 +12,11 @@
 
 import { readdir, readFile } from 'node:fs/promises';
 import { join, basename } from 'node:path';
-import matter from 'gray-matter';
 
 import { readConfig, readLocalState, findTbdRoot } from './config.js';
 import { isDocsStale, syncDocsWithDefaults } from './doc-sync.js';
 import { estimateTokens } from '../lib/format-utils.js';
+import { hasMarkdownFrontmatter, parseMarkdownMatter } from '../utils/gray-matter.js';
 
 // =============================================================================
 // Scoring Constants
@@ -249,15 +249,15 @@ export class DocCache {
 
   /**
    * Parse YAML frontmatter from content and return typed data.
-   * Uses gray-matter for consistent frontmatter parsing.
+   * Uses the centralized gray-matter boundary for consistent YAML parsing.
    */
   private parseFrontmatterData(content: string): DocFrontmatter | undefined {
-    if (!matter.test(content)) {
+    if (!hasMarkdownFrontmatter(content)) {
       return undefined;
     }
 
     try {
-      const parsed = matter(content).data as Record<string, unknown>;
+      const parsed = parseMarkdownMatter(content).data as Record<string, unknown>;
       return {
         title: typeof parsed.title === 'string' ? parsed.title : undefined,
         description: typeof parsed.description === 'string' ? parsed.description : undefined,

--- a/packages/tbd/src/file/doc-fork.ts
+++ b/packages/tbd/src/file/doc-fork.ts
@@ -15,7 +15,6 @@ import { readFile, readdir, rm, rmdir, mkdir, stat } from 'node:fs/promises';
 import { dirname, join, relative } from 'node:path';
 
 import { writeFile } from 'atomically';
-import matter from 'gray-matter';
 
 import { DocCache } from './doc-cache.js';
 import {
@@ -40,6 +39,7 @@ import {
   removeFork,
   writeBaseContent,
 } from './fork-manifest.js';
+import { parseMarkdownMatter } from '../utils/gray-matter.js';
 
 /** Map a doc kind to its plural directory name within the fork dir. */
 export const KIND_DIR: Record<ForkKind, string> = {
@@ -407,7 +407,10 @@ function readmeLinkPath(relPath: string): string {
 /** First frontmatter description (or title) of a doc file, for the README index. */
 async function docBlurb(absPath: string): Promise<string | undefined> {
   try {
-    const data = matter(await readFile(absPath, 'utf-8')).data as Record<string, unknown>;
+    const data = parseMarkdownMatter(await readFile(absPath, 'utf-8')).data as Record<
+      string,
+      unknown
+    >;
     const description = typeof data.description === 'string' ? data.description : undefined;
     const title = typeof data.title === 'string' ? data.title : undefined;
     const blurb = description ?? title;

--- a/packages/tbd/src/file/parser.ts
+++ b/packages/tbd/src/file/parser.ts
@@ -17,26 +17,11 @@
  * See: tbd-design.md §2.1 Markdown + YAML Front Matter Format
  */
 
-import matter from 'gray-matter';
-import { parse as parseYaml } from 'yaml';
-
+import { hasMarkdownFrontmatter, parseMarkdownMatter } from '../utils/gray-matter.js';
 import { normalizeLineEndings } from '../utils/markdown-utils.js';
 import { sortKeys, stringifyYaml } from '../utils/yaml-utils.js';
 import type { Issue } from '../lib/types.js';
 import { IssueSchema, ISSUE_FIELD_ORDER } from '../lib/schemas.js';
-
-/**
- * gray-matter options using the 'yaml' package as engine.
- * This preserves date strings instead of converting them to Date objects.
- */
-export const matterOptions = {
-  engines: {
-    yaml: {
-      parse: (str: string): object => parseYaml(str) as object,
-      stringify: (obj: object): string => stringifyYaml(obj),
-    },
-  },
-};
 
 /**
  * Parsed issue file content.
@@ -57,11 +42,11 @@ export function parseMarkdownWithFrontmatter(content: string): ParsedIssueFile {
   const normalizedContent = normalizeLineEndings(content);
 
   // Check for valid frontmatter
-  if (!matter.test(normalizedContent)) {
+  if (!hasMarkdownFrontmatter(normalizedContent)) {
     throw new Error('Invalid format: missing front matter opening delimiter');
   }
 
-  const parsed = matter(normalizedContent, matterOptions);
+  const parsed = parseMarkdownMatter(normalizedContent);
 
   // gray-matter returns empty object if no closing delimiter found
   // but the raw matter string will be empty if parsing failed

--- a/packages/tbd/src/lib/issue-query.ts
+++ b/packages/tbd/src/lib/issue-query.ts
@@ -77,9 +77,16 @@ export function defaultIssueQuery(): IssueQuery {
  * display ids).
  */
 export function selectIssues(issues: readonly Issue[], query: IssueQuery): Issue[] {
+  const filtered = filterIssues(issues, query);
+  const sorted = sortIssues(filtered, query.sort);
+  return query.limit === null ? sorted : sorted.slice(0, query.limit);
+}
+
+/** Apply shared CLI query predicates without paying for ordering when only facets need rows. */
+export function filterIssues(issues: readonly Issue[], query: IssueQuery): Issue[] {
   const readyIds = query.ready ? readyIssueIds(issues) : null;
 
-  const filtered = issues.filter((issue) => {
+  return issues.filter((issue) => {
     // By default, exclude closed issues unless --all or --status closed
     if (!query.includeClosed && query.status !== 'closed' && issue.status === 'closed') {
       return false;
@@ -113,9 +120,6 @@ export function selectIssues(issues: readonly Issue[], query: IssueQuery): Issue
     }
     return true;
   });
-
-  const sorted = sortIssues(filtered, query.sort);
-  return query.limit === null ? sorted : sorted.slice(0, query.limit);
 }
 
 /** Sort per `tbd list --sort`, ULID tiebreak. Exported for callers that sort supersets. */

--- a/packages/tbd/src/utils/gray-matter.ts
+++ b/packages/tbd/src/utils/gray-matter.ts
@@ -15,7 +15,10 @@ import { stringifyYaml } from './yaml-utils.js';
 const matterOptions = {
   engines: {
     yaml: {
-      parse: (input: string): object => parseYaml(input) as object,
+      // gray-matter slices at the LF in a CRLF closing delimiter, leaving the
+      // preceding CR in the YAML block. Normalize the block, not the Markdown
+      // body, so the final plain scalar cannot acquire a trailing newline.
+      parse: (input: string): object => parseYaml(input.replace(/\r\n?/g, '\n')) as object,
       stringify: (data: object): string => stringifyYaml(data),
     },
   },

--- a/packages/tbd/src/utils/gray-matter.ts
+++ b/packages/tbd/src/utils/gray-matter.ts
@@ -1,0 +1,49 @@
+/**
+ * The single gray-matter boundary used by tbd.
+ *
+ * gray-matter provides mature front-matter delimiter handling, while the
+ * repository's existing `yaml` dependency provides YAML 1.2 parsing and keeps
+ * date-like scalars as strings. Passing these options on every call also keeps
+ * gray-matter's legacy default js-yaml engine out of the parsing path.
+ */
+
+import matter from 'gray-matter';
+import { parse as parseYaml } from 'yaml';
+
+import { stringifyYaml } from './yaml-utils.js';
+
+const matterOptions = {
+  engines: {
+    yaml: {
+      parse: (input: string): object => parseYaml(input) as object,
+      stringify: (data: object): string => stringifyYaml(data),
+    },
+  },
+};
+
+const ALLOWED_FRONTMATTER_LANGUAGES = new Set(['yaml', 'yml']);
+
+function assertYamlLanguage(content: string): void {
+  if (!matter.test(content, matterOptions)) {
+    return;
+  }
+
+  const language = matter.language(content, matterOptions).name.toLowerCase();
+  if (language !== '' && !ALLOWED_FRONTMATTER_LANGUAGES.has(language)) {
+    throw new Error(`Unsupported front-matter language "${language}"; tbd accepts YAML only`);
+  }
+}
+
+/** Return whether content begins with a front-matter delimiter. */
+export function hasMarkdownFrontmatter(content: string): boolean {
+  return matter.test(content, matterOptions);
+}
+
+/** Parse Markdown front matter with tbd's YAML engine. */
+export function parseMarkdownMatter(content: string): matter.GrayMatterFile<string> {
+  // gray-matter also ships a JavaScript engine that evaluates explicit
+  // `---javascript` blocks. tbd's file format is YAML-only, so validate before
+  // gray-matter can select any built-in engine.
+  assertYamlLanguage(content);
+  return matter(content, matterOptions);
+}

--- a/packages/tbd/src/utils/markdown-utils.ts
+++ b/packages/tbd/src/utils/markdown-utils.ts
@@ -1,12 +1,11 @@
 /**
  * Markdown utilities for processing markdown content.
  *
- * Uses gray-matter for parsing and centralized yaml-utils for stringify to ensure
- * proper handling of special YAML characters (colons, quotes, etc.).
+ * Uses the centralized gray-matter boundary for delimiter handling and yaml-utils
+ * for serialization, ensuring consistent YAML semantics everywhere.
  */
 
-import matter from 'gray-matter';
-
+import { hasMarkdownFrontmatter, parseMarkdownMatter } from './gray-matter.js';
 import { stringifyYamlCompact } from './yaml-utils.js';
 
 export interface ParsedMarkdown {
@@ -32,12 +31,12 @@ export function normalizeLineEndings(content: string): string {
 export function parseMarkdown(content: string): ParsedMarkdown {
   const normalized = normalizeLineEndings(content);
 
-  if (!matter.test(normalized)) {
+  if (!hasMarkdownFrontmatter(normalized)) {
     return { frontmatter: null, body: content };
   }
 
   try {
-    const parsed = matter(normalized);
+    const parsed = parseMarkdownMatter(normalized);
 
     // Extract frontmatter from parsed.data by stringifying back to YAML
     // The matter property is unreliable, so we reconstruct from data

--- a/packages/tbd/src/web/client.ts
+++ b/packages/tbd/src/web/client.ts
@@ -67,6 +67,8 @@ const elements = {
   labelTrigger: byId('labeltrigger', HTMLButtonElement),
   labelSummary: byId('labelsummary', HTMLSpanElement),
   labelMenu: byId('labelmenu', HTMLDivElement),
+  labelSearch: byId('labelsearch', HTMLInputElement),
+  labelChoices: byId('labelchoices', HTMLDivElement),
   spec: byId('spec', HTMLInputElement),
   ready: byId('ready', HTMLInputElement),
   pretty: byId('pretty', HTMLInputElement),
@@ -359,6 +361,7 @@ function renderCategoricalFacets(board: BoardResponse): void {
 function readControls(): BoardControls {
   return {
     search: elements.search.value,
+    labelSearch: elements.labelSearch.value,
     status: choice(elements.status.value, ['', 'any', ...ISSUE_STATUSES] as const, ''),
     kind: choice(elements.kind.value, ['', 'bug', 'feature', 'task', 'epic', 'chore'] as const, ''),
     priority: choice(elements.priority.value, ['', '0', '1', '2', '3', '4'] as const, ''),
@@ -415,7 +418,33 @@ function labelChoice(
   return row;
 }
 
-function renderLabelChooser(facets: readonly LabelFacetView[], labels: readonly string[]): void {
+function activeLabelChoiceFocus(): string | null {
+  const active = document.activeElement;
+  if (!(active instanceof HTMLButtonElement) || !elements.labelChoices.contains(active)) {
+    return null;
+  }
+  return active.hasAttribute('data-label-any') ? '' : (active.dataset.labelChoice ?? null);
+}
+
+function restoreLabelChoiceFocus(requested: string | null): void {
+  if (requested === null) {
+    return;
+  }
+  const choice = [
+    ...elements.labelChoices.querySelectorAll<HTMLButtonElement>('.label-choice'),
+  ].find((row) =>
+    requested === '' ? row.hasAttribute('data-label-any') : row.dataset.labelChoice === requested,
+  );
+  choice?.focus();
+}
+
+function renderLabelChooser(
+  facets: readonly LabelFacetView[],
+  labels: readonly string[],
+  labelSearch: string,
+): void {
+  const labelFocus = pendingLabelFocus ?? activeLabelChoiceFocus();
+  pendingLabelFocus = null;
   selectedLabels.clear();
   for (const label of labels) {
     selectedLabels.add(label);
@@ -428,6 +457,9 @@ function renderLabelChooser(facets: readonly LabelFacetView[], labels: readonly 
         ? selected[0]!
         : `${selected[0]} +${selected.length - 1}`;
   elements.labelTrigger.dataset.active = String(selected.length > 0);
+  if (elements.labelSearch.value !== labelSearch) {
+    elements.labelSearch.value = labelSearch;
+  }
 
   const signature = JSON.stringify([selected, facets]);
   if (signature !== labelRenderSignature) {
@@ -435,21 +467,11 @@ function renderLabelChooser(facets: readonly LabelFacetView[], labels: readonly 
     for (const facet of facets) {
       choices.push(labelChoice(facet.label, facet.count, selectedLabels.has(facet.label)));
     }
-    elements.labelMenu.replaceChildren(...choices);
+    elements.labelChoices.replaceChildren(...choices);
     labelRenderSignature = signature;
   }
   setLabelMenuOpen(labelMenuOpen);
-
-  if (pendingLabelFocus !== null) {
-    const requested = pendingLabelFocus;
-    pendingLabelFocus = null;
-    const choice = [
-      ...elements.labelMenu.querySelectorAll<HTMLButtonElement>('.label-choice'),
-    ].find((row) =>
-      requested === '' ? row.hasAttribute('data-label-any') : row.dataset.labelChoice === requested,
-    );
-    choice?.focus();
-  }
+  restoreLabelChoiceFocus(labelFocus);
 }
 
 function renderSortHeaders(sorts: readonly BoardSortView[], pretty: boolean): void {
@@ -833,6 +855,51 @@ function renderGhost(row: BoardRowView): HTMLTableRowElement {
   return tableRow;
 }
 
+interface BoardFocusIdentity {
+  beadId: string;
+  role: 'disclosure' | 'copy';
+  copyLabel: string | null;
+}
+
+function captureBoardFocus(): BoardFocusIdentity | null {
+  const active = document.activeElement;
+  if (!(active instanceof HTMLButtonElement)) {
+    return null;
+  }
+  const row = active.closest<HTMLTableRowElement>('tr[data-bead-id]');
+  const beadId = row?.dataset.beadId;
+  if (beadId === undefined) {
+    return null;
+  }
+  if (active.classList.contains('disclosure')) {
+    return { beadId, role: 'disclosure', copyLabel: null };
+  }
+  if (active.classList.contains('copy-button')) {
+    return { beadId, role: 'copy', copyLabel: active.dataset.copyLabel ?? null };
+  }
+  return null;
+}
+
+function restoreBoardFocus(identity: BoardFocusIdentity | null): void {
+  if (identity === null) {
+    return;
+  }
+  const row = [...elements.rows.querySelectorAll<HTMLTableRowElement>('tr[data-bead-id]')].find(
+    (candidate) => candidate.dataset.beadId === identity.beadId,
+  );
+  if (row === undefined) {
+    return;
+  }
+  if (identity.role === 'disclosure') {
+    row.querySelector<HTMLButtonElement>('.disclosure')?.focus();
+    return;
+  }
+  const button = [...row.querySelectorAll<HTMLButtonElement>('.copy-button')].find(
+    (candidate) => candidate.dataset.copyLabel === identity.copyLabel,
+  );
+  button?.focus();
+}
+
 function renderRow(
   view: ClientView,
   row: BoardRowView,
@@ -840,6 +907,7 @@ function renderRow(
 ): DocumentFragment {
   const fragment = document.createDocumentFragment();
   const tableRow = document.createElement('tr');
+  tableRow.dataset.beadId = row.id;
   const open = view.expanded.has(row.id);
   const classes = [
     changedIds.has(row.id) ? 'changed' : '',
@@ -847,10 +915,6 @@ function renderRow(
     view.flashIds.has(row.id) ? 'flash' : '',
   ].filter(Boolean);
   tableRow.className = classes.join(' ');
-  tableRow.addEventListener('click', () => {
-    store.toggle(row.id);
-  });
-
   const caretCell = appendCell(tableRow, '', 'caret');
   const disclosure = document.createElement('button');
   disclosure.type = 'button';
@@ -1132,6 +1196,7 @@ function appendBoardPager(board: BoardResponse, pageIndex: number): void {
 }
 
 function renderBoard(view: ClientView, board: BoardResponse): void {
+  const boardFocus = captureBoardFocus();
   const page = paginateBoardRows(board.rows, boardPageIndex);
   const changedIds = new Set(view.watch?.movedIds ?? []);
   boardPageIndex = page.pageIndex;
@@ -1143,9 +1208,6 @@ function renderBoard(view: ClientView, board: BoardResponse): void {
     elements.pagePill,
     page.total === 0 ? 'No rows' : `Rows ${page.start + 1}–${page.end} of ${page.total}`,
   );
-  if (activeTooltipTarget !== null && elements.rows.contains(activeTooltipTarget)) {
-    hideTooltip();
-  }
   elements.rows.replaceChildren();
   for (const row of view.ghostRows) {
     elements.rows.append(renderGhost(row));
@@ -1154,6 +1216,7 @@ function renderBoard(view: ClientView, board: BoardResponse): void {
     elements.rows.append(renderRow(view, row, changedIds));
   }
   appendBoardPager(board, page.pageIndex);
+  restoreBoardFocus(boardFocus);
   elements.empty.hidden = board.rows.length > 0 || view.ghostRows.length > 0;
   elements.empty.textContent = view.boardError ?? 'No beads match this query.';
   const canBulkExpand = page.rows.length <= MAX_EXPANDED_ROWS;
@@ -1204,10 +1267,10 @@ function renderHeader(view: ClientView, board: BoardResponse, watch: Observation
   );
   elements.pretty.checked = view.controls.pretty;
   activeSorts = view.controls.sorts.map((sort) => ({ ...sort }));
-  elements.sortReset.hidden = isDefaultBoardSort(view.controls.sorts, view.controls.pretty);
+  elements.sortReset.hidden = isDefaultBoardSort(view.controls.sorts);
   renderSortHeaders(view.controls.sorts, view.controls.pretty);
   renderCategoricalFacets(board);
-  renderLabelChooser(board.labelFacets, view.controls.labels);
+  renderLabelChooser(board.labelFacets, view.controls.labels, view.controls.labelSearch);
   document.title = `tbd beads (${watch.totalBeads})`;
 }
 
@@ -1224,7 +1287,14 @@ function render(): void {
   }
 
   renderHeader(view, board, watch);
-  if (disconnected) {
+  if (view.boardError !== null) {
+    elements.observerPill.textContent = 'refresh error';
+    elements.observerPill.className = 'pill error';
+    setTooltip(
+      elements.observerPill,
+      `Board refresh failed: ${view.boardError}. Showing the last successful board while the viewer retries.`,
+    );
+  } else if (disconnected) {
     elements.observerPill.textContent = 'disconnected';
     elements.observerPill.className = 'pill error';
     setTooltip(
@@ -1237,6 +1307,9 @@ function render(): void {
   renderStats(watch.stats);
   renderReport(watch);
   renderLog(watch);
+  if (activeTooltipTarget !== null && !document.contains(activeTooltipTarget)) {
+    hideTooltip();
+  }
   store.acknowledgeDataMotion();
 
   if (scrollBoardToTopAfterRender) {
@@ -1339,6 +1412,15 @@ function debounceControls(): void {
     applyControls();
   }, 120);
 }
+function debounceLabelSearch(): void {
+  if (filterTimer !== null) {
+    window.clearTimeout(filterTimer);
+  }
+  filterTimer = window.setTimeout(() => {
+    filterTimer = null;
+    void store.setControls(readControls());
+  }, 120);
+}
 for (const input of [elements.search, elements.spec]) {
   input.addEventListener('input', debounceControls);
 }
@@ -1350,20 +1432,19 @@ elements.pretty.addEventListener('change', () => {
 });
 elements.sortReset.addEventListener('click', () => {
   activeSorts = DEFAULT_BOARD_SORTS.map((sort) => ({ ...sort }));
-  elements.pretty.checked = true;
   applyControls();
 });
 elements.labelTrigger.addEventListener('click', () => {
   setLabelMenuOpen(!labelMenuOpen);
   if (labelMenuOpen) {
-    elements.labelMenu.querySelector<HTMLButtonElement>('.label-choice')?.focus();
+    elements.labelSearch.focus();
   }
 });
 elements.labelTrigger.addEventListener('keydown', (event) => {
   if (event.key === 'ArrowDown') {
     event.preventDefault();
     setLabelMenuOpen(true);
-    elements.labelMenu.querySelector<HTMLButtonElement>('.label-choice')?.focus();
+    elements.labelSearch.focus();
   }
 });
 elements.labelMenu.addEventListener('click', (event) => {
@@ -1392,7 +1473,7 @@ elements.labelMenu.addEventListener('click', (event) => {
   applyControls();
 });
 elements.labelMenu.addEventListener('keydown', (event) => {
-  const rows = [...elements.labelMenu.querySelectorAll<HTMLButtonElement>('.label-choice')];
+  const rows = [...elements.labelChoices.querySelectorAll<HTMLButtonElement>('.label-choice')];
   const current = rows.indexOf(document.activeElement as HTMLButtonElement);
   let next = -1;
   if (event.key === 'ArrowDown') {
@@ -1412,6 +1493,24 @@ elements.labelMenu.addEventListener('keydown', (event) => {
   if (next >= 0) {
     event.preventDefault();
     rows[next]?.focus();
+  }
+});
+elements.labelSearch.addEventListener('input', debounceLabelSearch);
+elements.rows.addEventListener('click', (event) => {
+  const target = event.target instanceof Element ? event.target : null;
+  if (target === null) {
+    return;
+  }
+  const row = target.closest<HTMLTableRowElement>('tr[data-bead-id]');
+  const suppressForSelection =
+    target.closest<HTMLButtonElement>('.disclosure') === null &&
+    !(window.getSelection()?.isCollapsed ?? true);
+  if (row === null || suppressForSelection) {
+    return;
+  }
+  const id = row.dataset.beadId;
+  if (id !== undefined) {
+    store.toggle(id);
   }
 });
 document.addEventListener('pointerdown', (event) => {

--- a/packages/tbd/src/web/client.ts
+++ b/packages/tbd/src/web/client.ts
@@ -7,6 +7,9 @@ import {
   MAX_EXPANDED_ROWS,
   paginateBoardRows,
   phaseLabel,
+  promoteBoardSort,
+  resolvedBoardSorts,
+  treeGuideText,
   treeContinuationColumns,
 } from './core.js';
 import type {
@@ -14,11 +17,14 @@ import type {
   BoardControls,
   BoardResponse,
   BoardRowView,
+  BoardSortKeyView,
+  BoardSortView,
   ClientStore,
   ClientView,
   IssueChangeView,
   IssueStatusView,
   IssueStatsView,
+  LabelFacetView,
   ObservationStateView,
 } from './core.js';
 
@@ -52,9 +58,11 @@ const elements = {
   status: byId('status', HTMLSelectElement),
   kind: byId('type', HTMLSelectElement),
   priority: byId('priority', HTMLSelectElement),
-  labels: byId('label', HTMLInputElement),
+  labelChooser: byId('labelchooser', HTMLSpanElement),
+  labelTrigger: byId('labeltrigger', HTMLButtonElement),
+  labelSummary: byId('labelsummary', HTMLSpanElement),
+  labelMenu: byId('labelmenu', HTMLDivElement),
   spec: byId('spec', HTMLInputElement),
-  sort: byId('sort', HTMLSelectElement),
   ready: byId('ready', HTMLInputElement),
   pretty: byId('pretty', HTMLInputElement),
   expandAll: byId('expandall', HTMLButtonElement),
@@ -68,6 +76,11 @@ const PRIORITY_LABEL = ['Critical', 'High', 'Medium', 'Low', 'Lowest'] as const;
 const RELATIVE_TIME_REFRESH_MS = 30_000;
 let boardPageIndex = 0;
 let scrollBoardToTopAfterRender = false;
+let labelMenuOpen = false;
+let pendingLabelFocus: string | null = null;
+let labelRenderSignature = '';
+const selectedLabels = new Set<string>();
+let activeSorts: BoardSortView[] = [];
 
 function choice<T extends string>(value: string, choices: readonly T[], fallback: T): T {
   return choices.includes(value as T) ? (value as T) : fallback;
@@ -75,6 +88,13 @@ function choice<T extends string>(value: string, choices: readonly T[], fallback
 
 function isIssueStatus(value: string): value is IssueStatusView {
   return ISSUE_STATUSES.includes(value as IssueStatusView);
+}
+
+function isBoardSortKey(value: string | undefined): value is BoardSortKeyView {
+  return (
+    value !== undefined &&
+    ['id', 'priority', 'status', 'kind', 'title', 'updated', 'labels'].includes(value)
+  );
 }
 
 for (const option of elements.status.options) {
@@ -112,12 +132,126 @@ function readControls(): BoardControls {
     status: choice(elements.status.value, ['', 'any', ...ISSUE_STATUSES] as const, ''),
     kind: choice(elements.kind.value, ['', 'bug', 'feature', 'task', 'epic', 'chore'] as const, ''),
     priority: choice(elements.priority.value, ['', '0', '1', '2', '3', '4'] as const, ''),
-    labels: elements.labels.value,
+    labels: [...selectedLabels].sort(),
     spec: elements.spec.value,
-    sort: choice(elements.sort.value, ['priority', 'created', 'updated'] as const, 'priority'),
+    sorts: activeSorts.map((sort) => ({ ...sort })),
     ready: elements.ready.checked,
     pretty: elements.pretty.checked,
   };
+}
+
+function setLabelMenuOpen(open: boolean): void {
+  labelMenuOpen = open;
+  elements.labelMenu.hidden = !open;
+  elements.labelTrigger.setAttribute('aria-expanded', String(open));
+  elements.labelChooser.toggleAttribute('data-open', open);
+}
+
+function labelChoice(
+  label: string | null,
+  countValue: number | null,
+  selected: boolean,
+): HTMLButtonElement {
+  const row = document.createElement('button');
+  row.type = 'button';
+  row.tabIndex = -1;
+  row.className = 'label-choice';
+  row.setAttribute('role', 'menuitemcheckbox');
+  row.setAttribute('aria-checked', String(selected));
+  if (label === null) {
+    row.dataset.labelAny = '';
+  } else {
+    row.dataset.labelChoice = label;
+  }
+
+  const check = document.createElement('span');
+  check.className = 'label-choice-check';
+  check.setAttribute('aria-hidden', 'true');
+  check.textContent = selected ? '✓' : '';
+  const name = document.createElement('span');
+  if (label === null) {
+    name.className = 'label-choice-any';
+  } else {
+    name.className = 'tag label-choice-tag';
+  }
+  name.textContent = label ?? 'labels: any';
+  row.append(check, name);
+  if (countValue !== null) {
+    const count = document.createElement('span');
+    count.className = 'label-choice-count';
+    count.textContent = String(countValue);
+    row.append(count);
+  }
+  return row;
+}
+
+function renderLabelChooser(facets: readonly LabelFacetView[], labels: readonly string[]): void {
+  selectedLabels.clear();
+  for (const label of labels) {
+    selectedLabels.add(label);
+  }
+  const selected = [...selectedLabels].sort();
+  elements.labelSummary.textContent =
+    selected.length === 0
+      ? 'labels: any'
+      : selected.length === 1
+        ? selected[0]!
+        : `${selected[0]} +${selected.length - 1}`;
+  elements.labelTrigger.dataset.active = String(selected.length > 0);
+
+  const signature = JSON.stringify([selected, facets]);
+  if (signature !== labelRenderSignature) {
+    const choices: HTMLButtonElement[] = [labelChoice(null, null, selected.length === 0)];
+    for (const facet of facets) {
+      choices.push(labelChoice(facet.label, facet.count, selectedLabels.has(facet.label)));
+    }
+    elements.labelMenu.replaceChildren(...choices);
+    labelRenderSignature = signature;
+  }
+  setLabelMenuOpen(labelMenuOpen);
+
+  if (pendingLabelFocus !== null) {
+    const requested = pendingLabelFocus;
+    pendingLabelFocus = null;
+    const choice = [
+      ...elements.labelMenu.querySelectorAll<HTMLButtonElement>('.label-choice'),
+    ].find((row) =>
+      requested === '' ? row.hasAttribute('data-label-any') : row.dataset.labelChoice === requested,
+    );
+    choice?.focus();
+  }
+}
+
+function renderSortHeaders(sorts: readonly BoardSortView[]): void {
+  const resolved = resolvedBoardSorts(sorts);
+  for (const header of document.querySelectorAll<HTMLTableCellElement>('th[data-sort-key]')) {
+    const key = header.dataset.sortKey;
+    if (!isBoardSortKey(key)) {
+      continue;
+    }
+    const precedence = resolved.findIndex((sort) => sort.key === key);
+    const sort = precedence < 0 ? undefined : resolved[precedence];
+    header.setAttribute(
+      'aria-sort',
+      precedence === 0 ? (sort?.direction === 'desc' ? 'descending' : 'ascending') : 'none',
+    );
+    const button = header.querySelector<HTMLButtonElement>('.sort-button');
+    const indicator = header.querySelector<HTMLElement>('.sort-indicator');
+    if (indicator !== null) {
+      indicator.textContent =
+        sort === undefined ? '' : `${sort.direction === 'asc' ? '↑' : '↓'}${precedence + 1}`;
+    }
+    if (button !== null) {
+      const current =
+        sort === undefined
+          ? 'not in the sort stack'
+          : `${sort.direction === 'asc' ? 'ascending' : 'descending'}, precedence ${precedence + 1}`;
+      button.setAttribute(
+        'aria-label',
+        `Sort by ${key}; currently ${current}. Clicking makes it primary${precedence === 0 ? ' and reverses its direction' : ''}.`,
+      );
+    }
+  }
 }
 
 function short(value: string | null): string {
@@ -484,7 +618,7 @@ function renderRow(
   if (row.prefix !== '') {
     const guide = document.createElement('span');
     guide.className = 'guide';
-    guide.textContent = row.prefix;
+    guide.textContent = treeGuideText(row.prefix);
     titleContent.append(guide);
     for (const column of treeContinuationColumns(row.prefix)) {
       const continuation = document.createElement('span');
@@ -805,6 +939,9 @@ function renderHeader(view: ClientView, board: BoardResponse, watch: Observation
       ? 'Run this to reproduce the table below.'
       : `Close but not exact: ${caveats.join('; ')}.`;
   elements.pretty.checked = view.controls.pretty;
+  activeSorts = view.controls.sorts.map((sort) => ({ ...sort }));
+  renderSortHeaders(view.controls.sorts);
+  renderLabelChooser(board.labelFacets, view.controls.labels);
   document.title = `tbd beads (${watch.totalBeads})`;
 }
 
@@ -933,18 +1070,98 @@ function debounceControls(): void {
     applyControls();
   }, 120);
 }
-for (const input of [elements.search, elements.labels, elements.spec]) {
+for (const input of [elements.search, elements.spec]) {
   input.addEventListener('input', debounceControls);
 }
-for (const input of [
-  elements.status,
-  elements.kind,
-  elements.priority,
-  elements.sort,
-  elements.ready,
-  elements.pretty,
-]) {
+for (const input of [elements.status, elements.kind, elements.priority, elements.ready]) {
   input.addEventListener('change', applyControls);
+}
+elements.pretty.addEventListener('change', () => {
+  if (elements.pretty.checked) {
+    // Pretty restores the exact hierarchical CLI view and its priority order.
+    activeSorts = [];
+  }
+  applyControls();
+});
+elements.labelTrigger.addEventListener('click', () => {
+  setLabelMenuOpen(!labelMenuOpen);
+  if (labelMenuOpen) {
+    elements.labelMenu.querySelector<HTMLButtonElement>('.label-choice')?.focus();
+  }
+});
+elements.labelTrigger.addEventListener('keydown', (event) => {
+  if (event.key === 'ArrowDown') {
+    event.preventDefault();
+    setLabelMenuOpen(true);
+    elements.labelMenu.querySelector<HTMLButtonElement>('.label-choice')?.focus();
+  }
+});
+elements.labelMenu.addEventListener('click', (event) => {
+  const row =
+    event.target instanceof Element
+      ? event.target.closest<HTMLButtonElement>('.label-choice')
+      : null;
+  if (row === null) {
+    return;
+  }
+  if (row.hasAttribute('data-label-any')) {
+    selectedLabels.clear();
+    pendingLabelFocus = '';
+  } else {
+    const label = row.dataset.labelChoice;
+    if (label === undefined) {
+      return;
+    }
+    if (selectedLabels.has(label)) {
+      selectedLabels.delete(label);
+    } else {
+      selectedLabels.add(label);
+    }
+    pendingLabelFocus = label;
+  }
+  applyControls();
+});
+elements.labelMenu.addEventListener('keydown', (event) => {
+  const rows = [...elements.labelMenu.querySelectorAll<HTMLButtonElement>('.label-choice')];
+  const current = rows.indexOf(document.activeElement as HTMLButtonElement);
+  let next = -1;
+  if (event.key === 'ArrowDown') {
+    next = current < 0 ? 0 : (current + 1) % rows.length;
+  } else if (event.key === 'ArrowUp') {
+    next = current < 0 ? rows.length - 1 : (current - 1 + rows.length) % rows.length;
+  } else if (event.key === 'Home') {
+    next = 0;
+  } else if (event.key === 'End') {
+    next = rows.length - 1;
+  } else if (event.key === 'Escape') {
+    event.preventDefault();
+    setLabelMenuOpen(false);
+    elements.labelTrigger.focus();
+    return;
+  }
+  if (next >= 0) {
+    event.preventDefault();
+    rows[next]?.focus();
+  }
+});
+document.addEventListener('pointerdown', (event) => {
+  if (event.target instanceof Node && !elements.labelChooser.contains(event.target)) {
+    setLabelMenuOpen(false);
+  }
+});
+for (const button of document.querySelectorAll<HTMLButtonElement>('.sort-button[data-sort-key]')) {
+  button.addEventListener('click', () => {
+    const key = button.dataset.sortKey;
+    if (!isBoardSortKey(key)) {
+      return;
+    }
+    const view = store.getView();
+    activeSorts = promoteBoardSort(view.controls.sorts, key);
+    // A globally sorted table and a parent-first tree are contradictory views.
+    // Column sorting therefore activates the flat list while keeping Pretty explicit.
+    elements.pretty.checked = false;
+    applyControls();
+  });
 }
 elements.expandAll.addEventListener('click', () => {
   const view = store.getView();
@@ -1003,6 +1220,7 @@ document.addEventListener('click', closeMenu);
 document.addEventListener('keydown', (event) => {
   if (event.key === 'Escape') {
     closeMenu();
+    setLabelMenuOpen(false);
   }
 });
 for (const button of themeButtons) {

--- a/packages/tbd/src/web/client.ts
+++ b/packages/tbd/src/web/client.ts
@@ -3,6 +3,7 @@ import {
   caveatsFor,
   createClientStore,
   deltasValid,
+  formatRelativeAge,
   MAX_EXPANDED_ROWS,
   paginateBoardRows,
   phaseLabel,
@@ -64,6 +65,7 @@ const elements = {
 const ISSUE_STATUSES = ['open', 'in_progress', 'blocked', 'deferred', 'closed'] as const;
 const ISSUE_PRIORITIES = ['0', '1', '2', '3', '4'] as const;
 const PRIORITY_LABEL = ['Critical', 'High', 'Medium', 'Low', 'Lowest'] as const;
+const RELATIVE_TIME_REFRESH_MS = 30_000;
 let boardPageIndex = 0;
 let scrollBoardToTopAfterRender = false;
 
@@ -128,6 +130,36 @@ function appendCell(row: HTMLTableRowElement, text: string, className = ''): HTM
   cell.className = className;
   row.append(cell);
   return cell;
+}
+
+function updateRelativeTime(time: HTMLTimeElement, nowMs = Date.now()): void {
+  const age = formatRelativeAge(time.dateTime, nowMs);
+  if (age === null) {
+    time.className = 'updated-age';
+    time.textContent = 'unknown';
+    time.removeAttribute('title');
+    return;
+  }
+  time.className = `updated-age age-${age.tier}`;
+  time.dateTime = age.exact;
+  time.title = age.exact;
+  time.textContent = age.label;
+}
+
+function appendUpdatedCell(row: HTMLTableRowElement, timestamp: string): void {
+  const cell = appendCell(row, '', 'updated');
+  const time = document.createElement('time');
+  time.dateTime = timestamp;
+  time.dataset.relativeTime = '';
+  updateRelativeTime(time);
+  cell.append(time);
+}
+
+function updateRelativeTimes(): void {
+  const nowMs = Date.now();
+  for (const time of document.querySelectorAll<HTMLTimeElement>('time[data-relative-time]')) {
+    updateRelativeTime(time, nowMs);
+  }
 }
 
 function copyButton(label: string): HTMLButtonElement {
@@ -404,6 +436,7 @@ function renderGhost(row: BoardRowView): HTMLTableRowElement {
   appendCell(tableRow, 'deleted', 'status-deferred');
   appendCell(tableRow, row.kind, 'kind');
   appendCell(tableRow, row.title, 'title');
+  appendUpdatedCell(tableRow, row.updated_at);
   appendCell(tableRow, '', 'labels');
   return tableRow;
 }
@@ -467,6 +500,8 @@ function renderRow(
   titleContent.append(titleText);
   title.append(titleContent);
 
+  appendUpdatedCell(tableRow, row.updated_at);
+
   const tags = appendCell(tableRow, '', 'labels');
   const cluster = document.createElement('span');
   cluster.className = 'tag-cluster';
@@ -490,7 +525,7 @@ function renderRow(
     bodyRow.className = 'bodyrow';
     appendCell(bodyRow, '', 'caret');
     const cell = appendCell(bodyRow, '', 'body-cell');
-    cell.colSpan = 6;
+    cell.colSpan = 7;
     cell.append(renderBody(view, row.id));
     fragment.append(bodyRow);
   }
@@ -681,7 +716,7 @@ function appendBoardPager(board: BoardResponse, pageIndex: number): void {
   const row = document.createElement('tr');
   row.className = 'board-page-row';
   const cell = appendCell(row, '', 'board-page');
-  cell.colSpan = 7;
+  cell.colSpan = 8;
 
   const previous = document.createElement('button');
   previous.type = 'button';
@@ -982,7 +1017,9 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () 
 });
 applyTheme(themeMode(document.documentElement.dataset.themeMode), false);
 
+const relativeTimeTimer = window.setInterval(updateRelativeTimes, RELATIVE_TIME_REFRESH_MS);
 window.addEventListener('beforeunload', () => {
+  window.clearInterval(relativeTimeTimer);
   store.stop();
 });
 void store.start();

--- a/packages/tbd/src/web/client.ts
+++ b/packages/tbd/src/web/client.ts
@@ -2,15 +2,16 @@ import { STATUS_ICONS } from '../lib/status-icons.js';
 import {
   caveatsFor,
   createClientStore,
+  DEFAULT_BOARD_SORTS,
   deltasValid,
+  formatDeltaValue,
   formatRelativeAge,
+  isDefaultBoardSort,
   MAX_EXPANDED_ROWS,
   paginateBoardRows,
   phaseLabel,
   promoteBoardSort,
   resolvedBoardSorts,
-  treeGuideText,
-  treeContinuationColumns,
 } from './core.js';
 import type {
   BeadBodyView,
@@ -22,6 +23,7 @@ import type {
   ClientStore,
   ClientView,
   IssueChangeView,
+  IssueKindView,
   IssueStatusView,
   IssueStatsView,
   LabelFacetView,
@@ -56,8 +58,11 @@ const elements = {
   tipPill: byId('tippill', HTMLSpanElement),
   search: byId('q', HTMLInputElement),
   status: byId('status', HTMLSelectElement),
+  statusValue: byId('statusvalue', HTMLSpanElement),
   kind: byId('type', HTMLSelectElement),
+  kindValue: byId('typevalue', HTMLSpanElement),
   priority: byId('priority', HTMLSelectElement),
+  priorityValue: byId('priorityvalue', HTMLSpanElement),
   labelChooser: byId('labelchooser', HTMLSpanElement),
   labelTrigger: byId('labeltrigger', HTMLButtonElement),
   labelSummary: byId('labelsummary', HTMLSpanElement),
@@ -65,6 +70,7 @@ const elements = {
   spec: byId('spec', HTMLInputElement),
   ready: byId('ready', HTMLInputElement),
   pretty: byId('pretty', HTMLInputElement),
+  sortReset: byId('sortreset', HTMLButtonElement),
   expandAll: byId('expandall', HTMLButtonElement),
   gear: byId('gear', HTMLButtonElement),
   menu: byId('menu', HTMLDivElement),
@@ -81,6 +87,150 @@ let pendingLabelFocus: string | null = null;
 let labelRenderSignature = '';
 const selectedLabels = new Set<string>();
 let activeSorts: BoardSortView[] = [];
+
+const tooltip = document.createElement('div');
+tooltip.id = 'viewer-tooltip';
+tooltip.className = 'viewer-tooltip';
+tooltip.setAttribute('role', 'tooltip');
+tooltip.setAttribute('aria-hidden', 'true');
+document.body.append(tooltip);
+let activeTooltipTarget: HTMLElement | null = null;
+let activeTooltipDescribedBy: string | null = null;
+let tooltipPointer: { x: number; y: number } | null = null;
+
+function setTooltip(target: HTMLElement, value: string): void {
+  target.removeAttribute('title');
+  target.dataset.tooltip = value;
+  if (activeTooltipTarget === target) {
+    tooltip.textContent = value;
+  }
+}
+
+function positionTooltip(): void {
+  if (activeTooltipTarget === null) {
+    return;
+  }
+  const viewportGap = 8;
+  const pointerOffsetX = 12;
+  const pointerOffsetY = 16;
+  const anchor = activeTooltipTarget.getBoundingClientRect();
+  const tip = tooltip.getBoundingClientRect();
+  let x = tooltipPointer?.x ?? anchor.left;
+  let y = tooltipPointer?.y ?? anchor.bottom;
+  x += tooltipPointer === null ? 0 : pointerOffsetX;
+  y += tooltipPointer === null ? viewportGap : pointerOffsetY;
+  if (x + tip.width > window.innerWidth - viewportGap) {
+    x =
+      tooltipPointer === null
+        ? window.innerWidth - tip.width - viewportGap
+        : tooltipPointer.x - tip.width - viewportGap;
+  }
+  if (y + tip.height > window.innerHeight - viewportGap) {
+    y =
+      tooltipPointer === null
+        ? anchor.top - tip.height - viewportGap
+        : tooltipPointer.y - tip.height - viewportGap;
+  }
+  tooltip.style.left = `${Math.max(viewportGap, x)}px`;
+  tooltip.style.top = `${Math.max(viewportGap, y)}px`;
+}
+
+function showTooltip(target: HTMLElement, pointer: { x: number; y: number } | null): void {
+  const value = target.dataset.tooltip?.trim();
+  if (value === undefined || value === '') {
+    return;
+  }
+  if (activeTooltipTarget !== target) {
+    tooltip.classList.remove('visible');
+    // Restart the CSS reveal delay for each distinct target, matching pointer intent.
+    void tooltip.offsetWidth;
+    if (activeTooltipTarget !== null) {
+      if (activeTooltipDescribedBy === null) {
+        activeTooltipTarget.removeAttribute('aria-describedby');
+      } else {
+        activeTooltipTarget.setAttribute('aria-describedby', activeTooltipDescribedBy);
+      }
+    }
+    activeTooltipTarget = target;
+    activeTooltipDescribedBy = target.getAttribute('aria-describedby');
+    const describedBy = new Set((activeTooltipDescribedBy ?? '').split(/\s+/u).filter(Boolean));
+    describedBy.add(tooltip.id);
+    target.setAttribute('aria-describedby', [...describedBy].join(' '));
+  }
+  tooltipPointer = pointer;
+  tooltip.textContent = value;
+  tooltip.classList.toggle('literal', target.hasAttribute('data-tooltip-literal'));
+  tooltip.setAttribute('aria-hidden', 'false');
+  positionTooltip();
+  tooltip.classList.add('visible');
+}
+
+function hideTooltip(): void {
+  if (activeTooltipTarget !== null) {
+    if (activeTooltipDescribedBy === null) {
+      activeTooltipTarget.removeAttribute('aria-describedby');
+    } else {
+      activeTooltipTarget.setAttribute('aria-describedby', activeTooltipDescribedBy);
+    }
+  }
+  activeTooltipTarget = null;
+  activeTooltipDescribedBy = null;
+  tooltipPointer = null;
+  tooltip.classList.remove('visible');
+  tooltip.setAttribute('aria-hidden', 'true');
+}
+
+function tooltipTarget(target: EventTarget | null): HTMLElement | null {
+  return target instanceof Element ? target.closest<HTMLElement>('[data-tooltip]') : null;
+}
+
+document.addEventListener('pointerover', (event) => {
+  const target = tooltipTarget(event.target);
+  if (
+    target === null ||
+    (event.relatedTarget instanceof Node && target.contains(event.relatedTarget))
+  ) {
+    return;
+  }
+  showTooltip(target, { x: event.clientX, y: event.clientY });
+});
+document.addEventListener('pointermove', (event) => {
+  if (activeTooltipTarget === null || tooltipPointer === null) {
+    return;
+  }
+  tooltipPointer = { x: event.clientX, y: event.clientY };
+  positionTooltip();
+});
+document.addEventListener('pointerout', (event) => {
+  if (
+    activeTooltipTarget === null ||
+    (event.relatedTarget instanceof Node && activeTooltipTarget.contains(event.relatedTarget))
+  ) {
+    return;
+  }
+  hideTooltip();
+});
+document.addEventListener('focusin', (event) => {
+  const target = tooltipTarget(event.target);
+  if (target !== null) {
+    showTooltip(target, null);
+  }
+});
+document.addEventListener('focusout', (event) => {
+  if (
+    activeTooltipTarget !== null &&
+    !(event.relatedTarget instanceof Node && activeTooltipTarget.contains(event.relatedTarget))
+  ) {
+    hideTooltip();
+  }
+});
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape') {
+    hideTooltip();
+  }
+});
+window.addEventListener('scroll', hideTooltip, true);
+window.addEventListener('resize', hideTooltip);
 
 function choice<T extends string>(value: string, choices: readonly T[], fallback: T): T {
   return choices.includes(value as T) ? (value as T) : fallback;
@@ -112,6 +262,16 @@ for (const option of elements.kind.options) {
   option.classList.add('kind-choice');
 }
 
+function syncAggregateChooserLabel(
+  chooser: HTMLSelectElement,
+  display: HTMLSpanElement,
+  labels: Readonly<Record<string, string>>,
+): void {
+  const label = labels[chooser.value];
+  display.hidden = label === undefined;
+  display.textContent = label ?? '';
+}
+
 function syncChooserSemantics(): void {
   for (const status of ISSUE_STATUSES) {
     elements.status.classList.toggle(`status-${status}`, elements.status.value === status);
@@ -122,9 +282,79 @@ function syncChooserSemantics(): void {
       elements.priority.value === priority,
     );
   }
+  syncAggregateChooserLabel(elements.status, elements.statusValue, {
+    '': 'status: active',
+    any: 'any (incl. closed)',
+  });
+  syncAggregateChooserLabel(elements.kind, elements.kindValue, { '': 'type: any' });
+  syncAggregateChooserLabel(elements.priority, elements.priorityValue, {
+    '': 'priority: any',
+  });
 }
 
 syncChooserSemantics();
+
+function setFacetOption(
+  option: HTMLOptionElement,
+  label: string,
+  count: number,
+  selectedValue: string,
+): void {
+  option.textContent = `${label} · ${count}`;
+  const unavailable = count === 0 && option.value !== selectedValue;
+  option.hidden = unavailable;
+  option.disabled = unavailable;
+}
+
+function renderCategoricalFacets(board: BoardResponse): void {
+  const statusCounts = new Map(board.statusFacets.map((facet) => [facet.value, facet.count]));
+  const statusAny = board.statusFacets.reduce((total, facet) => total + facet.count, 0);
+  const statusActive = board.statusFacets.reduce(
+    (total, facet) => total + (facet.value === 'closed' ? 0 : facet.count),
+    0,
+  );
+  for (const option of elements.status.options) {
+    const count =
+      option.value === ''
+        ? statusActive
+        : option.value === 'any'
+          ? statusAny
+          : (statusCounts.get(option.value as IssueStatusView) ?? 0);
+    const label =
+      option.value === ''
+        ? 'status: active'
+        : option.value === 'any'
+          ? 'any (incl. closed)'
+          : `${STATUS_ICONS[option.value as IssueStatusView]} ${option.value}`;
+    setFacetOption(option, label, count, elements.status.value);
+  }
+
+  const kindCounts = new Map(board.kindFacets.map((facet) => [facet.value, facet.count]));
+  const kindAny = board.kindFacets.reduce((total, facet) => total + facet.count, 0);
+  for (const option of elements.kind.options) {
+    const count =
+      option.value === '' ? kindAny : (kindCounts.get(option.value as IssueKindView) ?? 0);
+    setFacetOption(
+      option,
+      option.value === '' ? 'type: any' : option.value,
+      count,
+      elements.kind.value,
+    );
+  }
+
+  const priorityCounts = new Map(board.priorityFacets.map((facet) => [facet.value, facet.count]));
+  const priorityAny = board.priorityFacets.reduce((total, facet) => total + facet.count, 0);
+  for (const option of elements.priority.options) {
+    const count =
+      option.value === '' ? priorityAny : (priorityCounts.get(Number(option.value)) ?? 0);
+    setFacetOption(
+      option,
+      option.value === '' ? 'priority: any' : `P${option.value}`,
+      count,
+      elements.priority.value,
+    );
+  }
+}
 
 function readControls(): BoardControls {
   return {
@@ -222,7 +452,7 @@ function renderLabelChooser(facets: readonly LabelFacetView[], labels: readonly 
   }
 }
 
-function renderSortHeaders(sorts: readonly BoardSortView[]): void {
+function renderSortHeaders(sorts: readonly BoardSortView[], pretty: boolean): void {
   const resolved = resolvedBoardSorts(sorts);
   for (const header of document.querySelectorAll<HTMLTableCellElement>('th[data-sort-key]')) {
     const key = header.dataset.sortKey;
@@ -250,6 +480,14 @@ function renderSortHeaders(sorts: readonly BoardSortView[]): void {
         'aria-label',
         `Sort by ${key}; currently ${current}. Clicking makes it primary${precedence === 0 ? ' and reverses its direction' : ''}.`,
       );
+      setTooltip(
+        button,
+        pretty
+          ? key === 'updated'
+            ? 'Pretty moves outermost groups by the latest update in each visible subtree; children keep official order.'
+            : 'Pretty applies this key to outermost groups; children keep official order.'
+          : 'Flat mode applies this key to individual rows.',
+      );
     }
   }
 }
@@ -271,13 +509,16 @@ function updateRelativeTime(time: HTMLTimeElement, nowMs = Date.now()): void {
   if (age === null) {
     time.className = 'updated-age';
     time.textContent = 'unknown';
-    time.removeAttribute('title');
+    delete time.dataset.tooltip;
+    time.removeAttribute('aria-label');
     return;
   }
   time.className = `updated-age age-${age.tier}`;
   time.dateTime = age.exact;
-  time.title = age.exact;
+  setTooltip(time, age.exact);
+  time.dataset.tooltipLiteral = '';
   time.textContent = age.label;
+  time.setAttribute('aria-label', `${age.label}; ${age.exact}`);
 }
 
 function appendUpdatedCell(row: HTMLTableRowElement, timestamp: string): void {
@@ -300,7 +541,7 @@ function copyButton(label: string): HTMLButtonElement {
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'copy-button';
-  button.title = `Copy ${label}`;
+  setTooltip(button, `Copy ${label}`);
   button.setAttribute('aria-label', `Copy ${label}`);
   button.dataset.copyLabel = label;
   return button;
@@ -318,13 +559,15 @@ function finishCopy(button: HTMLButtonElement, succeeded: boolean): void {
   button.classList.toggle('copy-failed', !succeeded);
   const feedback = succeeded ? 'Copied' : 'Copy failed';
   const label = button.dataset.copyLabel ?? 'value';
-  button.title = feedback;
+  setTooltip(button, feedback);
   button.setAttribute('aria-label', `${feedback}: ${label}`);
 }
 
 function copyValueFor(button: HTMLButtonElement): string {
   const value = button.previousElementSibling;
-  return value?.classList.contains('copy-value') === true ? (value.textContent ?? '') : '';
+  return value instanceof HTMLElement && value.classList.contains('copy-value')
+    ? (value.dataset.copyValue ?? value.textContent ?? '')
+    : '';
 }
 
 function copyableText(value: string, label: string): HTMLSpanElement {
@@ -339,10 +582,16 @@ function copyableText(value: string, label: string): HTMLSpanElement {
 }
 
 function setCopyableText(parent: HTMLElement, value: string, label: string): void {
+  if (activeTooltipTarget !== null && parent.contains(activeTooltipTarget)) {
+    hideTooltip();
+  }
   parent.replaceChildren(copyableText(value, label));
 }
 
 function setCopyableBlock(parent: HTMLElement, value: string, label: string): void {
+  if (activeTooltipTarget !== null && parent.contains(activeTooltipTarget)) {
+    hideTooltip();
+  }
   parent.classList.add('copy-surface');
   const text = document.createElement('span');
   text.className = 'copy-value';
@@ -398,7 +647,7 @@ document.addEventListener('animationend', (event) => {
   button.classList.remove('copied', 'copy-failed');
   button.classList.add('copy-suppressed');
   const label = button.dataset.copyLabel ?? 'value';
-  button.title = `Copy ${label}`;
+  setTooltip(button, `Copy ${label}`);
   button.setAttribute('aria-label', `Copy ${label}`);
 });
 
@@ -454,16 +703,12 @@ function findChange(changes: readonly IssueChangeView[], id: string): IssueChang
   return changes.find((change) => change.id === id) ?? null;
 }
 
-function jsonText(value: unknown): string {
-  return JSON.stringify(value) ?? 'undefined';
-}
-
 function renderDelta(parent: HTMLElement, watch: ObservationStateView, id: string): void {
   if (!deltasValid(watch)) {
     return;
   }
   const delta = findChange(watch.latestChanges, id);
-  if (delta === null) {
+  if (delta === null || delta.change === 'created') {
     return;
   }
 
@@ -498,12 +743,25 @@ function renderDelta(parent: HTMLElement, watch: ObservationStateView, id: strin
       line.append(hunk);
     } else {
       const values = document.createElement('span');
-      values.className = 'dval';
-      setCopyableText(
-        values,
-        `${jsonText(field.before)}  →  ${jsonText(field.after)}`,
-        `${field.field} change`,
-      );
+      values.className = 'dval copyable';
+      const before = formatDeltaValue(field.before);
+      const after = formatDeltaValue(field.after);
+      const literal = document.createElement('span');
+      literal.className = 'copy-value';
+      const copyValue = `${before.full}  →  ${after.full}`;
+      literal.dataset.copyValue = copyValue;
+      literal.setAttribute('aria-label', copyValue);
+      const beforeText = document.createElement('span');
+      beforeText.className = 'delta-before';
+      beforeText.textContent = before.preview;
+      const arrow = document.createElement('span');
+      arrow.className = 'delta-arrow';
+      arrow.textContent = '  →  ';
+      const afterText = document.createElement('span');
+      afterText.className = 'delta-after';
+      afterText.textContent = after.preview;
+      literal.append(beforeText, arrow, afterText);
+      values.append(literal, copyButton(`${field.field} change`));
       line.append(values);
     }
     box.append(line);
@@ -579,7 +837,6 @@ function renderRow(
   view: ClientView,
   row: BoardRowView,
   changedIds: ReadonlySet<string>,
-  contextIds: ReadonlySet<string>,
 ): DocumentFragment {
   const fragment = document.createDocumentFragment();
   const tableRow = document.createElement('tr');
@@ -587,7 +844,6 @@ function renderRow(
   const classes = [
     changedIds.has(row.id) ? 'changed' : '',
     open ? 'open' : '',
-    contextIds.has(row.id) ? 'context' : '',
     view.flashIds.has(row.id) ? 'flash' : '',
   ].filter(Boolean);
   tableRow.className = classes.join(' ');
@@ -618,15 +874,8 @@ function renderRow(
   if (row.prefix !== '') {
     const guide = document.createElement('span');
     guide.className = 'guide';
-    guide.textContent = treeGuideText(row.prefix);
+    guide.textContent = row.prefix;
     titleContent.append(guide);
-    for (const column of treeContinuationColumns(row.prefix)) {
-      const continuation = document.createElement('span');
-      continuation.className = 'tree-continuation';
-      continuation.style.setProperty('--tree-guide-offset', `${column + 0.5}ch`);
-      continuation.setAttribute('aria-hidden', 'true');
-      titleContent.append(continuation);
-    }
   }
   const titleText = document.createElement('span');
   titleText.className = 'title-text';
@@ -639,17 +888,18 @@ function renderRow(
   const tags = appendCell(tableRow, '', 'labels');
   const cluster = document.createElement('span');
   cluster.className = 'tag-cluster';
-  if (row.ready) {
-    const ready = document.createElement('span');
-    ready.className = 'tag ready';
-    ready.textContent = 'ready';
-    cluster.append(ready);
-  }
   for (const label of row.labels) {
     const tag = document.createElement('span');
     tag.className = 'tag';
     tag.textContent = label;
     cluster.append(tag);
+  }
+  if (row.ready) {
+    const ready = document.createElement('span');
+    ready.className = 'ready-marker';
+    ready.textContent = 'ready';
+    ready.dataset.tooltip = 'Open, unassigned, and has no open blockers';
+    cluster.append(ready);
   }
   tags.append(cluster);
   fragment.append(tableRow);
@@ -884,20 +1134,24 @@ function appendBoardPager(board: BoardResponse, pageIndex: number): void {
 function renderBoard(view: ClientView, board: BoardResponse): void {
   const page = paginateBoardRows(board.rows, boardPageIndex);
   const changedIds = new Set(view.watch?.movedIds ?? []);
-  const contextIds = new Set(board.contextIds);
   boardPageIndex = page.pageIndex;
   elements.pageControls.hidden = page.pageCount <= 1;
   elements.pagePrevious.disabled = page.pageIndex === 0;
   elements.pageNext.disabled = page.pageIndex >= page.pageCount - 1;
   elements.pagePill.textContent = `page ${page.pageIndex + 1} of ${page.pageCount}`;
-  elements.pagePill.title =
-    page.total === 0 ? 'No rows' : `Rows ${page.start + 1}–${page.end} of ${page.total}`;
+  setTooltip(
+    elements.pagePill,
+    page.total === 0 ? 'No rows' : `Rows ${page.start + 1}–${page.end} of ${page.total}`,
+  );
+  if (activeTooltipTarget !== null && elements.rows.contains(activeTooltipTarget)) {
+    hideTooltip();
+  }
   elements.rows.replaceChildren();
   for (const row of view.ghostRows) {
     elements.rows.append(renderGhost(row));
   }
   for (const row of page.rows) {
-    elements.rows.append(renderRow(view, row, changedIds, contextIds));
+    elements.rows.append(renderRow(view, row, changedIds));
   }
   appendBoardPager(board, page.pageIndex);
   elements.empty.hidden = board.rows.length > 0 || view.ghostRows.length > 0;
@@ -907,7 +1161,7 @@ function renderBoard(view: ClientView, board: BoardResponse): void {
   elements.expandAll.hidden = page.rows.length === 0 || !canBulkExpand;
   elements.expandAll.textContent = allOpen ? 'Collapse all' : 'Expand all';
   elements.expandAll.disabled = elements.expandAll.hidden;
-  elements.expandAll.title = 'Expand or collapse every bead on this page.';
+  setTooltip(elements.expandAll, 'Expand or collapse every bead on this page.');
 }
 
 function renderHeader(view: ClientView, board: BoardResponse, watch: ObservationStateView): void {
@@ -917,30 +1171,42 @@ function renderHeader(view: ClientView, board: BoardResponse, watch: Observation
   dot.className = 'dot';
   elements.observerPill.append(dot, document.createTextNode(phase.label));
   elements.observerPill.className = `pill ${watch.observationPhase}`;
-  elements.observerPill.title = `Connected to the viewer server. ${phase.help}`;
+  setTooltip(elements.observerPill, `Connected to the viewer server. ${phase.help}`);
 
   const hidden = board.closedHidden > 0 ? ` · ${board.closedHidden} closed hidden` : '';
-  elements.countMeta.textContent = `${board.matched === board.total ? `${board.total} beads` : `${board.matched} of ${board.total}`}${hidden}`;
-  elements.countMeta.title =
+  elements.countMeta.textContent = `${
+    board.matched === board.total
+      ? `${board.total} beads`
+      : `${board.matched} of ${board.total} shown`
+  }${hidden}`;
+  setTooltip(
+    elements.countMeta,
     board.closedHidden > 0
       ? 'Closed beads are hidden under active, matching tbd list. Choose any or closed to include them.'
-      : 'Beads matching the current query, out of the whole graph.';
+      : 'Beads matching the current query, out of the whole graph.',
+  );
   setCopyableText(
     elements.tipPill,
     `${watch.syncBranch} @ ${short(watch.localTip)}`,
     'local sync-branch tip',
   );
-  elements.tipPill.title =
-    'Local sync-branch tip. tbd web never fetches; run tbd sync to exchange remote changes.';
+  setTooltip(
+    elements.tipPill,
+    'Local sync-branch tip. tbd web never fetches; run tbd sync to exchange remote changes.',
+  );
   setCopyableText(elements.command, board.command, 'command');
   const caveats = caveatsFor(board);
-  elements.command.title =
+  setTooltip(
+    elements.command,
     board.commandExact && caveats.length === 0
       ? 'Run this to reproduce the table below.'
-      : `Close but not exact: ${caveats.join('; ')}.`;
+      : `Close but not exact: ${caveats.join('; ')}.`,
+  );
   elements.pretty.checked = view.controls.pretty;
   activeSorts = view.controls.sorts.map((sort) => ({ ...sort }));
-  renderSortHeaders(view.controls.sorts);
+  elements.sortReset.hidden = isDefaultBoardSort(view.controls.sorts, view.controls.pretty);
+  renderSortHeaders(view.controls.sorts, view.controls.pretty);
+  renderCategoricalFacets(board);
   renderLabelChooser(board.labelFacets, view.controls.labels);
   document.title = `tbd beads (${watch.totalBeads})`;
 }
@@ -961,7 +1227,10 @@ function render(): void {
   if (disconnected) {
     elements.observerPill.textContent = 'disconnected';
     elements.observerPill.className = 'pill error';
-    elements.observerPill.title = `The live connection dropped; the browser will retry automatically. Last server state: ${phaseLabel(watch).help}`;
+    setTooltip(
+      elements.observerPill,
+      `The live connection dropped; the browser will retry automatically. Last server state: ${phaseLabel(watch).help}`,
+    );
   }
   renderBoard(view, board);
   renderStatus(watch);
@@ -1077,10 +1346,11 @@ for (const input of [elements.status, elements.kind, elements.priority, elements
   input.addEventListener('change', applyControls);
 }
 elements.pretty.addEventListener('change', () => {
-  if (elements.pretty.checked) {
-    // Pretty restores the exact hierarchical CLI view and its priority order.
-    activeSorts = [];
-  }
+  applyControls();
+});
+elements.sortReset.addEventListener('click', () => {
+  activeSorts = DEFAULT_BOARD_SORTS.map((sort) => ({ ...sort }));
+  elements.pretty.checked = true;
   applyControls();
 });
 elements.labelTrigger.addEventListener('click', () => {
@@ -1157,9 +1427,6 @@ for (const button of document.querySelectorAll<HTMLButtonElement>('.sort-button[
     }
     const view = store.getView();
     activeSorts = promoteBoardSort(view.controls.sorts, key);
-    // A globally sorted table and a parent-first tree are contradictory views.
-    // Column sorting therefore activates the flat list while keeping Pretty explicit.
-    elements.pretty.checked = false;
     applyControls();
   });
 }

--- a/packages/tbd/src/web/client.ts
+++ b/packages/tbd/src/web/client.ts
@@ -7,9 +7,11 @@ import {
   formatDeltaValue,
   formatRelativeAge,
   isDefaultBoardSort,
+  labelSearchValueForRender,
   MAX_EXPANDED_ROWS,
   paginateBoardRows,
   phaseLabel,
+  preserveLabelSearchEditingKey,
   promoteBoardSort,
   resolvedBoardSorts,
 } from './core.js';
@@ -457,8 +459,13 @@ function renderLabelChooser(
         ? selected[0]!
         : `${selected[0]} +${selected.length - 1}`;
   elements.labelTrigger.dataset.active = String(selected.length > 0);
-  if (elements.labelSearch.value !== labelSearch) {
-    elements.labelSearch.value = labelSearch;
+  const renderedLabelSearch = labelSearchValueForRender(
+    elements.labelSearch.value,
+    labelSearch,
+    document.activeElement === elements.labelSearch,
+  );
+  if (elements.labelSearch.value !== renderedLabelSearch) {
+    elements.labelSearch.value = renderedLabelSearch;
   }
 
   const signature = JSON.stringify([selected, facets]);
@@ -1473,6 +1480,9 @@ elements.labelMenu.addEventListener('click', (event) => {
   applyControls();
 });
 elements.labelMenu.addEventListener('keydown', (event) => {
+  if (preserveLabelSearchEditingKey(event.key, document.activeElement === elements.labelSearch)) {
+    return;
+  }
   const rows = [...elements.labelChoices.querySelectorAll<HTMLButtonElement>('.label-choice')];
   const current = rows.indexOf(document.activeElement as HTMLButtonElement);
   let next = -1;

--- a/packages/tbd/src/web/core.ts
+++ b/packages/tbd/src/web/core.ts
@@ -248,6 +248,20 @@ export const MAX_GHOST_ROWS = 100;
 /** Maximum visible characters for each scalar side of an expanded local field delta. */
 export const DELTA_VALUE_PREVIEW_CHARS = 80;
 
+/** Keep a focused search draft authoritative until its debounced control update lands. */
+export function labelSearchValueForRender(
+  currentValue: string,
+  storedValue: string,
+  searchOwnsFocus: boolean,
+): string {
+  return searchOwnsFocus ? currentValue : storedValue;
+}
+
+/** Home/End edit a focused search query; elsewhere they navigate the label menu. */
+export function preserveLabelSearchEditingKey(key: string, searchOwnsFocus: boolean): boolean {
+  return searchOwnsFocus && (key === 'Home' || key === 'End');
+}
+
 export interface BoardPageView {
   rows: readonly BoardRowView[];
   /** Zero-based page index after invalid and out-of-range input is clamped. */

--- a/packages/tbd/src/web/core.ts
+++ b/packages/tbd/src/web/core.ts
@@ -29,7 +29,16 @@ export interface BoardRowView {
   spec_path: string | null;
   assignee: string | null;
   ready: boolean;
+  updated_at: string;
   prefix: string;
+}
+
+export type AgeTierView = 'sec' | 'min' | 'hr' | 'day' | 'wk' | 'old';
+
+export interface RelativeAgeView {
+  exact: string;
+  label: string;
+  tier: AgeTierView;
 }
 
 export interface FieldChangeView {
@@ -209,6 +218,58 @@ export interface BoardPageView {
   /** Zero-based exclusive offset into the complete response. */
   end: number;
   total: number;
+}
+
+const MINUTE_MS = 60 * 1_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const WEEK_MS = 7 * DAY_MS;
+const MONTH_MS = 30 * DAY_MS;
+const YEAR_MS = 365 * DAY_MS;
+
+/**
+ * Format one ISO timestamp using tbd's compact "ago" vocabulary and MetaBrowser's
+ * deterministic minute/hour/day/week/month/year boundaries.
+ */
+export function formatRelativeAge(timestamp: string, nowMs = Date.now()): RelativeAgeView | null {
+  const date = new Date(timestamp);
+  const timestampMs = date.getTime();
+  if (!Number.isFinite(timestampMs)) {
+    return null;
+  }
+
+  const ageMs = Math.max(0, nowMs - timestampMs);
+  let tier: AgeTierView;
+  if (ageMs < MINUTE_MS) {
+    tier = 'sec';
+  } else if (ageMs < HOUR_MS) {
+    tier = 'min';
+  } else if (ageMs < DAY_MS) {
+    tier = 'hr';
+  } else if (ageMs < WEEK_MS) {
+    tier = 'day';
+  } else if (ageMs < MONTH_MS) {
+    tier = 'wk';
+  } else {
+    tier = 'old';
+  }
+
+  const steps: readonly [suffix: string, milliseconds: number][] = [
+    ['y', YEAR_MS],
+    ['mo', MONTH_MS],
+    ['w', WEEK_MS],
+    ['d', DAY_MS],
+    ['h', HOUR_MS],
+    ['m', MINUTE_MS],
+  ];
+  let label = 'just now';
+  for (const [suffix, milliseconds] of steps) {
+    if (ageMs >= milliseconds) {
+      label = `${Math.round(ageMs / milliseconds)}${suffix} ago`;
+      break;
+    }
+  }
+  return { exact: date.toISOString(), label, tier };
 }
 
 /** Select one bounded browser-render window from a complete board response. */

--- a/packages/tbd/src/web/core.ts
+++ b/packages/tbd/src/web/core.ts
@@ -1,5 +1,7 @@
 /** Pure browser-state orchestration. Owns no DOM and no global EventSource/fetch. */
 
+import { truncateMiddle } from '../lib/truncate.js';
+
 export type IssueStatusView = 'open' | 'in_progress' | 'blocked' | 'deferred' | 'closed';
 export type IssueKindView = 'bug' | 'feature' | 'task' | 'epic' | 'chore';
 export type ObservationPhaseView = 'starting' | 'watching' | 'error' | 'stopped';
@@ -57,6 +59,11 @@ export interface RelativeAgeView {
 
 export interface LabelFacetView {
   label: string;
+  count: number;
+}
+
+export interface ValueFacetView<T extends string | number> {
+  value: T;
   count: number;
 }
 
@@ -128,15 +135,16 @@ export interface BoardResponse {
   command: string;
   commandExact: boolean;
   filtersExact: boolean;
-  contextCount: number;
   search: string;
   total: number;
   matched: number;
   closedHidden: number;
+  statusFacets: ValueFacetView<IssueStatusView>[];
+  kindFacets: ValueFacetView<IssueKindView>[];
+  priorityFacets: ValueFacetView<number>[];
   labelFacets: LabelFacetView[];
   rows: BoardRowView[];
   truncated: number;
-  contextIds: string[];
   state: ObservationStateView;
 }
 
@@ -206,6 +214,11 @@ export interface ClientStoreOptions {
   initialControls?: Partial<BoardControls>;
 }
 
+export const DEFAULT_BOARD_SORTS: readonly BoardSortView[] = [
+  { key: 'updated', direction: 'desc' },
+  { key: 'priority', direction: 'asc' },
+];
+
 const DEFAULT_CONTROLS: BoardControls = {
   search: '',
   status: '',
@@ -213,7 +226,7 @@ const DEFAULT_CONTROLS: BoardControls = {
   priority: '',
   labels: [],
   spec: '',
-  sorts: [],
+  sorts: [...DEFAULT_BOARD_SORTS],
   ready: false,
   pretty: true,
 };
@@ -227,6 +240,8 @@ export const MAX_EXPANDED_ROWS = 100;
 export const MAX_BODY_CACHE_ENTRIES = 200;
 /** Data-motion context is useful, but a mass deletion must not bypass DOM paging. */
 export const MAX_GHOST_ROWS = 100;
+/** Maximum visible characters for each scalar side of an expanded local field delta. */
+export const DELTA_VALUE_PREVIEW_CHARS = 80;
 
 export interface BoardPageView {
   rows: readonly BoardRowView[];
@@ -309,36 +324,10 @@ export function paginateBoardRows(
   return { rows: rows.slice(start, end), pageIndex, pageCount, start, end, total };
 }
 
-/**
- * Return character columns whose ancestor tree bars continue through a wrapped title.
- *
- * Pretty prefixes are made from four-character ancestor segments followed by one
- * four-character terminal connector. The terminal `├── ` or `└── ` belongs only to
- * the current bead; only ancestor `│   ` segments continue below the first line.
- */
-export function treeContinuationColumns(prefix: string): number[] {
-  const terminalConnectorWidth = 4;
-  const ancestorEnd = Math.max(0, prefix.length - terminalConnectorWidth);
-  const columns: number[] = [];
-  for (let index = 0; index < ancestorEnd; index += 1) {
-    if (prefix[index] === '│') {
-      columns.push(index);
-    }
-  }
-  return columns;
-}
-
-/**
- * Remove first-line ancestor bars when one continuous CSS line owns that column.
- * Terminal branch/elbow glyphs stay textual because they belong only to this bead.
- */
-export function treeGuideText(prefix: string): string {
-  let text = prefix;
-  for (const column of treeContinuationColumns(prefix)) {
-    // Pretty prefixes contain only single-code-unit spaces and box-drawing marks.
-    text = `${text.slice(0, column)} ${text.slice(column + 1)}`;
-  }
-  return text;
+/** Format a bounded, middle-ellipsized field-delta preview without losing copy data. */
+export function formatDeltaValue(value: unknown): { full: string; preview: string } {
+  const full = JSON.stringify(value) ?? 'undefined';
+  return { full, preview: truncateMiddle(full, DELTA_VALUE_PREVIEW_CHARS) };
 }
 
 const DEFAULT_SORT_DIRECTIONS: Readonly<Record<BoardSortKeyView, BoardSortDirectionView>> = {
@@ -356,7 +345,7 @@ export function resolvedBoardSorts(sorts: readonly BoardSortView[]): readonly Bo
   return sorts.length === 0 ? [{ key: 'priority', direction: 'asc' }] : sorts;
 }
 
-/** Promote a column to primary; only clicking the current primary toggles direction. */
+/** Promote a column to primary; toggle it in place and retain at most one tie-breaker. */
 export function promoteBoardSort(
   sorts: readonly BoardSortView[],
   key: BoardSortKeyView,
@@ -369,7 +358,19 @@ export function promoteBoardSort(
         ? 'desc'
         : 'asc'
       : (existing?.direction ?? DEFAULT_SORT_DIRECTIONS[key]);
-  return [{ key, direction }, ...current.filter((sort) => sort.key !== key)];
+  return [{ key, direction }, ...current.filter((sort) => sort.key !== key)].slice(0, 2);
+}
+
+export function isDefaultBoardSort(sorts: readonly BoardSortView[], pretty: boolean): boolean {
+  return (
+    pretty &&
+    sorts.length === DEFAULT_BOARD_SORTS.length &&
+    sorts.every(
+      (sort, index) =>
+        sort.key === DEFAULT_BOARD_SORTS[index]?.key &&
+        sort.direction === DEFAULT_BOARD_SORTS[index]?.direction,
+    )
+  );
 }
 
 interface BodyRequest {
@@ -402,6 +403,9 @@ function asBoardResponse(value: unknown): BoardResponse {
   if (
     !isRecord(value) ||
     !Array.isArray(value.rows) ||
+    !Array.isArray(value.statusFacets) ||
+    !Array.isArray(value.kindFacets) ||
+    !Array.isArray(value.priorityFacets) ||
     !Array.isArray(value.labelFacets) ||
     !('state' in value)
   ) {
@@ -465,13 +469,6 @@ export function caveatsFor(board: BoardResponse): string[] {
   }
   if (board.search !== '') {
     caveats.push(`text search "${board.search}" applies`);
-  }
-  if (board.contextCount > 0) {
-    caveats.push(
-      `${board.contextCount} dimmed ancestor row${board.contextCount === 1 ? '' : 's'} ${
-        board.contextCount === 1 ? 'is' : 'are'
-      } shown for context`,
-    );
   }
   if (board.truncated > 0) {
     caveats.push(`only the first ${board.rows.length} of ${board.truncated} rows are shown`);

--- a/packages/tbd/src/web/core.ts
+++ b/packages/tbd/src/web/core.ts
@@ -23,6 +23,8 @@ export interface BoardSortView {
 
 export interface BoardControls {
   search: string;
+  /** Presentation-only search used to discover labels beyond the bounded facet menu. */
+  labelSearch: string;
   status: '' | 'any' | IssueStatusView;
   kind: '' | IssueKindView;
   priority: '' | '0' | '1' | '2' | '3' | '4';
@@ -143,6 +145,8 @@ export interface BoardResponse {
   kindFacets: ValueFacetView<IssueKindView>[];
   priorityFacets: ValueFacetView<number>[];
   labelFacets: LabelFacetView[];
+  /** Honest description of browser-only ordering omitted from the equivalent CLI command. */
+  orderingCaveat: string | null;
   rows: BoardRowView[];
   truncated: number;
   state: ObservationStateView;
@@ -221,6 +225,7 @@ export const DEFAULT_BOARD_SORTS: readonly BoardSortView[] = [
 
 const DEFAULT_CONTROLS: BoardControls = {
   search: '',
+  labelSearch: '',
   status: '',
   kind: '',
   priority: '',
@@ -361,9 +366,8 @@ export function promoteBoardSort(
   return [{ key, direction }, ...current.filter((sort) => sort.key !== key)].slice(0, 2);
 }
 
-export function isDefaultBoardSort(sorts: readonly BoardSortView[], pretty: boolean): boolean {
+export function isDefaultBoardSort(sorts: readonly BoardSortView[]): boolean {
   return (
-    pretty &&
     sorts.length === DEFAULT_BOARD_SORTS.length &&
     sorts.every(
       (sort, index) =>
@@ -432,6 +436,9 @@ export function buildQueryString(controls: BoardControls): string {
   if (controls.search.trim() !== '') {
     params.set('q', controls.search.trim());
   }
+  if (controls.labelSearch.trim() !== '') {
+    params.set('labelq', controls.labelSearch.trim());
+  }
   if (controls.status !== '' && controls.status !== 'any') {
     params.set('status', controls.status);
   }
@@ -466,6 +473,9 @@ export function caveatsFor(board: BoardResponse): string[] {
   const caveats: string[] = [];
   if (!board.filtersExact) {
     caveats.push('filters or ordering with no exact CLI equivalent apply');
+  }
+  if (board.orderingCaveat !== null) {
+    caveats.push(board.orderingCaveat);
   }
   if (board.search !== '') {
     caveats.push(`text search "${board.search}" applies`);

--- a/packages/tbd/src/web/core.ts
+++ b/packages/tbd/src/web/core.ts
@@ -265,7 +265,9 @@ export function formatRelativeAge(timestamp: string, nowMs = Date.now()): Relati
   let label = 'just now';
   for (const [suffix, milliseconds] of steps) {
     if (ageMs >= milliseconds) {
-      label = `${Math.round(ageMs / milliseconds)}${suffix} ago`;
+      // Floor keeps the label inside the same threshold bucket as its color tier:
+      // 59m stays 59m until the formatter switches both label and tier to 1h.
+      label = `${Math.floor(ageMs / milliseconds)}${suffix} ago`;
       break;
     }
   }

--- a/packages/tbd/src/web/core.ts
+++ b/packages/tbd/src/web/core.ts
@@ -4,15 +4,29 @@ export type IssueStatusView = 'open' | 'in_progress' | 'blocked' | 'deferred' | 
 export type IssueKindView = 'bug' | 'feature' | 'task' | 'epic' | 'chore';
 export type ObservationPhaseView = 'starting' | 'watching' | 'error' | 'stopped';
 export type ObservationModeView = 'native+reconcile' | 'native' | 'reconcile' | 'unavailable';
+export type BoardSortKeyView =
+  | 'id'
+  | 'priority'
+  | 'status'
+  | 'kind'
+  | 'title'
+  | 'updated'
+  | 'labels';
+export type BoardSortDirectionView = 'asc' | 'desc';
+
+export interface BoardSortView {
+  key: BoardSortKeyView;
+  direction: BoardSortDirectionView;
+}
 
 export interface BoardControls {
   search: string;
   status: '' | 'any' | IssueStatusView;
   kind: '' | IssueKindView;
   priority: '' | '0' | '1' | '2' | '3' | '4';
-  labels: string;
+  labels: string[];
   spec: string;
-  sort: 'priority' | 'created' | 'updated';
+  sorts: BoardSortView[];
   ready: boolean;
   pretty: boolean;
 }
@@ -39,6 +53,11 @@ export interface RelativeAgeView {
   exact: string;
   label: string;
   tier: AgeTierView;
+}
+
+export interface LabelFacetView {
+  label: string;
+  count: number;
 }
 
 export interface FieldChangeView {
@@ -114,6 +133,7 @@ export interface BoardResponse {
   total: number;
   matched: number;
   closedHidden: number;
+  labelFacets: LabelFacetView[];
   rows: BoardRowView[];
   truncated: number;
   contextIds: string[];
@@ -191,9 +211,9 @@ const DEFAULT_CONTROLS: BoardControls = {
   status: '',
   kind: '',
   priority: '',
-  labels: '',
+  labels: [],
   spec: '',
-  sort: 'priority',
+  sorts: [],
   ready: false,
   pretty: true,
 };
@@ -308,6 +328,50 @@ export function treeContinuationColumns(prefix: string): number[] {
   return columns;
 }
 
+/**
+ * Remove first-line ancestor bars when one continuous CSS line owns that column.
+ * Terminal branch/elbow glyphs stay textual because they belong only to this bead.
+ */
+export function treeGuideText(prefix: string): string {
+  let text = prefix;
+  for (const column of treeContinuationColumns(prefix)) {
+    // Pretty prefixes contain only single-code-unit spaces and box-drawing marks.
+    text = `${text.slice(0, column)} ${text.slice(column + 1)}`;
+  }
+  return text;
+}
+
+const DEFAULT_SORT_DIRECTIONS: Readonly<Record<BoardSortKeyView, BoardSortDirectionView>> = {
+  id: 'asc',
+  priority: 'asc',
+  status: 'asc',
+  kind: 'asc',
+  title: 'asc',
+  updated: 'desc',
+  labels: 'asc',
+};
+
+/** The unsent sort stack is the exact `tbd list` default: priority ascending. */
+export function resolvedBoardSorts(sorts: readonly BoardSortView[]): readonly BoardSortView[] {
+  return sorts.length === 0 ? [{ key: 'priority', direction: 'asc' }] : sorts;
+}
+
+/** Promote a column to primary; only clicking the current primary toggles direction. */
+export function promoteBoardSort(
+  sorts: readonly BoardSortView[],
+  key: BoardSortKeyView,
+): BoardSortView[] {
+  const current = resolvedBoardSorts(sorts);
+  const existing = current.find((sort) => sort.key === key);
+  const direction =
+    current[0]?.key === key
+      ? current[0].direction === 'asc'
+        ? 'desc'
+        : 'asc'
+      : (existing?.direction ?? DEFAULT_SORT_DIRECTIONS[key]);
+  return [{ key, direction }, ...current.filter((sort) => sort.key !== key)];
+}
+
 interface BodyRequest {
   id: string;
   token: number;
@@ -335,7 +399,12 @@ function asObservationState(value: unknown): ObservationStateView {
 }
 
 function asBoardResponse(value: unknown): BoardResponse {
-  if (!isRecord(value) || !Array.isArray(value.rows) || !('state' in value)) {
+  if (
+    !isRecord(value) ||
+    !Array.isArray(value.rows) ||
+    !Array.isArray(value.labelFacets) ||
+    !('state' in value)
+  ) {
     throw new Error('Server returned an invalid board response');
   }
   asObservationState(value.state);
@@ -371,11 +440,11 @@ export function buildQueryString(controls: BoardControls): string {
   if (controls.spec.trim() !== '') {
     params.set('spec', controls.spec.trim());
   }
-  for (const label of controls.labels.split(/[,\s]+/u).filter(Boolean)) {
+  for (const label of controls.labels.filter(Boolean)) {
     params.append('label', label);
   }
-  if (controls.sort !== 'priority') {
-    params.set('sort', controls.sort);
+  for (const sort of controls.sorts) {
+    params.append('order', `${sort.key}:${sort.direction}`);
   }
   if (controls.status === 'any') {
     params.set('all', '1');
@@ -392,7 +461,7 @@ export function buildQueryString(controls: BoardControls): string {
 export function caveatsFor(board: BoardResponse): string[] {
   const caveats: string[] = [];
   if (!board.filtersExact) {
-    caveats.push('filters with no exact CLI equivalent apply');
+    caveats.push('filters or ordering with no exact CLI equivalent apply');
   }
   if (board.search !== '') {
     caveats.push(`text search "${board.search}" applies`);
@@ -469,7 +538,12 @@ class Store implements ClientStore {
     private readonly onRender: () => void,
     options: ClientStoreOptions,
   ) {
-    this.controls = { ...DEFAULT_CONTROLS, ...options.initialControls };
+    this.controls = {
+      ...DEFAULT_CONTROLS,
+      ...options.initialControls,
+      labels: [...(options.initialControls?.labels ?? DEFAULT_CONTROLS.labels)],
+      sorts: [...(options.initialControls?.sorts ?? DEFAULT_CONTROLS.sorts)],
+    };
     this.storage = options.storage;
     this.resumeStorageKey = options.resumeStorageKey ?? DEFAULT_RESUME_KEY;
   }
@@ -544,7 +618,7 @@ class Store implements ClientStore {
   }
 
   async setControls(controls: BoardControls): Promise<void> {
-    this.controls = { ...controls };
+    this.controls = { ...controls, labels: [...controls.labels], sorts: [...controls.sorts] };
     this.boardRequestController?.abort();
     await this.refresh();
   }

--- a/packages/tbd/src/web/index.html
+++ b/packages/tbd/src/web/index.html
@@ -234,7 +234,7 @@
             id="labeltrigger"
             data-tooltip="--label is repeatable; beads must have every selected label"
             aria-label="Labels; all selected labels are required"
-            aria-haspopup="menu"
+            aria-haspopup="dialog"
             aria-controls="labelmenu"
             aria-expanded="false"
           >
@@ -244,10 +244,20 @@
           <div
             class="label-chooser-menu"
             id="labelmenu"
-            role="menu"
+            role="dialog"
             aria-label="Filter by every selected label"
             hidden
-          ></div>
+          >
+            <input
+              id="labelsearch"
+              class="label-search"
+              type="search"
+              placeholder="Find a label"
+              aria-label="Find a label"
+              autocomplete="off"
+            />
+            <div id="labelchoices" role="menu" aria-label="Available labels"></div>
+          </div>
         </span>
         <input id="spec" placeholder="spec" size="12" data-tooltip="--spec" aria-label="Spec" />
         <label class="check" data-tooltip="--ready"

--- a/packages/tbd/src/web/index.html
+++ b/packages/tbd/src/web/index.html
@@ -57,6 +57,7 @@
           class="icon-button"
           id="gear"
           type="button"
+          data-tooltip="Settings"
           aria-label="Settings"
           aria-expanded="false"
           aria-controls="menu"
@@ -85,7 +86,7 @@
               role="menuitemradio"
               data-theme-choice="system"
               aria-checked="false"
-              title="System theme"
+              data-tooltip="System theme"
               aria-label="System theme"
             >
               <svg
@@ -108,7 +109,7 @@
               role="menuitemradio"
               data-theme-choice="light"
               aria-checked="false"
-              title="Light theme"
+              data-tooltip="Light theme"
               aria-label="Light theme"
             >
               <svg
@@ -137,7 +138,7 @@
               role="menuitemradio"
               data-theme-choice="dark"
               aria-checked="false"
-              title="Dark theme"
+              data-tooltip="Dark theme"
               aria-label="Dark theme"
             >
               <svg
@@ -175,7 +176,12 @@
            --status X (where --all would be a no-op). Two separate controls allowed
            redundant states and made "any" a lie. -->
         <span class="select-control">
-          <select id="status" class="semantic-chooser" title="--status / --all" aria-label="Status">
+          <select
+            id="status"
+            class="semantic-chooser"
+            data-tooltip="--status / --all"
+            aria-label="Status"
+          >
             <option value="">status: active</option>
             <option value="any">any (incl. closed)</option>
             <option value="open">open</option>
@@ -184,10 +190,16 @@
             <option value="deferred">deferred</option>
             <option value="closed">closed</option>
           </select>
+          <span id="statusvalue" class="select-value" aria-hidden="true">status: active</span>
           <span class="chevron chevron-down" aria-hidden="true"></span>
         </span>
         <span class="select-control">
-          <select id="type" class="semantic-chooser kind-choice" title="--type" aria-label="Type">
+          <select
+            id="type"
+            class="semantic-chooser kind-choice"
+            data-tooltip="--type"
+            aria-label="Type"
+          >
             <option value="">type: any</option>
             <option value="bug">bug</option>
             <option value="feature">feature</option>
@@ -195,10 +207,16 @@
             <option value="epic">epic</option>
             <option value="chore">chore</option>
           </select>
+          <span id="typevalue" class="select-value" aria-hidden="true">type: any</span>
           <span class="chevron chevron-down" aria-hidden="true"></span>
         </span>
         <span class="select-control">
-          <select id="priority" class="semantic-chooser" title="--priority" aria-label="Priority">
+          <select
+            id="priority"
+            class="semantic-chooser"
+            data-tooltip="--priority"
+            aria-label="Priority"
+          >
             <option value="">priority: any</option>
             <option value="0">P0</option>
             <option value="1">P1</option>
@@ -206,6 +224,7 @@
             <option value="3">P3</option>
             <option value="4">P4</option>
           </select>
+          <span id="priorityvalue" class="select-value" aria-hidden="true">priority: any</span>
           <span class="chevron chevron-down" aria-hidden="true"></span>
         </span>
         <span class="label-chooser" id="labelchooser">
@@ -213,7 +232,7 @@
             type="button"
             class="label-chooser-trigger"
             id="labeltrigger"
-            title="--label is repeatable; beads must have every selected label"
+            data-tooltip="--label is repeatable; beads must have every selected label"
             aria-label="Labels; all selected labels are required"
             aria-haspopup="menu"
             aria-controls="labelmenu"
@@ -230,11 +249,22 @@
             hidden
           ></div>
         </span>
-        <input id="spec" placeholder="spec" size="12" title="--spec" aria-label="Spec" />
-        <label class="check" title="--ready"><input type="checkbox" id="ready" /> ready</label>
-        <label class="check" title="--pretty"
+        <input id="spec" placeholder="spec" size="12" data-tooltip="--spec" aria-label="Spec" />
+        <label class="check" data-tooltip="--ready"
+          ><input type="checkbox" id="ready" /> ready</label
+        >
+        <label class="check" data-tooltip="--pretty"
           ><input type="checkbox" id="pretty" checked /> pretty</label
         >
+        <button
+          type="button"
+          class="sort-reset"
+          id="sortreset"
+          data-tooltip="Restore Updated descending, then Priority ascending"
+          hidden
+        >
+          reset sort
+        </button>
         <button id="expandall" hidden>Expand all</button>
       </div>
 

--- a/packages/tbd/src/web/index.html
+++ b/packages/tbd/src/web/index.html
@@ -208,16 +208,29 @@
           </select>
           <span class="chevron chevron-down" aria-hidden="true"></span>
         </span>
-        <input id="label" placeholder="label" size="10" title="--label" aria-label="Labels" />
-        <input id="spec" placeholder="spec" size="12" title="--spec" aria-label="Spec" />
-        <span class="select-control">
-          <select id="sort" title="--sort" aria-label="Sort">
-            <option value="priority">sort: priority</option>
-            <option value="created">sort: created</option>
-            <option value="updated">sort: updated</option>
-          </select>
-          <span class="chevron chevron-down" aria-hidden="true"></span>
+        <span class="label-chooser" id="labelchooser">
+          <button
+            type="button"
+            class="label-chooser-trigger"
+            id="labeltrigger"
+            title="--label is repeatable; beads must have every selected label"
+            aria-label="Labels; all selected labels are required"
+            aria-haspopup="menu"
+            aria-controls="labelmenu"
+            aria-expanded="false"
+          >
+            <span id="labelsummary">labels: any</span>
+            <span class="chevron chevron-down" aria-hidden="true"></span>
+          </button>
+          <div
+            class="label-chooser-menu"
+            id="labelmenu"
+            role="menu"
+            aria-label="Filter by every selected label"
+            hidden
+          ></div>
         </span>
+        <input id="spec" placeholder="spec" size="12" title="--spec" aria-label="Spec" />
         <label class="check" title="--ready"><input type="checkbox" id="ready" /> ready</label>
         <label class="check" title="--pretty"
           ><input type="checkbox" id="pretty" checked /> pretty</label
@@ -246,13 +259,41 @@
           <thead>
             <tr>
               <th></th>
-              <th>ID</th>
-              <th>P</th>
-              <th>Status</th>
-              <th>Kind</th>
-              <th>Title</th>
-              <th class="updated">Updated</th>
-              <th class="labels">Labels</th>
+              <th data-sort-key="id">
+                <button type="button" class="sort-button" data-sort-key="id">
+                  ID<span class="sort-indicator" aria-hidden="true"></span>
+                </button>
+              </th>
+              <th data-sort-key="priority">
+                <button type="button" class="sort-button" data-sort-key="priority">
+                  P<span class="sort-indicator" aria-hidden="true"></span>
+                </button>
+              </th>
+              <th data-sort-key="status">
+                <button type="button" class="sort-button" data-sort-key="status">
+                  Status<span class="sort-indicator" aria-hidden="true"></span>
+                </button>
+              </th>
+              <th data-sort-key="kind">
+                <button type="button" class="sort-button" data-sort-key="kind">
+                  Kind<span class="sort-indicator" aria-hidden="true"></span>
+                </button>
+              </th>
+              <th data-sort-key="title">
+                <button type="button" class="sort-button" data-sort-key="title">
+                  Title<span class="sort-indicator" aria-hidden="true"></span>
+                </button>
+              </th>
+              <th class="updated" data-sort-key="updated">
+                <button type="button" class="sort-button" data-sort-key="updated">
+                  Updated<span class="sort-indicator" aria-hidden="true"></span>
+                </button>
+              </th>
+              <th class="labels" data-sort-key="labels">
+                <button type="button" class="sort-button" data-sort-key="labels">
+                  Labels<span class="sort-indicator" aria-hidden="true"></span>
+                </button>
+              </th>
             </tr>
           </thead>
           <tbody id="rows"></tbody>

--- a/packages/tbd/src/web/index.html
+++ b/packages/tbd/src/web/index.html
@@ -232,7 +232,17 @@
 
     <main>
       <div id="tablewrap">
-        <table aria-label="Beads">
+        <table class="board-table" aria-label="Beads">
+          <colgroup>
+            <col class="board-col-disclosure" />
+            <col class="board-col-id" />
+            <col class="board-col-priority" />
+            <col class="board-col-status" />
+            <col class="board-col-kind" />
+            <col class="board-col-title" />
+            <col class="board-col-updated" />
+            <col class="board-col-labels" />
+          </colgroup>
           <thead>
             <tr>
               <th></th>
@@ -241,6 +251,7 @@
               <th>Status</th>
               <th>Kind</th>
               <th>Title</th>
+              <th class="updated">Updated</th>
               <th class="labels">Labels</th>
             </tr>
           </thead>

--- a/packages/tbd/src/web/styles.css
+++ b/packages/tbd/src/web/styles.css
@@ -98,11 +98,13 @@
 
      Dynamic labels (.label-chooser-menu, .label-choice)
        Label facets come from the complete local snapshot, ranked by bead count
-       then name, and capped at 32 while retaining selected values. The menu is
-       a keyboard-operable multi-chooser: a fixed check column, the same neutral
-       `.tag` primitive used in rows, and a tabular sans tally. Selection stays
-       open for composition; Any clears the set. Repeated labels retain the CLI's
-       AND contract, and the control's accessible name states that requirement.
+       then name. The unsearched menu shows the first 32; its search field queries
+       the complete label vocabulary and returns up to 32 matches while retaining
+       selected values. The menu is a keyboard-operable multi-chooser: a fixed check
+       column, the same neutral `.tag` primitive used in rows, and a tabular sans
+       tally. Selection stays open for composition; Any clears the set. Repeated
+       labels retain the CLI's AND contract, and the control's accessible name states
+       that requirement.
 
      Facet tallies (.semantic-chooser option, .label-choice-count)
        Every finite categorical filter shows counts. Status, Type, and Priority
@@ -129,6 +131,7 @@
        fast fade, viewport clamping, Escape/scroll dismissal, and no per-target
        listeners or repeated tooltip DOM. Text is compact sans chrome unless
        the revealed value is explicitly marked as a literal (exact ISO time).
+       Render completion dismisses the tooltip if its anchor left the document.
        Essential labels remain visible or accessible outside the tooltip.
 
      Tree structure (.guide, .title-content)
@@ -156,11 +159,21 @@
        Every data header is one unboxed button. The arrow and ordinal expose the
        two-key sort stack: the latest clicked column is primary, the prior primary
        is its sole tie-breaker, and only clicking the current primary reverses it.
-       The default is Pretty with Updated descending then Priority ascending; Reset
-       restores that complete state. In Pretty, sorts move only outermost visible
+       The default sort stack is Updated descending then Priority ascending; Reset
+       restores that stack without changing Pretty. In Pretty, sorts move only outermost visible
        parent groups. Updated uses the latest timestamp across each complete visible
        subtree, regardless of parent kind, while children always retain official
-       child_order_hints order. Flat mode applies the same stack globally.
+       child_order_hints order. Flat mode applies the same stack globally. The
+       equivalent-command tooltip names this browser-only ordering rather than
+       implying that the adjacent CLI command reproduces it.
+
+     Live board interaction (.board-table tbody, .disclosure)
+       One delegated tbody click handler owns row expansion. A non-collapsed text
+       selection suppresses expansion, copy controls stop propagation, and keyboard
+       activation remains native to the disclosure button. Live replacement restores
+       focus by stable bead ID and control role; label choices restore focus by label.
+       Refresh failures keep the last successful rows visible and change the persistent
+       observer pill to an error state until a successful board response clears it.
 
      Typography and expansion (--weight-medium, --weight-strong)
        The complete type scale is 15px page title, 14px body/content, and one
@@ -754,6 +767,13 @@ button {
     transform var(--transition-fast),
     visibility 0s linear 0s;
 }
+.label-search {
+  width: 100%;
+  margin-bottom: 4px;
+}
+#labelchoices {
+  display: grid;
+}
 .label-chooser-menu[hidden] {
   display: grid;
   opacity: 0;
@@ -1219,11 +1239,13 @@ tr.bodyrow > td.body-cell {
   overflow: hidden;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 4;
+  line-clamp: 4;
 }
 tr.open .title-text {
   display: block;
   overflow: visible;
   -webkit-line-clamp: unset;
+  line-clamp: unset;
 }
 /* ── DATA motion ────────────────────────────────────────────────
    Applied only when the server reports a new `dataVersion`. Never

--- a/packages/tbd/src/web/styles.css
+++ b/packages/tbd/src/web/styles.css
@@ -40,6 +40,11 @@
        Aggregate prose and counts are unboxed, neutral sans text. Use
        tabular numerals for alignment. A count is not a pill.
 
+     Repository metadata (#statusdl)
+       Status-panel terms are sans chrome and values are monospace literals, but
+       both use the standard 14px body scale. The compact 12px scale is reserved
+       for genuinely dense secondary chrome, not primary field/value rows.
+
      Section headings (.section-heading, .hint)
        Every UI chunk has a small-cap sans name. When a faithful CLI
        equivalent exists, place that live command beside it as a monospace
@@ -60,16 +65,19 @@
      Updated age (.updated-age, .age-*)
        Relative timestamps use tbd's compact "ago" vocabulary and
        MetaBrowser's six freshness tiers; hover reveals exact ISO time.
+       The relative age is derived compact sans chrome; the tooltip's exact
+       ISO timestamp is a monospace literal. Both use the one compact size.
        All tiers stay in one blue hue band: newer is darker/saturated in
        light mode and brighter/saturated in dark mode, while older recedes.
        Blue therefore means age only; priority keeps red/amber/neutral and
        lifecycle state keeps its terminal-aligned semantic families.
 
      Tags (.tag)
-       Bordered tags are categorical attributes. User labels stay
-       neutral because tbd does not know their semantics. `.ready` uses
-       success green because it is a computed actionable state, not a
-       lifecycle status. Kind stays neutral auxiliary text.
+       Bordered tags are categorical attributes. User labels stay neutral
+       because tbd does not know their semantics. Ready is not a label: its
+       quiet, unboxed marker follows real labels and uses success green because
+       it is a computed actionable state, not a lifecycle status. Kind stays
+       neutral auxiliary text.
 
      Operational badges (.pill)
        Pills are reserved for bounded viewer state: observer phase,
@@ -96,6 +104,16 @@
        open for composition; Any clears the set. Repeated labels retain the CLI's
        AND contract, and the control's accessible name states that requirement.
 
+     Facet tallies (.semantic-chooser option, .label-choice-count)
+       Every finite categorical filter shows counts. Status, Type, and Priority
+       counts apply search plus every other active filter while omitting their
+       own dimension, so switching remains possible. Labels instead show the
+       next repeated-label AND intersection. Unselected zero-count choices are
+       hidden; a selected zero-count choice stays visible so its constraint can
+       be removed. Aggregate choices keep their contextual count in the open
+       menu, but their closed chooser face omits it to avoid repeating the same
+       total across controls. Search and Spec have no finite vocabulary and no tally.
+
      Literal copy (.copyable, .copy-surface, .copy-button)
        Monospace values and faithful commands expose one small muted copy
        icon on container hover or keyboard focus. Inline values reserve its
@@ -105,14 +123,26 @@
        still green. Glyphs are CSS masks and events are delegated, leaving one
        accessible button—but no SVG subtree or private listeners—per literal.
 
-     Tree structure (.guide, .tree-continuation, .title-content)
-       Line-drawing characters are structural text, so they reuse the
-       --muted auxiliary-text token rather than the fainter border color.
-       Wrapped titles keep a hanging indent after the entire guide. Only
-       one continuous CSS stroke owns each ancestor vertical from the first
-       line through every wrapped line. The matching first-line text glyph is
-       blanked so color, width, and geometry cannot diverge at the wrap. The
-       terminal branch or elbow remains text on the first line only.
+     Tooltips (.viewer-tooltip, [data-tooltip])
+       One body-level, delegated tooltip replaces slow native title bubbles.
+       Pointer and keyboard focus share a 250ms deliberate reveal, the standard
+       fast fade, viewport clamping, Escape/scroll dismissal, and no per-target
+       listeners or repeated tooltip DOM. Text is compact sans chrome unless
+       the revealed value is explicitly marked as a literal (exact ISO time).
+       Essential labels remain visible or accessible outside the tooltip.
+
+     Tree structure (.guide, .title-content)
+       First-line box-drawing characters reuse the --muted auxiliary-text
+       token. Wrapped lines keep a clean hanging indent after the entire guide;
+       they do not synthesize vertical rules whose geometry can disagree with
+       the font's Unicode bars. Only `.title-text` wraps; disclosure remains in
+       its own column.
+
+     Local field deltas (.delta-before, .delta-after)
+       Each scalar side uses an 80-character middle-ellipsis preview so appended
+       changes remain visible; Copy retains the bounded full value. Before is
+       muted historical context and after is normal text. Creation emits no
+       redundant null-to-value detail in an expanded bead.
 
      Board columns (.board-table, .board-col-*)
        One fixed semantic colgroup owns geometry for header, rows, expanded
@@ -123,11 +153,13 @@
 
      Column sorting (.sort-button, .sort-indicator)
        Every data header is one unboxed button. The arrow and ordinal expose the
-       ordered sort stack: the latest clicked column is primary and earlier keys
-       remain tie-breakers; only clicking the current primary reverses it. A
-       global column order cannot also preserve parent-first hierarchy, so a
-       header click explicitly activates the flat view by clearing Pretty;
-       re-enabling Pretty clears the custom stack and restores CLI priority order.
+       two-key sort stack: the latest clicked column is primary, the prior primary
+       is its sole tie-breaker, and only clicking the current primary reverses it.
+       The default is Pretty with Updated descending then Priority ascending; Reset
+       restores that complete state. In Pretty, sorts move only outermost visible
+       parent groups. Updated uses the latest timestamp across each complete visible
+       subtree, regardless of parent kind, while children always retain official
+       child_order_hints order. Flat mode applies the same stack globally.
 
      Typography and expansion (--weight-medium, --weight-strong)
        The complete type scale is 15px page title, 14px body/content, and one
@@ -259,6 +291,8 @@
   --motion-fast-duration: 150ms;
   --motion-standard-easing: ease;
   --transition-fast: var(--motion-fast-duration) var(--motion-standard-easing);
+  --tooltip-show-delay: 250ms;
+  --z-tooltip: 100;
   /* DATA motion: long enough to notice across a full table, short
      enough not to linger. Removal is faster because the row is
      leaving and should not hold the reader. */
@@ -275,15 +309,15 @@
   --row-disclosure-width: 20px;
   --board-row-line-height: 18px;
   --row-disclosure-offset-y: 1px;
-  /* Fixed board grid. Percentages total 100%; the 29/22 title-to-label split
+  /* Fixed board grid. Percentages total 100%; the 24/22 title-to-label split
      deliberately keeps long descriptions from starving categorical tags. */
   --board-disclosure-column-width: 3%;
   --board-id-column-width: 11%;
-  --board-priority-column-width: 5%;
+  --board-priority-column-width: 7%;
   --board-status-column-width: 12%;
   --board-kind-column-width: 8%;
-  --board-title-column-width: 29%;
-  --board-updated-column-width: 10%;
+  --board-title-column-width: 24%;
+  --board-updated-column-width: 13%;
   --board-labels-column-width: 22%;
   --icon-glyph-size: 15px;
   --icon-button-size: 28px;
@@ -648,6 +682,21 @@ button {
   width: 100%;
   padding-right: var(--select-chevron-padding);
 }
+.select-value {
+  position: absolute;
+  inset: 1px var(--select-chevron-padding) 1px 1px;
+  display: flex;
+  align-items: center;
+  padding-left: 7px;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--muted);
+  pointer-events: none;
+  white-space: nowrap;
+}
+.select-value[hidden] {
+  display: none;
+}
 .select-control > .chevron {
   position: absolute;
   top: 50%;
@@ -747,6 +796,47 @@ button {
   color: var(--muted);
   font-size: var(--font-size-small);
   font-variant-numeric: tabular-nums;
+}
+.sort-reset {
+  padding: 2px 4px;
+  border-color: transparent;
+  background: transparent;
+  color: var(--muted);
+  font-size: var(--font-size-small);
+}
+.sort-reset:hover,
+.sort-reset:focus-visible {
+  color: var(--text);
+  background: var(--panel);
+  border-color: var(--border);
+}
+.viewer-tooltip {
+  position: fixed;
+  z-index: var(--z-tooltip);
+  visibility: hidden;
+  max-width: 360px;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--panel);
+  box-shadow: 0 5px 16px var(--border);
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: var(--font-size-small);
+  line-height: 1.4;
+  pointer-events: none;
+  opacity: 0;
+  transition:
+    opacity var(--transition-fast),
+    visibility 0s linear var(--motion-fast-duration);
+}
+.viewer-tooltip.visible {
+  visibility: visible;
+  opacity: 1;
+  transition-delay: var(--tooltip-show-delay), 0s;
+}
+.viewer-tooltip.literal {
+  font-family: var(--mono);
 }
 button {
   cursor: pointer;
@@ -883,7 +973,8 @@ label.check {
 main {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 340px;
-  align-items: start;
+  /* Stretch both grid areas so the sidebar's rule spans the full board height. */
+  align-items: stretch;
 }
 @media (max-width: 900px) {
   main {
@@ -1028,7 +1119,7 @@ td.updated {
   white-space: nowrap;
 }
 .updated-age {
-  font-family: var(--mono);
+  font-family: var(--sans);
   font-size: var(--font-size-small);
   font-variant-numeric: tabular-nums;
   font-weight: var(--weight-medium);
@@ -1096,9 +1187,6 @@ tr.open > td {
 tr.open > td.id {
   font-weight: var(--weight-strong);
 }
-tr.context > td:not(.caret) {
-  opacity: 0.5;
-}
 tr.bodyrow > td {
   padding-top: 0;
   padding-bottom: 12px;
@@ -1122,16 +1210,6 @@ tr.bodyrow > td.body-cell {
   align-items: baseline;
   min-width: 0;
   position: relative;
-}
-.tree-continuation {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: var(--tree-guide-offset);
-  border-left: 1px solid var(--muted);
-  font-family: var(--mono);
-  font-size: var(--font-size-small);
-  pointer-events: none;
 }
 .title-text {
   display: -webkit-box;
@@ -1191,6 +1269,7 @@ tr.changed td.id .copy-value::after {
 @media (prefers-reduced-motion: reduce) {
   :root {
     --motion-fast-duration: 1ms;
+    --tooltip-show-delay: 0ms;
     --copy-feedback-duration: 1ms;
   }
   /* Keep the amber context, drop the movement. */
@@ -1218,9 +1297,11 @@ tr.changed td.id .copy-value::after {
   align-items: flex-start;
   gap: 3px;
 }
-.tag.ready {
+.ready-marker {
+  align-self: center;
+  font-size: var(--font-size-small);
   color: var(--success);
-  border-color: var(--success);
+  white-space: nowrap;
 }
 aside {
   border-left: 1px solid var(--border);
@@ -1373,6 +1454,13 @@ pre {
   font-size: var(--font-size-small);
   word-break: break-all;
 }
+.delta-before,
+.delta-arrow {
+  color: var(--muted);
+}
+.delta-after {
+  color: var(--text);
+}
 pre.hunk {
   margin: 3px 0 0;
   max-height: 200px;
@@ -1409,7 +1497,7 @@ pre.hunk {
   row-gap: 3px;
   align-items: baseline;
   margin: 0;
-  font-size: var(--font-size-small);
+  font-size: var(--font-size-body);
 }
 #statusdl dt {
   color: var(--muted);
@@ -1419,7 +1507,7 @@ pre.hunk {
 #statusdl dd {
   margin: 0;
   font-family: var(--mono);
-  font-size: var(--font-size-small);
+  font-size: var(--font-size-body);
   word-break: break-all;
 }
 .empty {

--- a/packages/tbd/src/web/styles.css
+++ b/packages/tbd/src/web/styles.css
@@ -57,6 +57,14 @@
        Match the CLI: P0=error red, P1=warning amber, P2–P4=neutral.
        Priority is compact text, never an icon or pill.
 
+     Updated age (.updated-age, .age-*)
+       Relative timestamps use tbd's compact "ago" vocabulary and
+       MetaBrowser's six freshness tiers; hover reveals exact ISO time.
+       All tiers stay in one blue hue band: newer is darker/saturated in
+       light mode and brighter/saturated in dark mode, while older recedes.
+       Blue therefore means age only; priority keeps red/amber/neutral and
+       lifecycle state keeps its terminal-aligned semantic families.
+
      Tags (.tag)
        Bordered tags are categorical attributes. User labels stay
        neutral because tbd does not know their semantics. `.ready` uses
@@ -95,6 +103,12 @@
        Wrapped titles keep a hanging indent after the entire guide. Only
        ancestor verticals continue through wrapped lines; the terminal
        branch or elbow belongs to the first line and never continues.
+
+     Board columns (.board-table, .board-col-*)
+       One fixed semantic colgroup owns geometry for header, rows, expanded
+       detail, ghosts, and paging. Content never participates in column sizing,
+       so expansion cannot shift the table. Title gets a bounded proportional
+       share and wraps; labels get a larger share and wrap only between tags.
 
      Typography and expansion (--weight-medium, --weight-strong)
        The complete type scale is 15px page title, 14px body/content, and one
@@ -177,6 +191,15 @@
   --warning: hsl(38 82% 36%);
   --error: hsl(0 64% 46%);
 
+  /* Updated-age ramp. This adapts MetaBrowser's freshness tiers but keeps
+     every stop in blue so age cannot be confused with priority or status. */
+  --age-sec: hsl(211 82% 38%);
+  --age-min: hsl(213 72% 42%);
+  --age-hr: hsl(215 58% 46%);
+  --age-day: hsl(217 46% 48%);
+  --age-wk: hsl(219 32% 46%);
+  --age-old: hsl(221 18% 44%);
+
   /* Wake family (38°, amber). Reserved for DATA motion. Nothing that
      responds to a UI interaction may use these two tokens. */
   --update: hsl(38 76% 42%);
@@ -194,6 +217,12 @@
   --dark-success: hsl(149 52% 55%);
   --dark-warning: hsl(38 82% 64%);
   --dark-error: hsl(0 100% 73%);
+  --dark-age-sec: hsl(211 82% 74%);
+  --dark-age-min: hsl(213 72% 71%);
+  --dark-age-hr: hsl(215 58% 68%);
+  --dark-age-day: hsl(217 46% 65%);
+  --dark-age-wk: hsl(219 32% 62%);
+  --dark-age-old: hsl(221 18% 59%);
   --dark-update: hsl(43 73% 57%);
   --dark-row-flash-bg: hsl(41 53% 15%);
 
@@ -227,6 +256,16 @@
   --row-disclosure-width: 20px;
   --board-row-line-height: 18px;
   --row-disclosure-offset-y: 1px;
+  /* Fixed board grid. Percentages total 100%; the 29/22 title-to-label split
+     deliberately keeps long descriptions from starving categorical tags. */
+  --board-disclosure-column-width: 3%;
+  --board-id-column-width: 11%;
+  --board-priority-column-width: 5%;
+  --board-status-column-width: 12%;
+  --board-kind-column-width: 8%;
+  --board-title-column-width: 29%;
+  --board-updated-column-width: 10%;
+  --board-labels-column-width: 22%;
   --icon-glyph-size: 15px;
   --icon-button-size: 28px;
   --copy-button-size: 18px;
@@ -257,6 +296,12 @@
     --success: var(--dark-success);
     --warning: var(--dark-warning);
     --error: var(--dark-error);
+    --age-sec: var(--dark-age-sec);
+    --age-min: var(--dark-age-min);
+    --age-hr: var(--dark-age-hr);
+    --age-day: var(--dark-age-day);
+    --age-wk: var(--dark-age-wk);
+    --age-old: var(--dark-age-old);
     --update: var(--dark-update);
     --row-flash-bg: var(--dark-row-flash-bg);
   }
@@ -273,6 +318,12 @@
   --success: var(--dark-success);
   --warning: var(--dark-warning);
   --error: var(--dark-error);
+  --age-sec: var(--dark-age-sec);
+  --age-min: var(--dark-age-min);
+  --age-hr: var(--dark-age-hr);
+  --age-day: var(--dark-age-day);
+  --age-wk: var(--dark-age-wk);
+  --age-old: var(--dark-age-old);
   --update: var(--dark-update);
   --row-flash-bg: var(--dark-row-flash-bg);
 }
@@ -742,6 +793,34 @@ table {
   width: 100%;
   min-width: 700px;
 }
+.board-table {
+  table-layout: fixed;
+  min-width: 820px;
+}
+.board-col-disclosure {
+  width: var(--board-disclosure-column-width);
+}
+.board-col-id {
+  width: var(--board-id-column-width);
+}
+.board-col-priority {
+  width: var(--board-priority-column-width);
+}
+.board-col-status {
+  width: var(--board-status-column-width);
+}
+.board-col-kind {
+  width: var(--board-kind-column-width);
+}
+.board-col-title {
+  width: var(--board-title-column-width);
+}
+.board-col-updated {
+  width: var(--board-updated-column-width);
+}
+.board-col-labels {
+  width: var(--board-labels-column-width);
+}
 th,
 td {
   text-align: left;
@@ -759,11 +838,6 @@ th {
   background: var(--bg);
   z-index: 1;
   font-weight: var(--weight-medium);
-}
-th.labels,
-td.labels {
-  width: 160px;
-  min-width: 160px;
 }
 td.id {
   font-family: var(--mono);
@@ -816,8 +890,37 @@ td.priority {
 td.kind {
   color: var(--muted);
 }
+td.title {
+  overflow-wrap: anywhere;
+}
+th.updated,
+td.updated {
+  white-space: nowrap;
+}
+.updated-age {
+  font-size: var(--font-size-small);
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--weight-medium);
+}
+.age-sec {
+  color: var(--age-sec);
+}
+.age-min {
+  color: var(--age-min);
+}
+.age-hr {
+  color: var(--age-hr);
+}
+.age-day {
+  color: var(--age-day);
+}
+.age-wk {
+  color: var(--age-wk);
+}
+.age-old {
+  color: var(--age-old);
+}
 td.caret {
-  width: 18px;
   color: var(--muted);
   user-select: none;
   padding-right: 0;

--- a/packages/tbd/src/web/styles.css
+++ b/packages/tbd/src/web/styles.css
@@ -132,11 +132,12 @@
        Essential labels remain visible or accessible outside the tooltip.
 
      Tree structure (.guide, .title-content)
-       First-line box-drawing characters reuse the --muted auxiliary-text
-       token. Wrapped lines keep a clean hanging indent after the entire guide;
-       they do not synthesize vertical rules whose geometry can disagree with
-       the font's Unicode bars. Only `.title-text` wraps; disclosure remains in
-       its own column.
+       Every non-root bead has exactly one `└──` elbow at its depth indentation;
+       sibling position never changes it to a tee and ancestor levels use spaces,
+       never vertical bars. The elbow reuses the --muted auxiliary-text token.
+       Wrapped lines keep a clean hanging indent after the entire guide and never
+       synthesize continuation rules. Only `.title-text` wraps; disclosure remains
+       in its own column.
 
      Local field deltas (.delta-before, .delta-after)
        Each scalar side uses an 80-character middle-ellipsis preview so appended

--- a/packages/tbd/src/web/styles.css
+++ b/packages/tbd/src/web/styles.css
@@ -76,7 +76,7 @@
        update activity, page position, and sync-branch tip. They are not
        a generic way to decorate text.
 
-     Controls (.select-control, .chooser) and icons (.chevron, .icon-button)
+     Controls (.select-control, .chooser, .label-chooser) and icons (.chevron, .icon-button)
        Native controls keep native behavior but share spacing, focus,
        and one CSS chevron geometry. Disclosure and dropdown chevrons
        are the same mark at different orientations. Lifecycle symbols
@@ -87,6 +87,14 @@
        reuse the exact status, priority, and kind roles from table cells.
        Boolean flags are checkboxes named for their CLI flag; verbs that
        perform an action are buttons.
+
+     Dynamic labels (.label-chooser-menu, .label-choice)
+       Label facets come from the complete local snapshot, ranked by bead count
+       then name, and capped at 32 while retaining selected values. The menu is
+       a keyboard-operable multi-chooser: a fixed check column, the same neutral
+       `.tag` primitive used in rows, and a tabular sans tally. Selection stays
+       open for composition; Any clears the set. Repeated labels retain the CLI's
+       AND contract, and the control's accessible name states that requirement.
 
      Literal copy (.copyable, .copy-surface, .copy-button)
        Monospace values and faithful commands expose one small muted copy
@@ -101,14 +109,25 @@
        Line-drawing characters are structural text, so they reuse the
        --muted auxiliary-text token rather than the fainter border color.
        Wrapped titles keep a hanging indent after the entire guide. Only
-       ancestor verticals continue through wrapped lines; the terminal
-       branch or elbow belongs to the first line and never continues.
+       one continuous CSS stroke owns each ancestor vertical from the first
+       line through every wrapped line. The matching first-line text glyph is
+       blanked so color, width, and geometry cannot diverge at the wrap. The
+       terminal branch or elbow remains text on the first line only.
 
      Board columns (.board-table, .board-col-*)
        One fixed semantic colgroup owns geometry for header, rows, expanded
        detail, ghosts, and paging. Content never participates in column sizing,
        so expansion cannot shift the table. Title gets a bounded proportional
        share and wraps; labels get a larger share and wrap only between tags.
+       Collapsed titles clamp at four lines; expanding restores the full title.
+
+     Column sorting (.sort-button, .sort-indicator)
+       Every data header is one unboxed button. The arrow and ordinal expose the
+       ordered sort stack: the latest clicked column is primary and earlier keys
+       remain tie-breakers; only clicking the current primary reverses it. A
+       global column order cannot also preserve parent-first hierarchy, so a
+       header click explicitly activates the flat view by clearing Pretty;
+       re-enabling Pretty clears the custom stack and restores CLI priority order.
 
      Typography and expansion (--weight-medium, --weight-strong)
        The complete type scale is 15px page title, 14px body/content, and one
@@ -642,6 +661,93 @@ button {
 .select-control:focus-within {
   color: var(--accent);
 }
+.label-chooser {
+  position: relative;
+  display: inline-flex;
+}
+.label-chooser-trigger {
+  display: inline-flex;
+  min-width: 112px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  color: var(--muted);
+}
+.label-chooser-trigger[data-active='true'],
+.label-chooser[data-open] > .label-chooser-trigger {
+  color: var(--text);
+}
+.label-chooser[data-open] > .label-chooser-trigger > .chevron {
+  transform: rotate(225deg);
+}
+.label-chooser-menu {
+  position: absolute;
+  top: calc(100% + 5px);
+  left: 0;
+  z-index: 10;
+  display: grid;
+  min-width: 190px;
+  max-width: 300px;
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 4px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 5px 16px var(--border);
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  transform-origin: top left;
+  transition:
+    opacity var(--transition-fast),
+    transform var(--transition-fast),
+    visibility 0s linear 0s;
+}
+.label-chooser-menu[hidden] {
+  display: grid;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(-4px);
+  transition:
+    opacity var(--transition-fast),
+    transform var(--transition-fast),
+    visibility 0s linear var(--motion-fast-duration);
+}
+.label-choice {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 5px 6px;
+  border: 0;
+  background: transparent;
+  text-align: left;
+}
+.label-choice:hover,
+.label-choice:focus-visible {
+  background: var(--panel);
+}
+.label-choice-check {
+  color: var(--accent);
+  text-align: center;
+}
+.label-choice-any {
+  color: var(--muted);
+}
+.label-choice-tag {
+  justify-self: start;
+  overflow: hidden;
+  max-width: 100%;
+  text-overflow: ellipsis;
+}
+.label-choice-count {
+  color: var(--muted);
+  font-size: var(--font-size-small);
+  font-variant-numeric: tabular-nums;
+}
 button {
   cursor: pointer;
 }
@@ -839,6 +945,30 @@ th {
   z-index: 1;
   font-weight: var(--weight-medium);
 }
+.sort-button {
+  display: inline-flex;
+  max-width: 100%;
+  align-items: baseline;
+  gap: 4px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+}
+.sort-button:hover,
+.sort-button:focus-visible {
+  color: var(--text);
+  border-color: transparent;
+}
+.sort-indicator {
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
 td.id {
   font-family: var(--mono);
   font-size: var(--font-size-small);
@@ -898,6 +1028,7 @@ td.updated {
   white-space: nowrap;
 }
 .updated-age {
+  font-family: var(--mono);
   font-size: var(--font-size-small);
   font-variant-numeric: tabular-nums;
   font-weight: var(--weight-medium);
@@ -994,7 +1125,7 @@ tr.bodyrow > td.body-cell {
 }
 .tree-continuation {
   position: absolute;
-  top: var(--board-row-line-height);
+  top: 0;
   bottom: 0;
   left: var(--tree-guide-offset);
   border-left: 1px solid var(--muted);
@@ -1003,8 +1134,17 @@ tr.bodyrow > td.body-cell {
   pointer-events: none;
 }
 .title-text {
+  display: -webkit-box;
   flex: 1 1 auto;
   min-width: 0;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+}
+tr.open .title-text {
+  display: block;
+  overflow: visible;
+  -webkit-line-clamp: unset;
 }
 /* ── DATA motion ────────────────────────────────────────────────
    Applied only when the server reports a new `dataVersion`. Never

--- a/packages/tbd/tests/bead-web-css.test.ts
+++ b/packages/tbd/tests/bead-web-css.test.ts
@@ -286,7 +286,7 @@ describe('chevron icon system', () => {
     expect(disclosureRule, 'expected a stable disclosure line box').not.toBeNull();
     expect(disclosureRule).toContain('place-items: center');
 
-    expect(page.match(/class="select-control"/gu)).toHaveLength(4);
+    expect(page.match(/class="select-control"/gu)).toHaveLength(3);
     expect(page.match(/class="chevron chevron-down"/gu)).toHaveLength(4);
     expect(client).toContain("disclosure.setAttribute('aria-expanded', String(open))");
     expect(client).toContain("chevron.className = `chevron chevron-${open ? 'down' : 'right'}`");
@@ -455,7 +455,7 @@ describe('semantic color and component roles', () => {
 });
 
 describe('tree-title layout', () => {
-  it('wraps after the tree guide and continues only ancestor verticals', async () => {
+  it('uses one continuous glyph geometry for first-line and wrapped ancestor verticals', async () => {
     const [css, client] = await Promise.all([readStyleBlock(), readFile(clientPath, 'utf8')]);
     const contentRule = blockAfter(css, '.title-content');
     const textRule = blockAfter(css, '.title-text');
@@ -465,12 +465,23 @@ describe('tree-title layout', () => {
     expect(textRule).toContain('min-width: 0');
     expect(blockAfter(css, '.guide')).toContain('color: var(--muted)');
     const continuationRule = blockAfter(css, '.tree-continuation');
-    expect(continuationRule).toContain('top: var(--board-row-line-height)');
+    expect(continuationRule).toContain('top: 0');
     expect(continuationRule).toContain('border-left: 1px solid var(--muted)');
     expect(client).toContain("titleContent.className = 'title-content'");
     expect(client).toContain('treeContinuationColumns(row.prefix)');
+    expect(client).toContain('guide.textContent = treeGuideText(row.prefix)');
     expect(client).toContain("titleText.className = 'title-text'");
     expect(client).not.toContain('title.append(document.createTextNode(row.title))');
+  });
+
+  it('clamps collapsed summaries at four lines and reveals the full title when open', async () => {
+    const css = await readStyleBlock();
+    const textRule = blockAfter(css, '.title-text');
+    const openTextRule = blockAfter(css, 'tr.open .title-text');
+    expect(textRule).toContain('-webkit-line-clamp: 4');
+    expect(textRule).toContain('overflow: hidden');
+    expect(openTextRule).toContain('-webkit-line-clamp: unset');
+    expect(openTextRule).toContain('overflow: visible');
   });
 });
 
@@ -494,7 +505,7 @@ describe('tag-column layout', () => {
     expect(tagRule).toContain('white-space: nowrap');
     expect(client).toContain("appendCell(tableRow, '', 'labels')");
     expect(client).toContain("cluster.className = 'tag-cluster'");
-    expect(page).toContain('<th class="labels">Labels</th>');
+    expect(page).toContain('<th class="labels" data-sort-key="labels">');
   });
 });
 
@@ -512,11 +523,12 @@ describe('updated-time and fixed-column system', () => {
     expect(page).toContain('<col class="board-col-title" />');
     expect(page).toContain('<col class="board-col-updated" />');
     expect(page).toContain('<col class="board-col-labels" />');
-    expect(page).toContain('<th class="updated">Updated</th>');
+    expect(page).toContain('<th class="updated" data-sort-key="updated">');
     expect(client).toContain('time.className = `updated-age age-${age.tier}`');
     expect(client).toContain('time.dateTime = age.exact');
     expect(client).toContain('time.title = age.exact');
     expect(client).toContain('window.setInterval(updateRelativeTimes, RELATIVE_TIME_REFRESH_MS)');
+    expect(blockAfter(css, '.updated-age')).toContain('font-family: var(--mono)');
     for (const tier of ['sec', 'min', 'hr', 'day', 'wk', 'old']) {
       expect(css).toContain(`--age-${tier}: hsl(`);
       expect(css).toContain(`--dark-age-${tier}: hsl(`);
@@ -529,6 +541,49 @@ describe('updated-time and fixed-column system', () => {
     expect(client).toContain('cell.colSpan = 7');
     expect(client).toContain('cell.colSpan = 8');
     expect(client).not.toContain('cell.colSpan = 6');
+  });
+});
+
+describe('dynamic label chooser', () => {
+  it('renders a counted accessible multi-chooser capped by the server at 32 facets', async () => {
+    const [css, client, page] = await Promise.all([
+      readStyleBlock(),
+      readFile(clientPath, 'utf8'),
+      readFile(pagePath, 'utf8'),
+    ]);
+    expect(page).toContain('id="labelchooser"');
+    expect(page).toContain('id="labeltrigger"');
+    expect(page).toContain('id="labelmenu"');
+    expect(page).not.toContain('<input id="label"');
+    expect(page).toContain('aria-label="Labels; all selected labels are required"');
+    expect(page).toContain('aria-label="Filter by every selected label"');
+    expect(client).toContain("row.setAttribute('role', 'menuitemcheckbox')");
+    expect(client).toContain("count.className = 'label-choice-count'");
+    expect(client).toContain("name.className = 'tag label-choice-tag'");
+    expect(client).toContain('selectedLabels');
+    expect(blockAfter(css, '.label-chooser-menu')).toContain('max-height: 320px');
+    expect(blockAfter(css, '.label-choice-count')).toContain('font-variant-numeric: tabular-nums');
+  });
+});
+
+describe('composable board sorting', () => {
+  it('makes every data-column header an accessible sort control and removes the old chooser', async () => {
+    const [css, client, page] = await Promise.all([
+      readStyleBlock(),
+      readFile(clientPath, 'utf8'),
+      readFile(pagePath, 'utf8'),
+    ]);
+    for (const key of ['id', 'priority', 'status', 'kind', 'title', 'updated', 'labels']) {
+      expect(page).toContain(`data-sort-key="${key}"`);
+    }
+    expect(page).not.toContain('id="sort"');
+    expect(client).toContain('promoteBoardSort(view.controls.sorts, key)');
+    expect(client).toContain('elements.pretty.checked = false');
+    expect(client).toContain('if (elements.pretty.checked)');
+    expect(client).toContain('activeSorts = []');
+    expect(client).toMatch(/header\.setAttribute\(\s*'aria-sort'/u);
+    expect(blockAfter(css, '.sort-button')).toContain('font: inherit');
+    expect(blockAfter(css, '.sort-indicator')).toContain('font-variant-numeric: tabular-nums');
   });
 });
 

--- a/packages/tbd/tests/bead-web-css.test.ts
+++ b/packages/tbd/tests/bead-web-css.test.ts
@@ -256,6 +256,8 @@ describe('typography: monospace marks data, not chrome', () => {
     const termRule = blockAfter(css, '#statusdl dt');
     expect(listRule).toContain('display: grid');
     expect(listRule).toContain('align-items: baseline');
+    expect(listRule).toContain('font-size: var(--font-size-body)');
+    expect(blockAfter(css, '#statusdl dd')).toContain('font-size: var(--font-size-body)');
     expect(termRule).toContain('float: none');
     expect(termRule).toContain('margin: 0');
   });
@@ -414,7 +416,20 @@ describe('semantic color and component roles', () => {
     expect(blockAfter(css, '.status-closed')).toContain('color: var(--muted)');
     expect(blockAfter(css, '.priority-0')).toContain('color: var(--error)');
     expect(blockAfter(css, '.priority-1')).toContain('color: var(--warning)');
-    expect(blockAfter(css, '.tag.ready')).toContain('color: var(--success)');
+    expect(blockAfter(css, '.ready-marker')).toContain('color: var(--success)');
+    expect(blockAfter(css, '.ready-marker')).not.toContain('border');
+  });
+
+  it('keeps readiness useful without presenting the derived state as a label', async () => {
+    const client = await readFile(clientPath, 'utf8');
+    expect(client).toContain("ready.className = 'ready-marker'");
+    expect(client).toContain(
+      "ready.dataset.tooltip = 'Open, unassigned, and has no open blockers'",
+    );
+    expect(client).not.toContain("ready.className = 'tag ready'");
+    expect(client.indexOf('for (const label of row.labels)')).toBeLessThan(
+      client.indexOf('if (row.ready)'),
+    );
   });
 
   it('reuses table semantic classes in the native filter choosers', async () => {
@@ -441,6 +456,7 @@ describe('semantic color and component roles', () => {
     expect(page).toContain('<span class="header-meta" id="countmeta">0 beads</span>');
     expect(page).not.toContain('class="pill" id="countpill"');
     expect(client).toContain("countMeta: byId('countmeta', HTMLSpanElement)");
+    expect(client).toContain('`${board.matched} of ${board.total} shown`');
   });
 
   it('does not manufacture extra auxiliary-text grays with opacity', async () => {
@@ -455,7 +471,7 @@ describe('semantic color and component roles', () => {
 });
 
 describe('tree-title layout', () => {
-  it('uses one continuous glyph geometry for first-line and wrapped ancestor verticals', async () => {
+  it('keeps first-line Unicode guides and a clean hanging indent without synthetic bars', async () => {
     const [css, client] = await Promise.all([readStyleBlock(), readFile(clientPath, 'utf8')]);
     const contentRule = blockAfter(css, '.title-content');
     const textRule = blockAfter(css, '.title-text');
@@ -464,12 +480,10 @@ describe('tree-title layout', () => {
     expect(textRule, 'expected a separately wrapping title span').not.toBeNull();
     expect(textRule).toContain('min-width: 0');
     expect(blockAfter(css, '.guide')).toContain('color: var(--muted)');
-    const continuationRule = blockAfter(css, '.tree-continuation');
-    expect(continuationRule).toContain('top: 0');
-    expect(continuationRule).toContain('border-left: 1px solid var(--muted)');
     expect(client).toContain("titleContent.className = 'title-content'");
-    expect(client).toContain('treeContinuationColumns(row.prefix)');
-    expect(client).toContain('guide.textContent = treeGuideText(row.prefix)');
+    expect(client).toContain('guide.textContent = row.prefix');
+    expect(client).not.toContain('treeContinuationColumns');
+    expect(css).not.toContain('.tree-continuation');
     expect(client).toContain("titleText.className = 'title-text'");
     expect(client).not.toContain('title.append(document.createTextNode(row.title))');
   });
@@ -485,8 +499,23 @@ describe('tree-title layout', () => {
   });
 });
 
+describe('expanded local field deltas', () => {
+  it('uses bounded previews, preserves full copy data, and omits redundant creation diffs', async () => {
+    const [css, client] = await Promise.all([readStyleBlock(), readFile(clientPath, 'utf8')]);
+    expect(client).toContain("delta.change === 'created'");
+    expect(client).toContain('const before = formatDeltaValue(field.before)');
+    expect(client).toContain('const after = formatDeltaValue(field.after)');
+    expect(client).toContain('const copyValue = `${before.full}  →  ${after.full}`');
+    expect(client).toContain('literal.dataset.copyValue = copyValue');
+    expect(client).toContain("beforeText.className = 'delta-before'");
+    expect(client).toContain("afterText.className = 'delta-after'");
+    expect(blockAfter(css, '.delta-before,\n.delta-arrow')).toContain('color: var(--muted)');
+    expect(blockAfter(css, '.delta-after')).toContain('color: var(--text)');
+  });
+});
+
 describe('tag-column layout', () => {
-  it('keeps ready with labels while wrapping only complete tags in a wider column', async () => {
+  it('keeps the quiet ready marker after labels while wrapping complete tags', async () => {
     const [css, client, page] = await Promise.all([
       readStyleBlock(),
       readFile(clientPath, 'utf8'),
@@ -498,7 +527,9 @@ describe('tag-column layout', () => {
     const tagRule = blockAfter(css, '.tag');
     expect(labelsColumnRule).toContain('width: var(--board-labels-column-width)');
     expect(titleColumnRule).toContain('width: var(--board-title-column-width)');
-    expect(css).toContain('--board-title-column-width: 29%');
+    expect(css).toContain('--board-priority-column-width: 7%');
+    expect(css).toContain('--board-title-column-width: 24%');
+    expect(css).toContain('--board-updated-column-width: 13%');
     expect(css).toContain('--board-labels-column-width: 22%');
     expect(clusterRule).toContain('display: flex');
     expect(clusterRule).toContain('flex-wrap: wrap');
@@ -526,9 +557,11 @@ describe('updated-time and fixed-column system', () => {
     expect(page).toContain('<th class="updated" data-sort-key="updated">');
     expect(client).toContain('time.className = `updated-age age-${age.tier}`');
     expect(client).toContain('time.dateTime = age.exact');
-    expect(client).toContain('time.title = age.exact');
+    expect(client).toContain('setTooltip(time, age.exact)');
+    expect(client).toContain("time.dataset.tooltipLiteral = ''");
     expect(client).toContain('window.setInterval(updateRelativeTimes, RELATIVE_TIME_REFRESH_MS)');
-    expect(blockAfter(css, '.updated-age')).toContain('font-family: var(--mono)');
+    expect(blockAfter(css, '.updated-age')).toContain('font-family: var(--sans)');
+    expect(blockAfter(css, '.viewer-tooltip.literal')).toContain('font-family: var(--mono)');
     for (const tier of ['sec', 'min', 'hr', 'day', 'wk', 'old']) {
       expect(css).toContain(`--age-${tier}: hsl(`);
       expect(css).toContain(`--dark-age-${tier}: hsl(`);
@@ -578,9 +611,15 @@ describe('composable board sorting', () => {
     }
     expect(page).not.toContain('id="sort"');
     expect(client).toContain('promoteBoardSort(view.controls.sorts, key)');
-    expect(client).toContain('elements.pretty.checked = false');
-    expect(client).toContain('if (elements.pretty.checked)');
-    expect(client).toContain('activeSorts = []');
+    expect(client).not.toContain('elements.pretty.checked = false');
+    expect(client).not.toContain('activeSorts = []');
+    expect(client).toContain('activeSorts = DEFAULT_BOARD_SORTS.map');
+    expect(client).toContain('elements.pretty.checked = true');
+    expect(client).toContain(
+      'Pretty moves outermost groups by the latest update in each visible subtree; children keep official order.',
+    );
+    expect(client).toContain('isDefaultBoardSort(view.controls.sorts, view.controls.pretty)');
+    expect(page).toContain('id="sortreset"');
     expect(client).toMatch(/header\.setAttribute\(\s*'aria-sort'/u);
     expect(blockAfter(css, '.sort-button')).toContain('font: inherit');
     expect(blockAfter(css, '.sort-indicator')).toContain('font-variant-numeric: tabular-nums');
@@ -711,6 +750,73 @@ describe('observer header status', () => {
   });
 });
 
+describe('delegated tooltip system', () => {
+  it('uses one fast viewport-aware tooltip and no native title attributes', async () => {
+    const [css, client, page] = await Promise.all([
+      readStyleBlock(),
+      readFile(clientPath, 'utf8'),
+      readFile(pagePath, 'utf8'),
+    ]);
+    expect(page).not.toMatch(/\stitle=/u);
+    expect(page).toContain('data-tooltip="System theme"');
+    expect(client).toContain("tooltip.id = 'viewer-tooltip'");
+    expect(client.match(/document\.body\.append\(tooltip\)/gu)).toHaveLength(1);
+    expect(client).toContain("target.closest<HTMLElement>('[data-tooltip]')");
+    expect(client).toContain("document.addEventListener('pointerover'");
+    expect(client).toContain("document.addEventListener('focusin'");
+    expect(client).toContain("window.addEventListener('scroll', hideTooltip, true)");
+    expect(css).toContain('--tooltip-show-delay: 250ms');
+    expect(blockAfter(css, '.viewer-tooltip')).toContain('pointer-events: none');
+    expect(blockAfter(css, '.viewer-tooltip.visible')).toContain(
+      'transition-delay: var(--tooltip-show-delay), 0s',
+    );
+  });
+});
+
+describe('conditional categorical facets', () => {
+  it('renders cross-filtered tallies and hides only zero-count unselected options', async () => {
+    const [client, page] = await Promise.all([
+      readFile(clientPath, 'utf8'),
+      readFile(pagePath, 'utf8'),
+    ]);
+    expect(client).toContain('renderCategoricalFacets(board)');
+    expect(client).toContain('option.textContent = `${label} · ${count}`');
+    expect(client).toContain('const unavailable = count === 0 && option.value !== selectedValue');
+    expect(client).toContain('option.hidden = unavailable');
+    expect(page).toMatch(/id="status"\s+class="semantic-chooser"/u);
+    expect(page).toMatch(/id="type"\s+class="semantic-chooser kind-choice"/u);
+    expect(page).toMatch(/id="priority"\s+class="semantic-chooser"/u);
+  });
+
+  it('keeps aggregate counts in menus but removes them from closed chooser faces', async () => {
+    const [client, page, css] = await Promise.all([
+      readFile(clientPath, 'utf8'),
+      readFile(pagePath, 'utf8'),
+      readStyleBlock(),
+    ]);
+    expect(client).toContain('syncAggregateChooserLabel(elements.status, elements.statusValue');
+    expect(client).toContain("any: 'any (incl. closed)'");
+    expect(client).toContain('syncAggregateChooserLabel(elements.kind, elements.kindValue');
+    expect(client).toContain('syncAggregateChooserLabel(elements.priority, elements.priorityValue');
+    expect(page).toContain('id="statusvalue" class="select-value"');
+    expect(page).toContain('id="typevalue" class="select-value"');
+    expect(page).toContain('id="priorityvalue" class="select-value"');
+    expect(blockAfter(css, '.select-value')).toContain('pointer-events: none');
+    expect(blockAfter(css, '.select-value[hidden]')).toContain('display: none');
+  });
+});
+
+describe('board and status-panel divider', () => {
+  it('stretches one continuous divider and switches it to horizontal when stacked', async () => {
+    const css = await readStyleBlock();
+    expect(blockAfter(css, 'main')).toContain('align-items: stretch');
+    expect(blockAfter(css, 'aside')).toContain('border-left: 1px solid var(--border)');
+    expect(css).toMatch(
+      /@media \(max-width: 900px\)[\s\S]*?aside\s*\{[\s\S]*?border-left: none;[\s\S]*?border-top: 1px solid var\(--border\);/u,
+    );
+  });
+});
+
 describe('Boolean controls', () => {
   it('renders --pretty as a checkbox while leaving actions as buttons', async () => {
     const [client, page] = await Promise.all([
@@ -718,7 +824,7 @@ describe('Boolean controls', () => {
       readFile(pagePath, 'utf8'),
     ]);
     expect(page).toMatch(
-      /<label class="check" title="--pretty"[\s\S]*?<input type="checkbox" id="pretty" checked \/> pretty[\s\S]*?<\/label\s*>/u,
+      /<label class="check" data-tooltip="--pretty"[\s\S]*?<input type="checkbox" id="pretty" checked \/> pretty[\s\S]*?<\/label\s*>/u,
     );
     expect(page).not.toContain('id="pretty" class="on"');
     expect(page).not.toMatch(/id="ready"[\s\S]*?class="grow"[\s\S]*?id="pretty"/u);

--- a/packages/tbd/tests/bead-web-css.test.ts
+++ b/packages/tbd/tests/bead-web-css.test.ts
@@ -297,9 +297,29 @@ describe('chevron icon system', () => {
 
   it('routes every board-row click through one toggle path', async () => {
     const client = await readFile(clientPath, 'utf8');
-    expect(client).toContain("tableRow.addEventListener('click', () => {");
-    expect(client).toContain('store.toggle(row.id)');
+    expect(client).toContain('tableRow.dataset.beadId = row.id');
+    expect(client).toContain("elements.rows.addEventListener('click', (event) => {");
+    expect(client).toContain("target.closest<HTMLTableRowElement>('tr[data-bead-id]')");
+    expect(client).toContain('window.getSelection()?.isCollapsed ?? true');
+    expect(client).toContain("target.closest<HTMLButtonElement>('.disclosure') === null");
+    expect(client).toContain('store.toggle(id)');
+    expect(client).not.toContain("tableRow.addEventListener('click'");
     expect(client).not.toContain("disclosure.addEventListener('click'");
+  });
+
+  it('cleans detached tooltips and restores stable board and label focus after rerenders', async () => {
+    const client = await readFile(clientPath, 'utf8');
+    expect(client).toContain('captureBoardFocus()');
+    expect(client).toContain('restoreBoardFocus(boardFocus)');
+    expect(client).toContain('!document.contains(activeTooltipTarget)');
+    expect(client).toContain('activeLabelChoiceFocus()');
+    expect(client).toContain('restoreLabelChoiceFocus(labelFocus)');
+  });
+
+  it('surfaces a failed board refresh even while stale rows remain visible', async () => {
+    const client = await readFile(clientPath, 'utf8');
+    expect(client).toContain("elements.observerPill.textContent = 'refresh error'");
+    expect(client).toContain('Showing the last successful board');
   });
 
   it('baseline-aligns mixed row typography and centers disclosure in the shared line box', async () => {
@@ -493,8 +513,10 @@ describe('tree-title layout', () => {
     const textRule = blockAfter(css, '.title-text');
     const openTextRule = blockAfter(css, 'tr.open .title-text');
     expect(textRule).toContain('-webkit-line-clamp: 4');
+    expect(textRule).toContain('line-clamp: 4');
     expect(textRule).toContain('overflow: hidden');
     expect(openTextRule).toContain('-webkit-line-clamp: unset');
+    expect(openTextRule).toContain('line-clamp: unset');
     expect(openTextRule).toContain('overflow: visible');
   });
 });
@@ -587,6 +609,8 @@ describe('dynamic label chooser', () => {
     expect(page).toContain('id="labelchooser"');
     expect(page).toContain('id="labeltrigger"');
     expect(page).toContain('id="labelmenu"');
+    expect(page).toContain('id="labelsearch"');
+    expect(page).toContain('id="labelchoices"');
     expect(page).not.toContain('<input id="label"');
     expect(page).toContain('aria-label="Labels; all selected labels are required"');
     expect(page).toContain('aria-label="Filter by every selected label"');
@@ -594,6 +618,7 @@ describe('dynamic label chooser', () => {
     expect(client).toContain("count.className = 'label-choice-count'");
     expect(client).toContain("name.className = 'tag label-choice-tag'");
     expect(client).toContain('selectedLabels');
+    expect(client).toContain('labelSearch: elements.labelSearch.value');
     expect(blockAfter(css, '.label-chooser-menu')).toContain('max-height: 320px');
     expect(blockAfter(css, '.label-choice-count')).toContain('font-variant-numeric: tabular-nums');
   });
@@ -614,12 +639,12 @@ describe('composable board sorting', () => {
     expect(client).not.toContain('elements.pretty.checked = false');
     expect(client).not.toContain('activeSorts = []');
     expect(client).toContain('activeSorts = DEFAULT_BOARD_SORTS.map');
-    expect(client).toContain('elements.pretty.checked = true');
     expect(client).toContain(
       'Pretty moves outermost groups by the latest update in each visible subtree; children keep official order.',
     );
-    expect(client).toContain('isDefaultBoardSort(view.controls.sorts, view.controls.pretty)');
+    expect(client).toContain('isDefaultBoardSort(view.controls.sorts)');
     expect(page).toContain('id="sortreset"');
+    expect(client).not.toContain('elements.pretty.checked = true');
     expect(client).toMatch(/header\.setAttribute\(\s*'aria-sort'/u);
     expect(blockAfter(css, '.sort-button')).toContain('font: inherit');
     expect(blockAfter(css, '.sort-indicator')).toContain('font-variant-numeric: tabular-nums');

--- a/packages/tbd/tests/bead-web-css.test.ts
+++ b/packages/tbd/tests/bead-web-css.test.ts
@@ -481,16 +481,54 @@ describe('tag-column layout', () => {
       readFile(clientPath, 'utf8'),
       readFile(pagePath, 'utf8'),
     ]);
-    const labelsRule = blockAfter(css, 'th.labels,\ntd.labels');
+    const labelsColumnRule = blockAfter(css, '.board-col-labels');
+    const titleColumnRule = blockAfter(css, '.board-col-title');
     const clusterRule = blockAfter(css, '.tag-cluster');
     const tagRule = blockAfter(css, '.tag');
-    expect(labelsRule).toContain('min-width: 160px');
+    expect(labelsColumnRule).toContain('width: var(--board-labels-column-width)');
+    expect(titleColumnRule).toContain('width: var(--board-title-column-width)');
+    expect(css).toContain('--board-title-column-width: 29%');
+    expect(css).toContain('--board-labels-column-width: 22%');
     expect(clusterRule).toContain('display: flex');
     expect(clusterRule).toContain('flex-wrap: wrap');
     expect(tagRule).toContain('white-space: nowrap');
     expect(client).toContain("appendCell(tableRow, '', 'labels')");
     expect(client).toContain("cluster.className = 'tag-cluster'");
     expect(page).toContain('<th class="labels">Labels</th>');
+  });
+});
+
+describe('updated-time and fixed-column system', () => {
+  it('renders one semantic updated column with exact time metadata and blue age tiers', async () => {
+    const [css, client, page] = await Promise.all([
+      readStyleBlock(),
+      readFile(clientPath, 'utf8'),
+      readFile(pagePath, 'utf8'),
+    ]);
+    const boardRule = blockAfter(css, '.board-table');
+    expect(boardRule).toContain('table-layout: fixed');
+    expect(boardRule).toContain('min-width: 820px');
+    expect(page).toContain('<colgroup>');
+    expect(page).toContain('<col class="board-col-title" />');
+    expect(page).toContain('<col class="board-col-updated" />');
+    expect(page).toContain('<col class="board-col-labels" />');
+    expect(page).toContain('<th class="updated">Updated</th>');
+    expect(client).toContain('time.className = `updated-age age-${age.tier}`');
+    expect(client).toContain('time.dateTime = age.exact');
+    expect(client).toContain('time.title = age.exact');
+    expect(client).toContain('window.setInterval(updateRelativeTimes, RELATIVE_TIME_REFRESH_MS)');
+    for (const tier of ['sec', 'min', 'hr', 'day', 'wk', 'old']) {
+      expect(css).toContain(`--age-${tier}: hsl(`);
+      expect(css).toContain(`--dark-age-${tier}: hsl(`);
+      expect(blockAfter(css, `.age-${tier}`)).toContain(`color: var(--age-${tier})`);
+    }
+  });
+
+  it('keeps expansion and paging inside the complete eight-column grid', async () => {
+    const client = await readFile(clientPath, 'utf8');
+    expect(client).toContain('cell.colSpan = 7');
+    expect(client).toContain('cell.colSpan = 8');
+    expect(client).not.toContain('cell.colSpan = 6');
   });
 });
 
@@ -538,7 +576,7 @@ describe('expanded-row emphasis', () => {
     expect(bodyRule).toContain('padding-left: 10px');
     expect(client).toContain("appendCell(bodyRow, '', 'caret')");
     expect(client).toContain("appendCell(bodyRow, '', 'body-cell')");
-    expect(client).toContain('cell.colSpan = 6');
+    expect(client).toContain('cell.colSpan = 7');
     expect(client).toContain("const title = appendCell(tableRow, '', 'title')");
   });
 });

--- a/packages/tbd/tests/cli-edge-cases.tryscript.md
+++ b/packages/tbd/tests/cli-edge-cases.tryscript.md
@@ -122,11 +122,11 @@ Error: Issue not found: invalid!!!
 ? 1
 ```
 
-# Test: Non-existent short ID
+# Test: Distant non-existent ID does not get a near-miss suggestion
 
 ```console
-$ tbd show "zzzz" 2>&1
-Error: Issue not found: zzzz
+$ tbd show "test-zzzzzzz" 2>&1
+Error: Issue not found: test-zzzzzzz
 ? 1
 ```
 

--- a/packages/tbd/tests/cli-setup.tryscript.md
+++ b/packages/tbd/tests/cli-setup.tryscript.md
@@ -81,7 +81,7 @@ Views and Filtering:
   ready [options]                    List issues ready to work on (open,
                                      unblocked, unclaimed)
   list [options]                     List issues
-  web [options]                      Serve a live, read-only bead view on
+  web [options] [path]               Serve a live, read-only bead view on
                                      loopback
   blocked [options]                  List blocked issues
   stale [options]                    List issues not updated recently

--- a/packages/tbd/tests/cli-web.test.ts
+++ b/packages/tbd/tests/cli-web.test.ts
@@ -114,7 +114,7 @@ async function tbd(repoDir: string, ...args: string[]): Promise<string> {
   return stdout;
 }
 
-async function createRepo(): Promise<WebFixture> {
+async function createRepo(options: { withIssue?: boolean } = {}): Promise<WebFixture> {
   const root = await mkdtemp(join(tmpdir(), 'tbd-web-cli-'));
   cleanupPaths.push(root);
   const remoteDir = join(root, 'remote.git');
@@ -134,17 +134,19 @@ async function createRepo(): Promise<WebFixture> {
   await git(repoDir, 'add', '.tbd/config.yml');
   await git(repoDir, 'commit', '-m', 'configure tbd');
   await git(repoDir, 'push', '--set-upstream', 'origin', 'main');
-  await tbd(
-    repoDir,
-    '--json',
-    'create',
-    'Browser acceptance',
-    '--description',
-    'Loaded only from the detail endpoint',
-    '--label',
-    'acceptance',
-  );
-  await tbd(repoDir, '--json', 'sync');
+  if (options.withIssue !== false) {
+    await tbd(
+      repoDir,
+      '--json',
+      'create',
+      'Browser acceptance',
+      '--description',
+      'Loaded only from the detail endpoint',
+      '--label',
+      'acceptance',
+    );
+    await tbd(repoDir, '--json', 'sync');
+  }
   return { root, remoteDir, repoDir: await realpath(repoDir) };
 }
 
@@ -297,6 +299,97 @@ afterEach(async () => {
 });
 
 describe('tbd web CLI', { timeout: subprocessTestTimeout(30_000) }, () => {
+  it('serves a clean empty state from an initialized repository with zero beads', async () => {
+    const { repoDir } = await createRepo({ withIssue: false });
+    const port = await availablePort();
+    const child = spawn(process.execPath, [tbdBin, '--json', 'web', '--port', String(port)], {
+      cwd: repoDir,
+      env: { ...process.env, NO_COLOR: '1' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    children.add(child);
+    const descriptor = await waitForDescriptor(child);
+
+    const board = await fetch(`${descriptor.url}/api/board?pretty=1`);
+    expect(await board.json()).toMatchObject({
+      total: 0,
+      matched: 0,
+      closedHidden: 0,
+      rows: [],
+      labelFacets: [],
+    });
+    const page = await fetch(descriptor.url);
+    expect(await page.text()).toContain('No beads match this query.');
+
+    const exited = waitForExit(child);
+    expect(child.kill(supportsHandledProcessSignals ? 'SIGTERM' : 'SIGKILL')).toBe(true);
+    if (supportsHandledProcessSignals) {
+      await expect(exited).resolves.toEqual({ code: 0, signal: null });
+    } else {
+      await exited;
+    }
+    children.delete(child);
+  });
+
+  it('accepts an explicit repository subdirectory from an arbitrary working directory', async () => {
+    const fixture = await createRepo();
+    const callerDir = join(fixture.root, 'caller');
+    const repoSubdir = join(fixture.repoDir, 'nested', 'deeper');
+    await mkdir(callerDir);
+    await mkdir(repoSubdir, { recursive: true });
+    const port = await availablePort();
+    const child = spawn(
+      process.execPath,
+      [tbdBin, '--json', 'web', repoSubdir, '--port', String(port)],
+      {
+        cwd: callerDir,
+        env: { ...process.env, NO_COLOR: '1' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+    children.add(child);
+    const descriptor = await waitForDescriptor(child);
+    expect(descriptor.repo).toBe(fixture.repoDir);
+    const board = await fetch(`${descriptor.url}/api/board`);
+    expect(await board.json()).toMatchObject({ rows: [{ title: 'Browser acceptance' }] });
+
+    const exited = waitForExit(child);
+    expect(child.kill(supportsHandledProcessSignals ? 'SIGTERM' : 'SIGKILL')).toBe(true);
+    await exited;
+    children.delete(child);
+  });
+
+  it('reports standard uninitialized errors and a clear invalid-base-path error', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'tbd-web-errors-'));
+    cleanupPaths.push(root);
+    const uninitializedRepo = join(root, 'repo');
+    const plainDirectory = join(root, 'plain');
+    await mkdir(uninitializedRepo);
+    await mkdir(plainDirectory);
+    await git(uninitializedRepo, 'init', '-b', 'main');
+
+    for (const cwd of [uninitializedRepo, plainDirectory]) {
+      const result = spawnSync(process.execPath, [tbdBin, 'web'], {
+        cwd,
+        encoding: 'utf8',
+        env: { ...process.env, NO_COLOR: '1' },
+      });
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "Not a tbd repository (run 'tbd setup --auto --prefix=<name>' first)",
+      );
+    }
+
+    const missing = join(root, 'does-not-exist');
+    const invalidPath = spawnSync(process.execPath, [tbdBin, 'web', missing], {
+      cwd: plainDirectory,
+      encoding: 'utf8',
+      env: { ...process.env, NO_COLOR: '1' },
+    });
+    expect(invalidPath.status).toBe(2);
+    expect(invalidPath.stderr).toContain(`Base directory does not exist: ${missing}`);
+  });
+
   it('serves the packaged page and APIs with isolated, platform-safe lifecycle cleanup', async () => {
     const { repoDir } = await createRepo();
     const port = await availablePort();

--- a/packages/tbd/tests/cli-web.tryscript.md
+++ b/packages/tbd/tests/cli-web.tryscript.md
@@ -32,10 +32,14 @@ $ node run-built-cli.mjs init --prefix=test --quiet
 ## Help
 
 ```console
-$ node run-built-cli.mjs web --help | sed -n "1,13p"
-Usage: tbd web [options]
+$ node run-built-cli.mjs web --help | sed -n "1,17p"
+Usage: tbd web [options] [path]
 
 Serve a live, read-only bead view on loopback
+
+Arguments:
+  path            Repository or subdirectory to view (default: current
+                  directory)
 
 Options:
   --port <n>      Bind exactly this loopback port (default: search from 7777)
@@ -46,6 +50,14 @@ Global Options:
   --version       Show version number
   --dry-run       Show what would be done without making changes
   --verbose       Enable verbose output
+? 0
+```
+
+## Explicit repository path
+
+```console
+$ node run-built-cli.mjs --dry-run --json web .tbd | jq -c "{repo,port}"
+{"repo":"[..]","port":7777}
 ? 0
 ```
 

--- a/packages/tbd/tests/doc-categories.test.ts
+++ b/packages/tbd/tests/doc-categories.test.ts
@@ -12,9 +12,9 @@ import { describe, it, expect } from 'vitest';
 import { readFile, readdir } from 'node:fs/promises';
 import { join, dirname, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import matter from 'gray-matter';
 
 import { docCategory } from '../src/lib/doc-categories.js';
+import { parseMarkdownMatter } from '../src/utils/gray-matter.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const GUIDELINES_DIR = join(__dirname, '..', 'docs', 'guidelines');
@@ -48,9 +48,9 @@ describe('guideline doc categories', () => {
 
       let category: unknown;
       try {
-        // gray-matter (js-yaml) rejects duplicated keys, so a doc declaring
+        // The centralized YAML engine rejects duplicated keys, so a doc declaring
         // `category:` twice fails here rather than silently picking one.
-        const parsed = matter(raw);
+        const parsed = parseMarkdownMatter(raw);
         category = parsed.data.category;
       } catch (error) {
         failures.push(`${file}: frontmatter failed to parse (${(error as Error).message})`);

--- a/packages/tbd/tests/gray-matter.test.ts
+++ b/packages/tbd/tests/gray-matter.test.ts
@@ -50,6 +50,15 @@ Body.`;
     expect(parsed.content).toBe('Body.');
   });
 
+  it('normalizes CRLF inside front matter without changing the body', () => {
+    const parsed = parseMarkdownMatter(
+      '---\r\ntitle: Safe\r\ncategory: typescript\r\n---\r\nBody.\r\n',
+    );
+
+    expect(parsed.data).toEqual({ title: 'Safe', category: 'typescript' });
+    expect(parsed.content).toBe('Body.\r\n');
+  });
+
   it('keeps every production gray-matter import behind the checked boundary', async () => {
     const relativePaths = await readdir(SOURCE_ROOT, { recursive: true });
     const offenders: string[] = [];

--- a/packages/tbd/tests/gray-matter.test.ts
+++ b/packages/tbd/tests/gray-matter.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { readFile, readdir } from 'node:fs/promises';
+import { dirname, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { parseMarkdownMatter } from '../src/utils/gray-matter.js';
+
+const EXECUTION_MARKER = '__tbdGrayMatterExecutionMarker';
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const SOURCE_ROOT = resolve(TEST_DIR, '../src');
+const GRAY_MATTER_BOUNDARY = resolve(SOURCE_ROOT, 'utils/gray-matter.ts');
+const PRODUCTION_SOURCE_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.mts',
+  '.cts',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+]);
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, EXECUTION_MARKER);
+});
+
+describe('parseMarkdownMatter', () => {
+  it('rejects JavaScript front matter before gray-matter can evaluate it', () => {
+    const content = `---javascript
+(globalThis.${EXECUTION_MARKER} = true, { title: 'executed' })
+---
+Body.`;
+
+    expect(() => parseMarkdownMatter(content)).toThrow(
+      'Unsupported front-matter language "javascript"; tbd accepts YAML only',
+    );
+    expect(Reflect.get(globalThis, EXECUTION_MARKER)).toBeUndefined();
+  });
+
+  it('rejects non-executable non-YAML engines too', () => {
+    expect(() => parseMarkdownMatter('---json\n{"title":"JSON"}\n---\nBody.')).toThrow(
+      'Unsupported front-matter language "json"; tbd accepts YAML only',
+    );
+  });
+
+  it.each(['', 'yaml', 'yml'])('accepts the %s YAML language marker', (language) => {
+    const parsed = parseMarkdownMatter(`---${language}\ntitle: Safe\n---\nBody.`);
+
+    expect(parsed.data).toEqual({ title: 'Safe' });
+    expect(parsed.content).toBe('Body.');
+  });
+
+  it('keeps every production gray-matter import behind the checked boundary', async () => {
+    const relativePaths = await readdir(SOURCE_ROOT, { recursive: true });
+    const offenders: string[] = [];
+
+    for (const relativePath of relativePaths) {
+      if (!PRODUCTION_SOURCE_EXTENSIONS.has(extname(relativePath))) {
+        continue;
+      }
+
+      const sourcePath = resolve(SOURCE_ROOT, relativePath);
+      if (sourcePath === GRAY_MATTER_BOUNDARY) {
+        continue;
+      }
+
+      const source = await readFile(sourcePath, 'utf8');
+      if (/from\s+['"]gray-matter['"]/.test(source)) {
+        offenders.push(relativePath);
+      }
+    }
+
+    expect(offenders.sort()).toEqual([]);
+  });
+});

--- a/packages/tbd/tests/gray-matter.test.ts
+++ b/packages/tbd/tests/gray-matter.test.ts
@@ -44,9 +44,20 @@ Body.`;
   });
 
   it.each(['', 'yaml', 'yml'])('accepts the %s YAML language marker', (language) => {
-    const parsed = parseMarkdownMatter(`---${language}\ntitle: Safe\n---\nBody.`);
+    const parsed = parseMarkdownMatter(`---${language}
+released: 2025-01-01
+legacy_octal: 012
+sexagesimal: 1:20
+booleanish: yes
+---
+Body.`);
 
-    expect(parsed.data).toEqual({ title: 'Safe' });
+    expect(parsed.data).toEqual({
+      released: '2025-01-01',
+      legacy_octal: 12,
+      sexagesimal: '1:20',
+      booleanish: 'yes',
+    });
     expect(parsed.content).toBe('Body.');
   });
 

--- a/packages/tbd/tests/integration-files.test.ts
+++ b/packages/tbd/tests/integration-files.test.ts
@@ -83,6 +83,7 @@ describe('integration file formats', () => {
 
       expect(content).toContain('Show my beads in a browser');
       expect(content).toContain('tbd web --open');
+      expect(content).toContain('tbd web <path> --open');
       expect(content).toContain('viewer, not an editor');
       expect(content).toMatch(/ordinary `tbd`\s+commands/u);
     });
@@ -91,6 +92,9 @@ describe('integration file formats', () => {
       for (const name of ['skill-brief.md', 'shortcuts/system/skill-minimal.md']) {
         const content = await readFile(join(docsDir, name), 'utf-8');
         expect(content, `${name} must route browser requests`).toContain('tbd web --open');
+        expect(content, `${name} must support another working directory`).toContain(
+          'tbd web <path> --open',
+        );
         expect(content, `${name} must identify a viewer rather than an editor`).toContain(
           'viewer, not an editor',
         );

--- a/packages/tbd/tests/markdown-utils.test.ts
+++ b/packages/tbd/tests/markdown-utils.test.ts
@@ -95,6 +95,16 @@ Description.`;
     expect(frontmatter).toContain('- frontend');
   });
 
+  it('preserves YAML date scalars as strings', () => {
+    const content = `---
+released: 2025-01-01
+---
+
+Body.`;
+
+    expect(parseFrontmatter(content)).toBe('released: 2025-01-01');
+  });
+
   it('handles values containing colons (YAML special chars)', () => {
     // This is the critical bug: values with "Use for: something" patterns
     // must be quoted or they appear as separate YAML keys when re-parsed

--- a/packages/tbd/tests/merge-refs.test.ts
+++ b/packages/tbd/tests/merge-refs.test.ts
@@ -58,7 +58,12 @@ describeUnlessWindows('mergeBeadAcrossRefs', () => {
   });
 
   afterEach(async () => {
-    await rm(repo, { recursive: true, force: true });
+    await rm(repo, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 100,
+    });
   });
 
   it('unions children appended on each branch from a shared base', async () => {

--- a/packages/tbd/tests/performance.test.ts
+++ b/packages/tbd/tests/performance.test.ts
@@ -288,11 +288,20 @@ describe('web board performance', () => {
     const rendered = await measureTime(() =>
       Promise.resolve(board.buildBoardResponse(new URLSearchParams('all=1&pretty=1'), state)),
     );
+    const sorted = await measureTime(() =>
+      Promise.resolve(
+        board.buildBoardResponse(
+          new URLSearchParams('all=1&order=priority:asc&order=updated:desc'),
+          state,
+        ),
+      ),
+    );
 
     expect(loaded.ms).toBeLessThan(1_000);
     expect(refreshed.ms).toBeLessThan(1_000);
     expect(refreshed.result).toMatchObject({ moved: true, changeTotal: 1 });
     expect(rendered.ms).toBeLessThan(1_000);
+    expect(sorted.ms).toBeLessThan(1_000);
     expect(rendered.result).toMatchObject({
       commandExact: false,
       total: issueCount,
@@ -301,12 +310,13 @@ describe('web board performance', () => {
     });
     expect(MAX_BOARD_ROWS).toBe(10_000);
     expect(rendered.result.rows).toHaveLength(MAX_BOARD_ROWS);
+    expect(sorted.result.rows).toHaveLength(MAX_BOARD_ROWS);
     const serialized = JSON.stringify(rendered.result);
     const serializedBytes = new TextEncoder().encode(serialized).byteLength;
     expect(serialized).not.toContain('Description for issue');
     expect(serializedBytes).toBeLessThan(5 * 1024 * 1024);
     console.log(
-      `Web board loaded ${issueCount} issues in ${loaded.ms.toFixed(2)}ms, refreshed one local change in ${refreshed.ms.toFixed(2)}ms, and built a ${(serializedBytes / 1024 / 1024).toFixed(2)} MiB response in ${rendered.ms.toFixed(2)}ms`,
+      `Web board loaded ${issueCount} issues in ${loaded.ms.toFixed(2)}ms, refreshed one local change in ${refreshed.ms.toFixed(2)}ms, built a ${(serializedBytes / 1024 / 1024).toFixed(2)} MiB response in ${rendered.ms.toFixed(2)}ms, and composed two column sorts in ${sorted.ms.toFixed(2)}ms`,
     );
   });
 });

--- a/packages/tbd/tests/setup-flows.test.ts
+++ b/packages/tbd/tests/setup-flows.test.ts
@@ -130,6 +130,7 @@ describe('setup flows', { timeout: subprocessTestTimeout() }, () => {
       expect(portable).toContain('viewing beads in a live browser');
       expect(portable).toContain('Show my beads in a browser');
       expect(portable).toContain('tbd web --open');
+      expect(portable).toContain('tbd web <path> --open');
       expect(portable).toContain('viewer, not an editor');
 
       // The portable skill and the Claude mirror must carry the same payload.

--- a/packages/tbd/tests/web-board.test.ts
+++ b/packages/tbd/tests/web-board.test.ts
@@ -265,6 +265,12 @@ describe('BoardState', () => {
     expect(response.labelFacets).toHaveLength(32);
     expect(response.labelFacets).toContainEqual({ label: 'tag-34', count: 1 });
     expect(response.labelFacets.map((facet) => facet.label)).not.toContain('tag-31');
+
+    const searched = board.buildBoardResponse(
+      new URLSearchParams('labelq=tag-34'),
+      stateFor(board),
+    );
+    expect(searched.labelFacets).toEqual([{ label: 'tag-34', count: 1 }]);
   });
 
   it('recounts label facets as iterative conjunctions and restores them when unchecked', async () => {
@@ -370,7 +376,10 @@ describe('BoardState', () => {
 
     expect(response.rows.map((row) => row.id)).toEqual(['web-kid1', 'web-root', 'web-leaf']);
     expect(response.commandExact).toBe(false);
-    expect(response.filtersExact).toBe(false);
+    expect(response.filtersExact).toBe(true);
+    expect(response.orderingCaveat).toBe(
+      'Browser column sort: Priority ↑ then Updated ↓; flat mode applies the stack to individual rows',
+    );
   });
 
   it('orders mixed-precision updated timestamps chronologically in either direction', async () => {

--- a/packages/tbd/tests/web-board.test.ts
+++ b/packages/tbd/tests/web-board.test.ts
@@ -230,7 +230,25 @@ describe('BoardState', () => {
     );
 
     expect(response.rows.map((row) => row.id)).toEqual(['web-root', 'web-leaf', 'web-kid1']);
-    expect(response.rows.map((row) => row.prefix)).toEqual(['', '├── ', '└── ']);
+    expect(response.rows.map((row) => row.prefix)).toEqual(['', '└── ', '└── ']);
+  });
+
+  it('uses one elbow at the correct indentation for every pretty child', async () => {
+    const { board, setIssues } = harness();
+    const [root, child, leaf] = fixtureIssues();
+    setIssues([{ ...root!, status: 'open' }, child!, leaf!]);
+    await board.reload();
+
+    const response = board.buildBoardResponse(
+      new URLSearchParams('pretty=1&order=updated:desc'),
+      stateFor(board),
+    );
+
+    expect(response.rows.map((row) => row.id)).toEqual(['web-root', 'web-kid1', 'web-leaf']);
+    expect(response.rows.map((row) => row.prefix)).toEqual(['', '└── ', '    └── ']);
+    expect(
+      response.rows.every((row) => !row.prefix.includes('│') && !row.prefix.includes('├')),
+    ).toBe(true);
   });
 
   it('caps label facets at 32 while retaining a selected lower-ranked label', async () => {

--- a/packages/tbd/tests/web-board.test.ts
+++ b/packages/tbd/tests/web-board.test.ts
@@ -200,6 +200,28 @@ describe('BoardState', () => {
     expect(response.filtersExact).toBe(false);
   });
 
+  it('orders mixed-precision updated timestamps chronologically in either direction', async () => {
+    const { board, setIssues } = harness();
+    const [root, child, leaf] = fixtureIssues();
+    setIssues([
+      { ...root!, status: 'open', updated_at: '2026-01-01T00:00:00.100Z' },
+      { ...child!, updated_at: '2026-01-01T00:00:00Z' },
+      { ...leaf!, updated_at: '2026-01-01T00:00:00.050Z' },
+    ]);
+    await board.reload();
+
+    const orderedIds = (direction: 'asc' | 'desc') =>
+      board
+        .buildBoardResponse(
+          new URLSearchParams(`all=1&order=updated:${direction}`),
+          stateFor(board),
+        )
+        .rows.map((row) => row.id);
+
+    expect(orderedIds('asc')).toEqual(['web-kid1', 'web-leaf', 'web-root']);
+    expect(orderedIds('desc')).toEqual(['web-root', 'web-leaf', 'web-kid1']);
+  });
+
   it('orders every textual table column lexicographically with a display-id tie-break', async () => {
     const { board } = harness();
     await board.reload();

--- a/packages/tbd/tests/web-board.test.ts
+++ b/packages/tbd/tests/web-board.test.ts
@@ -138,7 +138,7 @@ function harness(): {
 }
 
 describe('BoardState', () => {
-  it('serves shared query semantics as light rows and retains tree ancestors as context', async () => {
+  it('serves shared query semantics as light rows without reinserting filtered ancestors', async () => {
     const { board } = harness();
     await board.reload();
 
@@ -147,21 +147,90 @@ describe('BoardState', () => {
       stateFor(board),
     );
 
-    expect(response.rows.map((row) => row.id)).toEqual(['web-root', 'web-kid1', 'web-leaf']);
-    expect(response.contextIds).toEqual(['web-root']);
+    expect(response.rows.map((row) => row.id)).toEqual(['web-kid1', 'web-leaf']);
     expect(response.command).toBe('tbd list --label viewer --pretty');
-    expect(response.commandExact).toBe(false);
+    expect(response.commandExact).toBe(true);
     expect(response.filtersExact).toBe(true);
-    expect(response.labelFacets).toEqual([
-      { label: 'viewer', count: 2 },
-      { label: 'release', count: 1 },
+    expect(response.statusFacets).toEqual([
+      { value: 'open', count: 2 },
+      { value: 'in_progress', count: 0 },
+      { value: 'blocked', count: 0 },
+      { value: 'deferred', count: 0 },
+      { value: 'closed', count: 0 },
     ]);
+    expect(response.kindFacets).toEqual([
+      { value: 'bug', count: 0 },
+      { value: 'feature', count: 0 },
+      { value: 'task', count: 2 },
+      { value: 'epic', count: 0 },
+      { value: 'chore', count: 0 },
+    ]);
+    expect(response.priorityFacets).toEqual([
+      { value: 0, count: 1 },
+      { value: 1, count: 1 },
+      { value: 2, count: 0 },
+      { value: 3, count: 0 },
+      { value: 4, count: 0 },
+    ]);
+    expect(response.labelFacets).toEqual([{ label: 'viewer', count: 2 }]);
     expect(response.closedHidden).toBe(0);
-    expect(response.rows[1]).not.toHaveProperty('description');
-    expect(response.rows[1]).not.toHaveProperty('notes');
-    expect(response.rows[1]?.updated_at).toBe('2025-01-01T00:00:00Z');
-    expect(response.rows[2]?.prefix).toBe('    └── ');
+    expect(response.rows[0]).not.toHaveProperty('description');
+    expect(response.rows[0]).not.toHaveProperty('notes');
+    expect(response.rows[0]?.updated_at).toBe('2025-01-01T00:00:00Z');
+    expect(response.rows[1]?.prefix).toBe('└── ');
     expect(response.state.stats.total).toBe(3);
+  });
+
+  it('keeps closed parents out of the default Active pretty tree', async () => {
+    const { board } = harness();
+    await board.reload();
+
+    const response = board.buildBoardResponse(new URLSearchParams('pretty=1'), stateFor(board));
+
+    expect(response.rows.map((row) => row.id)).toEqual(['web-kid1', 'web-leaf']);
+    expect(response.rows.every((row) => row.status !== 'closed')).toBe(true);
+  });
+
+  it('sorts outermost pretty groups by the latest timestamp in each visible subtree', async () => {
+    const { board, setIssues } = harness();
+    const [root, child, leaf] = fixtureIssues();
+    setIssues([
+      { ...root!, status: 'open', updated_at: '2026-01-01T00:00:00Z' },
+      { ...child!, updated_at: '2026-01-10T00:00:00Z' },
+      {
+        ...leaf!,
+        parent_id: testId('01zzzzzzzzzzzzzzzzzzzzzzzz'),
+        updated_at: '2026-01-09T00:00:00Z',
+      },
+    ]);
+    await board.reload();
+
+    const response = board.buildBoardResponse(
+      new URLSearchParams('pretty=1&order=updated:desc&order=priority:asc'),
+      stateFor(board),
+    );
+
+    expect(response.rows.map((row) => row.id)).toEqual(['web-root', 'web-kid1', 'web-leaf']);
+    expect(response.rows.map((row) => row.prefix)).toEqual(['', '└── ', '']);
+  });
+
+  it('retains official child ordering inside a sorted pretty group', async () => {
+    const { board, setIssues } = harness();
+    const [root, child, leaf] = fixtureIssues();
+    setIssues([
+      { ...root!, status: 'open', child_order_hints: [leaf!.id, child!.id] },
+      { ...child!, parent_id: root!.id, updated_at: '2026-01-10T00:00:00Z' },
+      { ...leaf!, parent_id: root!.id, updated_at: '2026-01-01T00:00:00Z' },
+    ]);
+    await board.reload();
+
+    const response = board.buildBoardResponse(
+      new URLSearchParams('pretty=1&order=updated:desc'),
+      stateFor(board),
+    );
+
+    expect(response.rows.map((row) => row.id)).toEqual(['web-root', 'web-leaf', 'web-kid1']);
+    expect(response.rows.map((row) => row.prefix)).toEqual(['', '├── ', '└── ']);
   });
 
   it('caps label facets at 32 while retaining a selected lower-ranked label', async () => {
@@ -178,6 +247,92 @@ describe('BoardState', () => {
     expect(response.labelFacets).toHaveLength(32);
     expect(response.labelFacets).toContainEqual({ label: 'tag-34', count: 1 });
     expect(response.labelFacets.map((facet) => facet.label)).not.toContain('tag-31');
+  });
+
+  it('recounts label facets as iterative conjunctions and restores them when unchecked', async () => {
+    const { board, setIssues } = harness();
+    const [root, child, leaf] = fixtureIssues();
+    setIssues([
+      { ...root!, status: 'open', labels: ['alpha', 'common'] },
+      { ...child!, labels: ['alpha', 'beta', 'common'] },
+      { ...leaf!, labels: ['alpha', 'gamma'] },
+    ]);
+    await board.reload();
+
+    const facets = (labels: string) =>
+      board.buildBoardResponse(new URLSearchParams(labels), stateFor(board)).labelFacets;
+
+    expect(facets('all=1')).toEqual([
+      { label: 'alpha', count: 3 },
+      { label: 'common', count: 2 },
+      { label: 'beta', count: 1 },
+      { label: 'gamma', count: 1 },
+    ]);
+    expect(facets('all=1&label=common')).toEqual([
+      { label: 'alpha', count: 2 },
+      { label: 'common', count: 2 },
+      { label: 'beta', count: 1 },
+    ]);
+    expect(facets('all=1&label=common&label=beta')).toEqual([
+      { label: 'alpha', count: 1 },
+      { label: 'beta', count: 1 },
+      { label: 'common', count: 1 },
+    ]);
+    expect(facets('all=1&label=beta')).toEqual([
+      { label: 'alpha', count: 1 },
+      { label: 'beta', count: 1 },
+      { label: 'common', count: 1 },
+    ]);
+    expect(facets('all=1&label=missing')).toEqual([{ label: 'missing', count: 0 }]);
+  });
+
+  it('counts each categorical facet inside every other active filter', async () => {
+    const { board, setIssues } = harness();
+    const [root, child, leaf] = fixtureIssues();
+    setIssues([
+      { ...root!, status: 'open', priority: 2, labels: ['alpha', 'common'] },
+      {
+        ...child!,
+        status: 'blocked',
+        kind: 'bug',
+        priority: 1,
+        labels: ['alpha', 'beta', 'common'],
+      },
+      { ...leaf!, status: 'open', kind: 'task', priority: 1, labels: ['alpha', 'gamma'] },
+    ]);
+    await board.reload();
+
+    const response = board.buildBoardResponse(
+      new URLSearchParams('all=1&status=open&priority=1&label=alpha'),
+      stateFor(board),
+    );
+
+    expect(response.rows.map((row) => row.id)).toEqual(['web-leaf']);
+    expect(response.statusFacets).toEqual([
+      { value: 'open', count: 1 },
+      { value: 'in_progress', count: 0 },
+      { value: 'blocked', count: 1 },
+      { value: 'deferred', count: 0 },
+      { value: 'closed', count: 0 },
+    ]);
+    expect(response.kindFacets).toEqual([
+      { value: 'bug', count: 0 },
+      { value: 'feature', count: 0 },
+      { value: 'task', count: 1 },
+      { value: 'epic', count: 0 },
+      { value: 'chore', count: 0 },
+    ]);
+    expect(response.priorityFacets).toEqual([
+      { value: 0, count: 0 },
+      { value: 1, count: 1 },
+      { value: 2, count: 1 },
+      { value: 3, count: 0 },
+      { value: 4, count: 0 },
+    ]);
+    expect(response.labelFacets).toEqual([
+      { label: 'alpha', count: 1 },
+      { label: 'gamma', count: 1 },
+    ]);
   });
 
   it('composes column ordering with the newest clicked key primary', async () => {
@@ -663,7 +818,7 @@ describe('BoardState', () => {
     expect(response.search).toBe('SSE');
   });
 
-  it('bounds pretty-tree context metadata to rows present in a capped response', async () => {
+  it('does not let a large filtered pretty tree bypass exact filtering through context', async () => {
     const branchCount = Math.floor(MAX_BOARD_ROWS / 3) + 2;
     let issueIndex = 0;
     const nextId = (): string => {
@@ -711,11 +866,8 @@ describe('BoardState', () => {
       stateFor(board),
     );
 
-    expect(response.rows).toHaveLength(MAX_BOARD_ROWS);
-    expect(response.truncated).toBe(issues.length);
-    const responseIds = new Set(response.rows.map((row) => row.id));
-    expect(response.contextIds.length).toBeGreaterThan(0);
-    expect(response.contextIds.every((id) => responseIds.has(id))).toBe(true);
-    expect(response.contextCount).toBe(response.contextIds.length);
+    expect(response.rows).toHaveLength(branchCount);
+    expect(response.truncated).toBe(0);
+    expect(response.rows.every((row) => row.prefix === '')).toBe(true);
   });
 });

--- a/packages/tbd/tests/web-board.test.ts
+++ b/packages/tbd/tests/web-board.test.ts
@@ -152,12 +152,67 @@ describe('BoardState', () => {
     expect(response.command).toBe('tbd list --label viewer --pretty');
     expect(response.commandExact).toBe(false);
     expect(response.filtersExact).toBe(true);
+    expect(response.labelFacets).toEqual([
+      { label: 'viewer', count: 2 },
+      { label: 'release', count: 1 },
+    ]);
     expect(response.closedHidden).toBe(0);
     expect(response.rows[1]).not.toHaveProperty('description');
     expect(response.rows[1]).not.toHaveProperty('notes');
     expect(response.rows[1]?.updated_at).toBe('2025-01-01T00:00:00Z');
     expect(response.rows[2]?.prefix).toBe('    └── ');
     expect(response.state.stats.total).toBe(3);
+  });
+
+  it('caps label facets at 32 while retaining a selected lower-ranked label', async () => {
+    const { board, setIssues } = harness();
+    const labels = Array.from(
+      { length: 35 },
+      (_, index) => `tag-${String(index).padStart(2, '0')}`,
+    );
+    setIssues([{ ...fixtureIssues()[0]!, status: 'open', labels }]);
+    await board.reload();
+
+    const response = board.buildBoardResponse(new URLSearchParams('label=tag-34'), stateFor(board));
+
+    expect(response.labelFacets).toHaveLength(32);
+    expect(response.labelFacets).toContainEqual({ label: 'tag-34', count: 1 });
+    expect(response.labelFacets.map((facet) => facet.label)).not.toContain('tag-31');
+  });
+
+  it('composes column ordering with the newest clicked key primary', async () => {
+    const { board, setIssues } = harness();
+    const [root, child, leaf] = fixtureIssues();
+    setIssues([
+      { ...root!, status: 'open', priority: 1, updated_at: '2026-01-03T00:00:00Z' },
+      { ...child!, priority: 0, updated_at: '2026-01-01T00:00:00Z' },
+      { ...leaf!, priority: 1, updated_at: '2026-01-02T00:00:00Z' },
+    ]);
+    await board.reload();
+
+    const response = board.buildBoardResponse(
+      new URLSearchParams('all=1&order=priority:asc&order=updated:desc'),
+      stateFor(board),
+    );
+
+    expect(response.rows.map((row) => row.id)).toEqual(['web-kid1', 'web-root', 'web-leaf']);
+    expect(response.commandExact).toBe(false);
+    expect(response.filtersExact).toBe(false);
+  });
+
+  it('orders every textual table column lexicographically with a display-id tie-break', async () => {
+    const { board } = harness();
+    await board.reload();
+    const orderedIds = (order: string) =>
+      board
+        .buildBoardResponse(new URLSearchParams(`all=1&order=${order}`), stateFor(board))
+        .rows.map((row) => row.id);
+
+    expect(orderedIds('id:asc')).toEqual(['web-kid1', 'web-leaf', 'web-root']);
+    expect(orderedIds('status:asc')).toEqual(['web-root', 'web-kid1', 'web-leaf']);
+    expect(orderedIds('kind:asc')).toEqual(['web-root', 'web-kid1', 'web-leaf']);
+    expect(orderedIds('title:asc')).toEqual(['web-root', 'web-kid1', 'web-leaf']);
+    expect(orderedIds('labels:desc')).toEqual(['web-kid1', 'web-leaf', 'web-root']);
   });
 
   it('serves full bodies only for validated public ids', async () => {

--- a/packages/tbd/tests/web-board.test.ts
+++ b/packages/tbd/tests/web-board.test.ts
@@ -155,6 +155,7 @@ describe('BoardState', () => {
     expect(response.closedHidden).toBe(0);
     expect(response.rows[1]).not.toHaveProperty('description');
     expect(response.rows[1]).not.toHaveProperty('notes');
+    expect(response.rows[1]?.updated_at).toBe('2025-01-01T00:00:00Z');
     expect(response.rows[2]?.prefix).toBe('    └── ');
     expect(response.state.stats.total).toBe(3);
   });

--- a/packages/tbd/tests/web-core.test.ts
+++ b/packages/tbd/tests/web-core.test.ts
@@ -100,6 +100,7 @@ function board(watch: ObservationStateView, title = 'Initial', id = 'web-one'): 
       count: value === 2 ? 1 : 0,
     })),
     labelFacets: [],
+    orderingCaveat: null,
     rows: [
       {
         id,
@@ -218,8 +219,8 @@ describe('client core pure helpers', () => {
       { key: 'title', direction: 'asc' },
       { key: 'updated', direction: 'desc' },
     ]);
-    expect(isDefaultBoardSort(DEFAULT_BOARD_SORTS, true)).toBe(true);
-    expect(isDefaultBoardSort(DEFAULT_BOARD_SORTS, false)).toBe(false);
+    expect(isDefaultBoardSort(DEFAULT_BOARD_SORTS)).toBe(true);
+    expect(isDefaultBoardSort([{ key: 'updated', direction: 'desc' }])).toBe(false);
   });
 
   it('formats updated timestamps with deterministic MetaBrowser age tiers', () => {
@@ -258,6 +259,7 @@ describe('client core pure helpers', () => {
       status: 'any',
       kind: 'bug',
       priority: '1',
+      labelSearch: 'rare label',
       labels: ['release', 'urgent'],
       spec: 'plan.md',
       sorts: [
@@ -268,17 +270,20 @@ describe('client core pure helpers', () => {
       pretty: true,
     };
     expect(buildQueryString(controls)).toBe(
-      'q=release+smoke&type=bug&priority=1&spec=plan.md&label=release&label=urgent&order=priority%3Aasc&order=updated%3Adesc&all=1&ready=1&pretty=1',
+      'q=release+smoke&labelq=rare+label&type=bug&priority=1&spec=plan.md&label=release&label=urgent&order=priority%3Aasc&order=updated%3Adesc&all=1&ready=1&pretty=1',
     );
   });
 
   it('names inexactness, local observation modes, and the change-data-version gate', () => {
     const response = board(state());
     response.filtersExact = false;
+    response.orderingCaveat =
+      'Browser column sort: Updated ↓ then Priority ↑; Pretty orders outermost groups and keeps children in official order';
     response.search = 'needle';
     response.truncated = 5_000;
     expect(caveatsFor(response)).toEqual([
       'filters or ordering with no exact CLI equivalent apply',
+      'Browser column sort: Updated ↓ then Priority ↑; Pretty orders outermost groups and keeps children in official order',
       'text search "needle" applies',
       'only the first 1 of 5000 rows are shown',
     ]);
@@ -302,6 +307,32 @@ describe('client core pure helpers', () => {
 });
 
 describe('createClientStore transport orchestration', () => {
+  it('keeps the last successful board visible across a failed refresh and clears the error', async () => {
+    let fail = false;
+    let title = 'Initial';
+    const transport: Transport = {
+      openEvents: () => ({ close: vi.fn() }),
+      fetchJson: () =>
+        fail
+          ? Promise.reject(new Error('temporary board failure'))
+          : Promise.resolve(board(state(), title)),
+    };
+    const store = createClientStore(transport, vi.fn());
+    await store.start();
+
+    fail = true;
+    await store.setControls({ ...store.getView().controls, search: 'failing query' });
+    expect(store.getView().board?.rows[0]?.title).toBe('Initial');
+    expect(store.getView().boardError).toBe('temporary board failure');
+
+    fail = false;
+    title = 'Recovered';
+    await store.setControls({ ...store.getView().controls, search: 'working query' });
+    expect(store.getView().board?.rows[0]?.title).toBe('Recovered');
+    expect(store.getView().boardError).toBeNull();
+    store.stop();
+  });
+
   it('keeps default Pretty and the composed sort across a live data refresh', async () => {
     let onState: ((next: unknown) => void) | null = null;
     let current = board(state());

--- a/packages/tbd/tests/web-core.test.ts
+++ b/packages/tbd/tests/web-core.test.ts
@@ -15,8 +15,10 @@ import {
   MAX_GHOST_ROWS,
   formatRelativeAge,
   isDefaultBoardSort,
+  labelSearchValueForRender,
   paginateBoardRows,
   phaseLabel,
+  preserveLabelSearchEditingKey,
   promoteBoardSort,
 } from '../src/web/core.js';
 import type {
@@ -130,6 +132,19 @@ async function flush(): Promise<void> {
 }
 
 describe('client core pure helpers', () => {
+  it('preserves an in-progress label query across renders until its debounce lands', () => {
+    expect(labelSearchValueForRender('rare la', 'rare', true)).toBe('rare la');
+    expect(labelSearchValueForRender('rare', 'rare', true)).toBe('rare');
+    expect(labelSearchValueForRender('stale', 'canonical', false)).toBe('canonical');
+  });
+
+  it('keeps Home and End as editing keys while the label search owns focus', () => {
+    expect(preserveLabelSearchEditingKey('Home', true)).toBe(true);
+    expect(preserveLabelSearchEditingKey('End', true)).toBe(true);
+    expect(preserveLabelSearchEditingKey('ArrowDown', true)).toBe(false);
+    expect(preserveLabelSearchEditingKey('Home', false)).toBe(false);
+  });
+
   it('pages 10000 rows only at the 5000-row last-resort boundary', () => {
     const seed = board(state()).rows[0]!;
     const rows: BoardRowView[] = Array.from({ length: 10_000 }, (_, index) => ({

--- a/packages/tbd/tests/web-core.test.ts
+++ b/packages/tbd/tests/web-core.test.ts
@@ -10,6 +10,7 @@ import {
   MAX_BODY_REQUEST_CONCURRENCY,
   MAX_EXPANDED_ROWS,
   MAX_GHOST_ROWS,
+  formatRelativeAge,
   paginateBoardRows,
   phaseLabel,
   treeContinuationColumns,
@@ -91,6 +92,7 @@ function board(watch: ObservationStateView, title = 'Initial', id = 'web-one'): 
         assignee: null,
         ready: true,
         prefix: '',
+        updated_at: '2026-08-11T11:55:00.000Z',
       },
     ],
     truncated: 0,
@@ -153,6 +155,29 @@ describe('client core pure helpers', () => {
     expect(treeContinuationColumns('│   ├── ')).toEqual([0]);
     expect(treeContinuationColumns('    │   └── ')).toEqual([4]);
     expect(treeContinuationColumns('│   │   └── ')).toEqual([0, 4]);
+  });
+
+  it('formats updated timestamps with deterministic MetaBrowser age tiers', () => {
+    const now = Date.parse('2026-08-11T12:00:00.000Z');
+    const age = (millisecondsAgo: number) =>
+      formatRelativeAge(new Date(now - millisecondsAgo).toISOString(), now);
+
+    expect(age(30_000)).toEqual({
+      exact: '2026-08-11T11:59:30.000Z',
+      label: 'just now',
+      tier: 'sec',
+    });
+    expect(age(5 * 60_000)).toMatchObject({ label: '5m ago', tier: 'min' });
+    expect(age(2 * 60 * 60_000)).toMatchObject({ label: '2h ago', tier: 'hr' });
+    expect(age(3 * 24 * 60 * 60_000)).toMatchObject({ label: '3d ago', tier: 'day' });
+    expect(age(2 * 7 * 24 * 60 * 60_000)).toMatchObject({ label: '2w ago', tier: 'wk' });
+    expect(age(60 * 24 * 60 * 60_000)).toMatchObject({ label: '2mo ago', tier: 'old' });
+    expect(age(2 * 365 * 24 * 60 * 60_000)).toMatchObject({ label: '2y ago', tier: 'old' });
+    expect(formatRelativeAge('not-a-date', now)).toBeNull();
+    expect(formatRelativeAge('2026-08-11T12:05:00.000Z', now)).toMatchObject({
+      label: 'just now',
+      tier: 'sec',
+    });
   });
 
   it('serializes controls one-to-one with CLI-shaped query parameters', () => {

--- a/packages/tbd/tests/web-core.test.ts
+++ b/packages/tbd/tests/web-core.test.ts
@@ -13,6 +13,8 @@ import {
   formatRelativeAge,
   paginateBoardRows,
   phaseLabel,
+  promoteBoardSort,
+  treeGuideText,
   treeContinuationColumns,
 } from '../src/web/core.js';
 import type {
@@ -78,6 +80,7 @@ function board(watch: ObservationStateView, title = 'Initial', id = 'web-one'): 
     total: 1,
     matched: 1,
     closedHidden: 0,
+    labelFacets: [],
     rows: [
       {
         id,
@@ -155,6 +158,33 @@ describe('client core pure helpers', () => {
     expect(treeContinuationColumns('│   ├── ')).toEqual([0]);
     expect(treeContinuationColumns('    │   └── ')).toEqual([4]);
     expect(treeContinuationColumns('│   │   └── ')).toEqual([0, 4]);
+    expect(treeGuideText('│   │   └── ')).toBe('        └── ');
+  });
+
+  it('promotes clicked columns into a deterministic composable sort stack', () => {
+    expect(promoteBoardSort([], 'updated')).toEqual([
+      { key: 'updated', direction: 'desc' },
+      { key: 'priority', direction: 'asc' },
+    ]);
+    expect(promoteBoardSort([{ key: 'updated', direction: 'desc' }], 'priority')).toEqual([
+      { key: 'priority', direction: 'asc' },
+      { key: 'updated', direction: 'desc' },
+    ]);
+    expect(
+      promoteBoardSort(
+        [
+          { key: 'priority', direction: 'asc' },
+          { key: 'updated', direction: 'desc' },
+        ],
+        'updated',
+      ),
+    ).toEqual([
+      { key: 'updated', direction: 'desc' },
+      { key: 'priority', direction: 'asc' },
+    ]);
+    expect(promoteBoardSort([{ key: 'title', direction: 'asc' }], 'title')).toEqual([
+      { key: 'title', direction: 'desc' },
+    ]);
   });
 
   it('formats updated timestamps with deterministic MetaBrowser age tiers', () => {
@@ -193,14 +223,17 @@ describe('client core pure helpers', () => {
       status: 'any',
       kind: 'bug',
       priority: '1',
-      labels: 'release, urgent',
+      labels: ['release', 'urgent'],
       spec: 'plan.md',
-      sort: 'updated',
+      sorts: [
+        { key: 'priority', direction: 'asc' },
+        { key: 'updated', direction: 'desc' },
+      ],
       ready: true,
       pretty: true,
     };
     expect(buildQueryString(controls)).toBe(
-      'q=release+smoke&type=bug&priority=1&spec=plan.md&label=release&label=urgent&sort=updated&all=1&ready=1&pretty=1',
+      'q=release+smoke&type=bug&priority=1&spec=plan.md&label=release&label=urgent&order=priority%3Aasc&order=updated%3Adesc&all=1&ready=1&pretty=1',
     );
   });
 
@@ -211,7 +244,7 @@ describe('client core pure helpers', () => {
     response.contextCount = 2;
     response.truncated = 5_000;
     expect(caveatsFor(response)).toEqual([
-      'filters with no exact CLI equivalent apply',
+      'filters or ordering with no exact CLI equivalent apply',
       'text search "needle" applies',
       '2 dimmed ancestor rows are shown for context',
       'only the first 1 of 5000 rows are shown',

--- a/packages/tbd/tests/web-core.test.ts
+++ b/packages/tbd/tests/web-core.test.ts
@@ -5,17 +5,19 @@ import {
   buildQueryString,
   caveatsFor,
   createClientStore,
+  DEFAULT_BOARD_SORTS,
+  DELTA_VALUE_PREVIEW_CHARS,
   deltasValid,
+  formatDeltaValue,
   MAX_BODY_CACHE_ENTRIES,
   MAX_BODY_REQUEST_CONCURRENCY,
   MAX_EXPANDED_ROWS,
   MAX_GHOST_ROWS,
   formatRelativeAge,
+  isDefaultBoardSort,
   paginateBoardRows,
   phaseLabel,
   promoteBoardSort,
-  treeGuideText,
-  treeContinuationColumns,
 } from '../src/web/core.js';
 import type {
   BoardControls,
@@ -75,11 +77,28 @@ function board(watch: ObservationStateView, title = 'Initial', id = 'web-one'): 
     command: 'tbd list --pretty',
     commandExact: true,
     filtersExact: true,
-    contextCount: 0,
     search: '',
     total: 1,
     matched: 1,
     closedHidden: 0,
+    statusFacets: [
+      { value: 'open', count: 1 },
+      { value: 'in_progress', count: 0 },
+      { value: 'blocked', count: 0 },
+      { value: 'deferred', count: 0 },
+      { value: 'closed', count: 0 },
+    ],
+    kindFacets: [
+      { value: 'bug', count: 0 },
+      { value: 'feature', count: 0 },
+      { value: 'task', count: 1 },
+      { value: 'epic', count: 0 },
+      { value: 'chore', count: 0 },
+    ],
+    priorityFacets: [0, 1, 2, 3, 4].map((value) => ({
+      value,
+      count: value === 2 ? 1 : 0,
+    })),
     labelFacets: [],
     rows: [
       {
@@ -99,7 +118,6 @@ function board(watch: ObservationStateView, title = 'Initial', id = 'web-one'): 
       },
     ],
     truncated: 0,
-    contextIds: [],
     state: watch,
   };
 }
@@ -151,14 +169,17 @@ describe('client core pure helpers', () => {
     });
   });
 
-  it('continues only ancestor verticals through wrapped pretty titles', () => {
-    expect(treeContinuationColumns('')).toEqual([]);
-    expect(treeContinuationColumns('├── ')).toEqual([]);
-    expect(treeContinuationColumns('└── ')).toEqual([]);
-    expect(treeContinuationColumns('│   ├── ')).toEqual([0]);
-    expect(treeContinuationColumns('    │   └── ')).toEqual([4]);
-    expect(treeContinuationColumns('│   │   └── ')).toEqual([0, 4]);
-    expect(treeGuideText('│   │   └── ')).toBe('        └── ');
+  it('middle-ellipsizes long scalar deltas at one documented boundary', () => {
+    const boundary = formatDeltaValue('x'.repeat(DELTA_VALUE_PREVIEW_CHARS - 2));
+    expect(boundary.preview).toBe(boundary.full);
+    expect(boundary.preview).toHaveLength(DELTA_VALUE_PREVIEW_CHARS);
+
+    const long = formatDeltaValue(`prefix-${'x'.repeat(100)}-suffix`);
+    expect(long.full).toBe(JSON.stringify(`prefix-${'x'.repeat(100)}-suffix`));
+    expect(long.preview).toHaveLength(DELTA_VALUE_PREVIEW_CHARS);
+    expect(long.preview).toMatch(/^"prefix-/u);
+    expect(long.preview).toMatch(/-suffix"$/u);
+    expect(long.preview).toContain('…');
   });
 
   it('promotes clicked columns into a deterministic composable sort stack', () => {
@@ -185,6 +206,20 @@ describe('client core pure helpers', () => {
     expect(promoteBoardSort([{ key: 'title', direction: 'asc' }], 'title')).toEqual([
       { key: 'title', direction: 'desc' },
     ]);
+    expect(
+      promoteBoardSort(
+        [
+          { key: 'updated', direction: 'desc' },
+          { key: 'priority', direction: 'asc' },
+        ],
+        'title',
+      ),
+    ).toEqual([
+      { key: 'title', direction: 'asc' },
+      { key: 'updated', direction: 'desc' },
+    ]);
+    expect(isDefaultBoardSort(DEFAULT_BOARD_SORTS, true)).toBe(true);
+    expect(isDefaultBoardSort(DEFAULT_BOARD_SORTS, false)).toBe(false);
   });
 
   it('formats updated timestamps with deterministic MetaBrowser age tiers', () => {
@@ -241,12 +276,10 @@ describe('client core pure helpers', () => {
     const response = board(state());
     response.filtersExact = false;
     response.search = 'needle';
-    response.contextCount = 2;
     response.truncated = 5_000;
     expect(caveatsFor(response)).toEqual([
       'filters or ordering with no exact CLI equivalent apply',
       'text search "needle" applies',
-      '2 dimmed ancestor rows are shown for context',
       'only the first 1 of 5000 rows are shown',
     ]);
     expect(phaseLabel(state())).toEqual({
@@ -269,6 +302,41 @@ describe('client core pure helpers', () => {
 });
 
 describe('createClientStore transport orchestration', () => {
+  it('keeps default Pretty and the composed sort across a live data refresh', async () => {
+    let onState: ((next: unknown) => void) | null = null;
+    let current = board(state());
+    const requests: string[] = [];
+    const transport: Transport = {
+      openEvents: (_url, callback) => {
+        onState = callback;
+        return { close: vi.fn() };
+      },
+      fetchJson: (url) => {
+        requests.push(url);
+        return Promise.resolve(current);
+      },
+    };
+    const store = createClientStore(transport, vi.fn());
+    await store.start();
+
+    current = board(state({ stateVersion: 1, dataVersion: 1 }), 'Updated live');
+    onState!(current.state);
+    await vi.waitFor(() => {
+      expect(store.getView().board?.rows[0]?.title).toBe('Updated live');
+    });
+
+    expect(store.getView().controls).toMatchObject({
+      pretty: true,
+      sorts: DEFAULT_BOARD_SORTS,
+    });
+    expect(requests).toHaveLength(2);
+    for (const request of requests) {
+      expect(request).toContain('order=updated%3Adesc&order=priority%3Aasc');
+      expect(request).toContain('pretty=1');
+    }
+    store.stop();
+  });
+
   it('connects before fetching, passes the saved local tip, and coalesces updates during fetch', async () => {
     const order: string[] = [];
     const first = deferred<unknown>();

--- a/packages/tbd/tests/web-core.test.ts
+++ b/packages/tbd/tests/web-core.test.ts
@@ -178,6 +178,13 @@ describe('client core pure helpers', () => {
       label: 'just now',
       tier: 'sec',
     });
+
+    expect(age(60 * 60_000 - 1)).toMatchObject({ label: '59m ago', tier: 'min' });
+    expect(age(60 * 60_000)).toMatchObject({ label: '1h ago', tier: 'hr' });
+    expect(age(24 * 60 * 60_000 - 1)).toMatchObject({ label: '23h ago', tier: 'hr' });
+    expect(age(24 * 60 * 60_000)).toMatchObject({ label: '1d ago', tier: 'day' });
+    expect(age(7 * 24 * 60 * 60_000 - 1)).toMatchObject({ label: '6d ago', tier: 'day' });
+    expect(age(7 * 24 * 60 * 60_000)).toMatchObject({ label: '1w ago', tier: 'wk' });
   });
 
   it('serializes controls one-to-one with CLI-shaped query parameters', () => {

--- a/skills/tbd/SKILL.md
+++ b/skills/tbd/SKILL.md
@@ -66,6 +66,8 @@ That’s your job.
 **Live browser requests:** When the user asks to see, show, open, or view beads in a
 browser, start `tbd web --open` yourself with the agent platform’s long-running process
 facility. Do not merely print the command.
+If the requested project is outside your current working directory, start
+`tbd web <path> --open`; the path may be its repository root or any subdirectory.
 Wait for the startup descriptor, give the user its loopback URL, and leave the process
 running until they ask you to stop it or the session environment requires cleanup.
 


### PR DESCRIPTION
## Summary

- harden every production `gray-matter` call behind the existing YAML parser, reject executable and non-YAML engines before dispatch, preserve date-like scalars, and enforce the boundary architecturally
- add a loopback-only live read-only bead viewer driven by native local filesystem events with one-second reconciliation; remote exchange remains exclusively `tbd sync`
- add conditional Status, Type, Priority, and bounded multi-label facets with counts, zero-result hiding, and repeatable-label AND semantics
- add stable columns, relative Updated ages with exact timestamp tooltips, compact expanded deltas, four-line collapsed titles, accessible copy controls, and the documented semantic color/icon system
- default to Pretty with Updated descending then Priority ascending; retain at most two composed sort keys and preserve sorting across live updates
- in Pretty mode, sort only outermost visible groups, roll Updated up from each complete visible subtree, preserve official child order, and keep all filters exact
- give every non-root browser row exactly one `└──` elbow at its hierarchy indentation; ancestor levels use spaces and the browser emits no tee or vertical-bar variants
- document the complete browser, concurrency, interaction, and design-system contracts in the README, CLI manual, architecture doc, development guide, active spec, and co-located CSS inventory

## Security scope

No dependency or lockfile version changes in this PR.

- The remaining production advisory is `gray-matter > js-yaml 3.15.0`, a quadratic `!!omap` resolver issue. Every tbd call supplies the existing `yaml` engine, so the vulnerable parser is unreachable through tbd. The fixed release remains subject to the repository cooldown policy.
- The executable JavaScript front-matter engine is now rejected before engine dispatch.
- The critical Vitest advisory concerns its optional development UI server, which this repository neither installs nor starts. Other non-production advisories are limited to development servers, build tooling, or trusted static repository inputs.
- Package-age validation reports no violations; no install or upgrade was needed.

## Validation

- `pnpm run ci`: passed, including formatting, Markdown, lint, both TypeScript checks, production build, and 114 files / 1,635 tests
- pre-commit quality hooks: passed
- final pre-push quality, build, and complete 1,635-test suite: passed independently
- `pnpm test:coverage`, `pnpm release:verify`, `pnpm check:package-age`, web-package QA, watch-release QA, and packed global-install validation: passed
- 5,000-bead benchmark: 973 ms in the final pre-push run, inside the 5-second gate
- 10,001-row board benchmark: complete bounded response in 52.62 ms; two-key ordering in 33.72 ms
- rebuilt live-browser validation covered exact Active filtering, Pretty persistence, subtree Updated rollup, official child ordering, conditional facets, fixed geometry, typography, expanded deltas, local-update convergence, and all 113 displayed hierarchy prefixes; no tee, vertical bar, or malformed prefix remained

## Review disposition

- every conversation and inline review thread has been read and addressed; no unresolved thread remains
- the mixed-precision Updated chronology finding was fixed in `2fbc0abc` with flat and Pretty rollup regression coverage
- DeepSource reports grade A across security, reliability, complexity, and hygiene
- the `yml` routing report was verified as a false positive through the dependency alias behavior and wrapper test matrix
- the relative-age boundary report was fixed with floor-based quantities and exact-boundary regression coverage

## Beads

- release-readiness epic: `tbd-o7lb`
- web polish epic: `tbd-wter`, closed with all 31 tracked children complete

## Final follow-up

- `tbd web [path]` now accepts a repository or any subdirectory from an arbitrary working directory and reports the canonical repository root. Initialized repositories with zero beads render a normal empty board; missing paths are clear usage errors, and existing uninitialized directories use the standard tbd repository error.
- Installed skill tiers and user/developer documentation now teach agents to use `tbd web <path> --open` when the target project is outside the current working directory.
- Commit `5f32e14f` also fixes both Bugbot findings from the final review: focused label-search drafts survive live/request rerenders until their debounce lands, and Home/End retain native caret behavior while the search field owns focus. Both inline threads have focused TDD coverage, direct replies, and are resolved.
- Final local validation: formatting and Markdown checks, lint, both TypeScript configurations, production build, all 1,635 Vitest tests, all 1,076 CLI transcript checks, packed web-package proof, release verification, and publint. The mandatory source-branch pre-push gate independently passed all 1,635 tests.
- Review tracking epic: `tbd-etgj`; completed follow-up beads: `tbd-4tei`, `tbd-ynmh`, `tbd-fqc6`, `tbd-kbsf`, and `tbd-ovdx`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches parsing boundaries for all issue/docs front matter and substantially changes web board query, sort, and tree semantics; risk is mitigated by extensive tests and loopback-only, read-only server scope.
> 
> **Overview**
> **Release readiness** routes all Markdown front matter through one YAML-only `gray-matter` wrapper using the existing `yaml` engine, rejects non-YAML language markers (blocking the JavaScript evaluator), and normalizes CRLF in YAML blocks so date-like scalars stay strings.
> 
> **`tbd web [path]`** accepts a repository or subdirectory from any working directory; empty initialized repos show a normal empty board, with standard errors for missing or uninitialized paths. Agent skills and docs teach `tbd web <path> --open` for out-of-cwd projects.
> 
> **Dense board presentation** adds cross-filtered Status/Type/Priority facets and a capped, searchable multi-label chooser with AND semantics; an **Updated** column with relative ages and exact tooltips; four-line collapsed titles; two-key header sorting defaulting to Updated↓ then Priority↑; and middle-ellipsized expanded field deltas. Pretty mode no longer injects filtered-out ancestors—matching `tbd list --pretty`—and sorts only outermost groups with Updated rolled up per visible subtree while preserving official child order. Tree rendering uses a single `└──` elbow per non-root row.
> 
> **Browser polish** includes delegated tooltips, tbody row expansion (ignoring text selection), focus restoration on live refresh, label-search draft stability across rerenders, and keeping the last good board visible when refresh fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18b7e0e01803f4729d711927d463d827412302e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->