### PR TITLE
process: finalize v0.5.0 repository state

### DIFF
--- a/.agents/skills/tbd/SKILL.md
+++ b/.agents/skills/tbd/SKILL.md
@@ -59,6 +59,8 @@ That’s your job.
 **Live browser requests:** When the user asks to see, show, open, or view beads in a
 browser, start `tbd web --open` yourself with the agent platform’s long-running process
 facility. Do not merely print the command.
+If the requested project is outside your current working directory, start
+`tbd web <path> --open`; the path may be its repository root or any subdirectory.
 Wait for the startup descriptor, give the user its loopback URL, and leave the process
 running until they ask you to stop it or the session environment requires cleanup.
 

--- a/.claude/hooks/tbd-closing-reminder.sh
+++ b/.claude/hooks/tbd-closing-reminder.sh
@@ -16,7 +16,7 @@ if [[ "$command" == git\ push* ]] || [[ "$command" == *"&& git push"* ]] || [[ "
     if command -v tbd &> /dev/null; then
       tbd closing
     elif command -v npx &> /dev/null; then
-      npx --yes get-tbd@0.4.2 closing
+      npx --yes get-tbd@0.5.0 closing
     fi
   fi
 fi

--- a/.claude/scripts/tbd-session.sh
+++ b/.claude/scripts/tbd-session.sh
@@ -18,10 +18,10 @@ fi
 
 # Pinned zero-install fallback. Never use an unpinned runner here.
 if command -v npx &> /dev/null; then
-    npx --yes get-tbd@0.4.2 prime "$@"
+    npx --yes get-tbd@0.5.0 prime "$@"
     exit $?
 fi
 
 echo "[tbd] tbd CLI not found and npx is unavailable."
-echo "[tbd] Install it with: npm install -g get-tbd@0.4.2"
+echo "[tbd] Install it with: npm install -g get-tbd@0.5.0"
 exit 1

--- a/.claude/skills/tbd/SKILL.md
+++ b/.claude/skills/tbd/SKILL.md
@@ -59,6 +59,8 @@ That’s your job.
 **Live browser requests:** When the user asks to see, show, open, or view beads in a
 browser, start `tbd web --open` yourself with the agent platform’s long-running process
 facility. Do not merely print the command.
+If the requested project is outside your current working directory, start
+`tbd web <path> --open`; the path may be its repository root or any subdirectory.
 Wait for the startup descriptor, give the user its loopback URL, and leave the process
 running until they ask you to stop it or the session environment requires cleanup.
 

--- a/.codex/tbd-closing-reminder.sh
+++ b/.codex/tbd-closing-reminder.sh
@@ -16,7 +16,7 @@ if [[ "$command" == git\ push* ]] || [[ "$command" == *"&& git push"* ]] || [[ "
     if command -v tbd &> /dev/null; then
       tbd closing
     elif command -v npx &> /dev/null; then
-      npx --yes get-tbd@0.4.2 closing
+      npx --yes get-tbd@0.5.0 closing
     fi
   fi
 fi

--- a/.codex/tbd-session.sh
+++ b/.codex/tbd-session.sh
@@ -18,10 +18,10 @@ fi
 
 # Pinned zero-install fallback. Never use an unpinned runner here.
 if command -v npx &> /dev/null; then
-    npx --yes get-tbd@0.4.2 prime "$@"
+    npx --yes get-tbd@0.5.0 prime "$@"
     exit $?
 fi
 
 echo "[tbd] tbd CLI not found and npx is unavailable."
-echo "[tbd] Install it with: npm install -g get-tbd@0.4.2"
+echo "[tbd] Install it with: npm install -g get-tbd@0.5.0"
 exit 1

--- a/docs/development.md
+++ b/docs/development.md
@@ -138,7 +138,7 @@ browser recovery across an observer restart.
 The package proof launches `tbd web` from an extracted npm tarball and verifies that its
 self-contained page and APIs work.
 Design and implementation details are in
-[plan-2026-08-10-tbd-web-live-bead-view.md](project/specs/active/plan-2026-08-10-tbd-web-live-bead-view.md).
+[plan-2026-08-10-tbd-web-live-bead-view.md](project/specs/done/plan-2026-08-10-tbd-web-live-bead-view.md).
 
 ### Building
 

--- a/docs/project/specs/done/plan-2026-08-10-tbd-web-live-bead-view.md
+++ b/docs/project/specs/done/plan-2026-08-10-tbd-web-live-bead-view.md
@@ -5,11 +5,11 @@ author: Joshua Levy (github.com/jlevy) with LLM assistance
 ---
 # Feature: `tbd web` — Live Bead View
 
-**Date:** 2026-08-10 (last updated 2026-08-11)
+**Date:** 2026-08-10 (last updated 2026-08-13)
 
 **Author:** Joshua Levy (github.com/jlevy) with LLM assistance
 
-**Status:** Implementation and validation complete on PR #207; merge-ready
+**Status:** Released in get-tbd v0.5.0 through PRs #207 and #209
 
 ## Overview
 


### PR DESCRIPTION
## Summary

- archive the completed `tbd web` specification under `specs/done` and update its released status/link
- refresh tracked Agent/Claude skill mirrors with the shipped explicit-path guidance
- pin the tracked Claude/Codex zero-install fallbacks to the now-published `get-tbd@0.5.0`

This is post-release repository cleanup only. It does not change the v0.5.0 tag, npm artifact, runtime code, dependencies, or lockfile. The existing user-owned `.tbd/config.yml` change is excluded.

## Validation

- public tag, GitHub Release body, npm `latest`, integrity, registry signatures, and SLSA provenance verified
- global exact-tarball install reports 0.5.0 and carries the bundled viewer docs/assets
- published CLI smoke: uninitialized error, empty repository, explicit subdirectory, packaged page/API, live update, graceful shutdown
- `pnpm run ci`: 114 files / 1,635 tests
- CLI transcripts: 1,076 passed
- release verify + publint passed
- packed web proof passed
- watch release topology passed
- package-age gate: 31 pins, 0 violations
- pre-push gate passed independently

## Security

The lockfile remains byte-identical to v0.4.2. `pnpm audit --prod` still reports only the documented `gray-matter → js-yaml@3.15.0` `!!omap` CPU advisory. tbd routes all gray-matter parsing through its custom YAML 1.2 engine, so that resolver is unreachable; the patched transitive release remains inside the 14-day cooldown.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 99ed8a862a03abc4ed85344bf1049e95827a79c8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->