### PR TITLE
docs: add setup-linear shortcut and Linear onboarding path

### DIFF
--- a/.agents/skills/tbd/SKILL.md
+++ b/.agents/skills/tbd/SKILL.md
@@ -117,6 +117,9 @@ or want help → run `tbd shortcut welcome-user`
 | “Make the guidelines visible / customize doc X” | `tbd docs fork --category=general --category=<lang>` (recommended: general + the repo’s languages), or `tbd docs fork <name>` / `--all`; then edit in `docs/tbd/` |
 | “Update the guidelines to the latest” | `tbd docs update`; on conflicts ask the user, then `--merge` or `--keep-ours` |
 | “I deleted a forked doc file” | `tbd docs status` shows it `missing`; restore with `tbd docs fork <name> --force` or finalize with `tbd docs unfork <name>` |
+| **External Trackers** |  |
+| “Set up Linear” / “Connect this repo to Linear” | `tbd shortcut setup-linear` |
+| “My Linear sync isn’t working” / “Add my Linear key” | `tbd shortcut setup-linear` |
 | **Cleanup & Maintenance** |  |
 | “Clean up this code” / “Remove dead code” | `tbd shortcut code-cleanup-all` |
 | “Fix repository problems” | `tbd doctor --fix` |
@@ -236,16 +239,23 @@ mutation and make one call per group.
 | `tbd integration link/unlink <bead> [ref]` | Bind or sever a bead and an existing tracker item; unlink safely cancels pending writes for that pair before clearing the link |
 | `tbd integration comment <bead> "text"` | Author a comment offline; posted on next sync |
 
-When a user asks to “sync our specs and beads to Linear”: run `status` first.
-No API key → ask the user to create one at `linear.app/settings/api` and put it in a
-**gitignored** `.env` as `LINEAR_API_KEY=…` (never commit it).
-No config → add
-`integrations: { linear: { enabled: true, team_key: <THEIRS>, project: <optional>, user_map: <optional alias-to-email-or-UUID map>, policy: default } }`
-to `.tbd/config.yml`, re-check `status`, then `--dry-run sync --push`, `sync --push`,
-`sync`. Full details: the External Tracker Integrations section of `tbd docs`. Bulk runs
-over 20 creates / 40 updates refuse without `--yes`. Never echo credentials into output
-or commits. `--pull` never replays or performs provider writes; deferred claims and
-conflict notices remain journaled until the next full sync.
+**Setting Linear up at all — including “add my key” — is `tbd shortcut setup-linear`.**
+Run it rather than improvising; it detects which case applies and walks the user through
+only that case.
+
+The mental model it encodes: **config is shared, credentials are personal.** The
+`integrations` block in `.tbd/config.yml` (team, project, policy) is committed, so a
+teammate who clones already has it; `LINEAR_API_KEY` lives in the environment or a
+**gitignored** `.env` and is never committed.
+So a user joining a repo whose team already syncs needs *only* a key—never a config
+edit, and never `sync --push` (their links arrived with the clone; a full `sync` is the
+correct first command).
+Run `status` first in every case.
+Full details: the External Tracker Integrations section of `tbd docs`. Bulk runs over 20
+creates / 40 updates refuse without `--yes`. Never echo credentials into output or
+commits.
+`--pull` never replays or performs provider writes; deferred claims and conflict
+notices remain journaled until the next full sync.
 Link/inbound creation refuse a remote `tbd://bead/…` claim unless `--force` is explicit
 and the old claim was verified stale.
 Configured `project` scopes both creates and automatic inbound scans; an explicit
@@ -323,6 +333,7 @@ Run `tbd shortcut <name>` to use any of these shortcuts:
 | revise-all-architecture-docs | Comprehensive revision of all current architecture documents |
 | revise-architecture-doc | Update an architecture document to reflect current codebase state |
 | setup-github-cli | Ensure GitHub CLI (gh) is installed and working |
+| setup-linear | Set up the Linear integration end to end—first-time configuration for a repository, or adding your own API key to a repository your team already configured |
 | suggest-upstream-improvements | Review local doc-fork customizations and contribute the generally useful changes back upstream |
 | sync-failure-recovery | Handle tbd sync failures by saving to workspace and recovering later |
 | update-specs-status | Reconcile active specs, the top-level work index (e.g. TODO.md), and tbd beads into one current status map |

--- a/.claude/skills/tbd/SKILL.md
+++ b/.claude/skills/tbd/SKILL.md
@@ -117,6 +117,9 @@ or want help → run `tbd shortcut welcome-user`
 | “Make the guidelines visible / customize doc X” | `tbd docs fork --category=general --category=<lang>` (recommended: general + the repo’s languages), or `tbd docs fork <name>` / `--all`; then edit in `docs/tbd/` |
 | “Update the guidelines to the latest” | `tbd docs update`; on conflicts ask the user, then `--merge` or `--keep-ours` |
 | “I deleted a forked doc file” | `tbd docs status` shows it `missing`; restore with `tbd docs fork <name> --force` or finalize with `tbd docs unfork <name>` |
+| **External Trackers** |  |
+| “Set up Linear” / “Connect this repo to Linear” | `tbd shortcut setup-linear` |
+| “My Linear sync isn’t working” / “Add my Linear key” | `tbd shortcut setup-linear` |
 | **Cleanup & Maintenance** |  |
 | “Clean up this code” / “Remove dead code” | `tbd shortcut code-cleanup-all` |
 | “Fix repository problems” | `tbd doctor --fix` |
@@ -236,16 +239,23 @@ mutation and make one call per group.
 | `tbd integration link/unlink <bead> [ref]` | Bind or sever a bead and an existing tracker item; unlink safely cancels pending writes for that pair before clearing the link |
 | `tbd integration comment <bead> "text"` | Author a comment offline; posted on next sync |
 
-When a user asks to “sync our specs and beads to Linear”: run `status` first.
-No API key → ask the user to create one at `linear.app/settings/api` and put it in a
-**gitignored** `.env` as `LINEAR_API_KEY=…` (never commit it).
-No config → add
-`integrations: { linear: { enabled: true, team_key: <THEIRS>, project: <optional>, user_map: <optional alias-to-email-or-UUID map>, policy: default } }`
-to `.tbd/config.yml`, re-check `status`, then `--dry-run sync --push`, `sync --push`,
-`sync`. Full details: the External Tracker Integrations section of `tbd docs`. Bulk runs
-over 20 creates / 40 updates refuse without `--yes`. Never echo credentials into output
-or commits. `--pull` never replays or performs provider writes; deferred claims and
-conflict notices remain journaled until the next full sync.
+**Setting Linear up at all — including “add my key” — is `tbd shortcut setup-linear`.**
+Run it rather than improvising; it detects which case applies and walks the user through
+only that case.
+
+The mental model it encodes: **config is shared, credentials are personal.** The
+`integrations` block in `.tbd/config.yml` (team, project, policy) is committed, so a
+teammate who clones already has it; `LINEAR_API_KEY` lives in the environment or a
+**gitignored** `.env` and is never committed.
+So a user joining a repo whose team already syncs needs *only* a key—never a config
+edit, and never `sync --push` (their links arrived with the clone; a full `sync` is the
+correct first command).
+Run `status` first in every case.
+Full details: the External Tracker Integrations section of `tbd docs`. Bulk runs over 20
+creates / 40 updates refuse without `--yes`. Never echo credentials into output or
+commits.
+`--pull` never replays or performs provider writes; deferred claims and conflict
+notices remain journaled until the next full sync.
 Link/inbound creation refuse a remote `tbd://bead/…` claim unless `--force` is explicit
 and the old claim was verified stale.
 Configured `project` scopes both creates and automatic inbound scans; an explicit
@@ -323,6 +333,7 @@ Run `tbd shortcut <name>` to use any of these shortcuts:
 | revise-all-architecture-docs | Comprehensive revision of all current architecture documents |
 | revise-architecture-doc | Update an architecture document to reflect current codebase state |
 | setup-github-cli | Ensure GitHub CLI (gh) is installed and working |
+| setup-linear | Set up the Linear integration end to end—first-time configuration for a repository, or adding your own API key to a repository your team already configured |
 | suggest-upstream-improvements | Review local doc-fork customizations and contribute the generally useful changes back upstream |
 | sync-failure-recovery | Handle tbd sync failures by saving to workspace and recovering later |
 | update-specs-status | Reconcile active specs, the top-level work index (e.g. TODO.md), and tbd beads into one current status map |

--- a/.tbd/config.yml
+++ b/.tbd/config.yml
@@ -85,6 +85,7 @@ docs_cache:
     shortcuts/standard/revise-all-architecture-docs.md: internal:shortcuts/standard/revise-all-architecture-docs.md
     shortcuts/standard/revise-architecture-doc.md: internal:shortcuts/standard/revise-architecture-doc.md
     shortcuts/standard/setup-github-cli.md: internal:shortcuts/standard/setup-github-cli.md
+    shortcuts/standard/setup-linear.md: internal:shortcuts/standard/setup-linear.md
     shortcuts/standard/suggest-upstream-improvements.md: internal:shortcuts/standard/suggest-upstream-improvements.md
     shortcuts/standard/sync-failure-recovery.md: internal:shortcuts/standard/sync-failure-recovery.md
     shortcuts/standard/update-specs-status.md: internal:shortcuts/standard/update-specs-status.md

--- a/packages/tbd/docs/shortcuts/standard/setup-linear.md
+++ b/packages/tbd/docs/shortcuts/standard/setup-linear.md
@@ -1,0 +1,195 @@
+---
+title: Setup Linear
+description: Set up the Linear integration end to end—first-time configuration for a repository, or adding your own API key to a repository your team already configured
+category: session
+author: Joshua Levy (github.com/jlevy) with LLM assistance
+---
+Use this when a user wants to connect this repository to Linear, or says their Linear
+sync “isn’t working” and you do not yet know whether the repository is configured, the
+key is missing, or both.
+
+Two things must be true before Linear sync works, and they are set up in different
+places by different people:
+
+| What | Where it lives | Who sets it | Shared? |
+| --- | --- | --- | --- |
+| **Configuration** — team, project, policy | `.tbd/config.yml`, committed to git | Whoever sets the repository up, once | Yes—everyone on the team gets it by cloning |
+| **Credential** — `LINEAR_API_KEY` | Environment or a **gitignored** `.env` | Every person and agent, individually | **Never**—a key is personal and is never committed |
+
+That split is the whole shape of this workflow.
+A user joining a team that already uses Linear needs only the second one.
+
+## Step 1: Find out which case you are in
+
+Do this before anything else.
+Do not edit config or ask for a key until you know which case applies.
+
+```bash
+tbd integration status --offline   # No network call: just config and credential
+```
+
+Read the output and match it:
+
+| What `status` says | Case | What is missing |
+| --- | --- | --- |
+| `No external tracker integrations are configured.` | **A. First-time setup** | Config and key |
+| `✓ enabled: yes` and `✓ target: <KEY>`, but `✗ credential: LINEAR_API_KEY not found` | **B. Joining a configured repo** | Just your key |
+| `✓ enabled`, `✓ target`, `✓ credential` | **C. Already set up** | Nothing—go to Step 4 |
+| `- enabled: configured but disabled` | **D. Deliberately off** | Ask before changing it |
+
+Case B is the common one on a team: the `integrations` block is committed, so it arrived
+with the clone. **Do not re-run first-time setup in case B.** Changing `team_key` or
+`project` when teammates and other agents are already syncing points this repository at
+a different place than theirs.
+
+## Step 2 (case A only): Configure the repository
+
+Skip this entirely for cases B, C, and D.
+
+You cannot infer the team or project—**ask the user**:
+
+- **Team key**: the prefix on their Linear issue identifiers.
+  `FIN-123` means the team key is `FIN`.
+- **Project** (optional but recommended): scopes both new issue creation and automatic
+  inbound discovery to one project, so tbd never wanders into unrelated team work.
+
+Then add to `.tbd/config.yml`:
+
+```yaml
+integrations:
+  linear:
+    enabled: true
+    team_key: FIN # theirs, from the user
+    project: my-project # optional; omit if they did not name one
+    policy: default # open epics + anything with a live plan spec
+```
+
+Leave `policy: default` unless the user asks for something else.
+It selects open epics plus anything whose `spec_path` points into `specs/active/`—the
+right starting point for “track our specs and major work”, and roughly 10% of a typical
+repository’s beads.
+
+Two optional keys worth mentioning only if the user raises the need:
+
+- `user_map: { alias: person@example.com }` — the **only** identities tbd may push as
+  assignees. Without it, assignees do not sync in either direction, and no email or raw
+  Linear user ever enters bead data.
+- `mirror_labels: true` — pushes bead labels as Linear labels.
+  Off by default on purpose: a repository can carry a hundred-plus labels, and creating
+  one Linear label each pollutes a shared team namespace.
+
+This block is committed.
+Commit it in the same change as any other setup, so the next teammate to clone gets it.
+
+## Step 3 (cases A and B): Add your own API key
+
+This step is per person and per machine.
+It is the *only* step a user in case B needs.
+
+**First, verify `.env` is gitignored — before writing anything into it.**
+`tbd integration status` reports `✓ .env: not present` when there is no file, which says
+nothing about whether creating one would be safe:
+
+```bash
+git check-ignore -q .env && echo "safe" || echo "NOT IGNORED — fix .gitignore first"
+```
+
+If it prints `NOT IGNORED`, add `.env` to `.gitignore` and commit that **before** the
+key exists on disk. This ordering is the point: it is what stops a key from being
+committed.
+
+Then have the user create a personal API key at `linear.app/settings/api` and put it in
+`.env` at the repository root:
+
+```
+LINEAR_API_KEY=lin_api_...
+```
+
+Rules that are not negotiable:
+
+- **Never** echo the key, print it, paste it into a commit message or PR body, or put it
+  anywhere tracked by git.
+- **Never** write it into `.tbd/config.yml`—that file is committed.
+- If a key was ever committed, say so plainly and tell the user to rotate it in Linear.
+  Removing the commit is not enough.
+
+tbd reads `LINEAR_API_KEY` from the process environment first, then from `.env`. An
+exported environment variable is equally fine and needs no file.
+
+## Step 4: Verify
+
+```bash
+tbd integration status   # Now with the network check
+```
+
+Every line should be `✓`, including `reachable`. If `reachable` fails, the key is wrong,
+revoked, or lacks access to that team—not a tbd problem.
+Have the user re-check the key and the team key.
+
+Report the result to the user in plain terms: configured or not, whose key is in use
+(the masked form `status` prints, never the key itself), and which team and project.
+
+## Step 5: The first sync
+
+**Which command depends on the case, and getting this wrong matters.**
+
+**Case B (joining a repo that already syncs):** the links between beads and Linear
+issues are stored in the beads themselves and arrived with your clone.
+Run a full sync, and preview it first:
+
+```bash
+tbd --dry-run integration sync   # Preview: reconciles nothing, writes nothing
+tbd integration sync             # Both directions; converges to `nothing to do`
+```
+
+Do **not** run `sync --push` as a joiner.
+The outbound-only path projects local bead values over the tracker without a three-way
+reconcile, so it can overwrite a teammate’s Linear-side edit that a full `sync` would
+have detected and reported as a conflict.
+
+**Case A (first repository setup):** nothing is linked yet, so stage the initial
+projection rather than creating dozens of issues in one shot:
+
+```bash
+tbd --dry-run integration sync --push              # Every bead id it would touch
+tbd integration sync --push --type epic --limit 5  # A handful first
+```
+
+Have the user look at those five in Linear.
+When they are happy with how it reads, widen, then switch to full sync for good:
+
+```bash
+tbd integration sync --push   # The rest of the policy's outbound set
+tbd integration sync          # Both directions, from now on
+```
+
+Runs above **20 creates** or **40 updates** refuse without `--yes`. That guard is there
+because a mis-set selector turns “a couple of epics” into “every bead in the repo”.
+If you hit it, re-read the dry run before adding `--yes`.
+
+After the first sync, plain `tbd sync` includes enabled trackers automatically, so a
+session-end `tbd sync` keeps Linear current with no extra command.
+
+## What to tell the user when you are done
+
+- Which case it was, and what you changed (config, `.env`, or nothing).
+- That the config is committed and shared, but their key is personal and stays local.
+- That `tbd sync` now covers Linear too.
+- For case A: that `.tbd/config.yml` needs committing so teammates inherit it.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `LINEAR_API_KEY not found` | No key in env or `.env` | Step 3 |
+| `.env: present and NOT gitignored` | Key is one `git add` from being committed | Add `.env` to `.gitignore` now; rotate the key if it was ever committed |
+| `reachable` fails with a valid-looking key | Key revoked, or no access to that team | Re-issue at `linear.app/settings/api`; confirm `team_key` |
+| Integration block vanished from `config.yml` | `tbd setup` was run by a tbd older than this feature | `git checkout .tbd/config.yml`, then upgrade tbd |
+| Sync says `nothing to do` but Linear looks stale | The policy does not select those beads | Check `policy.outbound` against what the user expects; `--dry-run integration sync --push` lists the selected set |
+| A bead reports malformed managed-block markers | A human edited inside the `⟦tbd⟧` … `⟦/tbd⟧` region in Linear | Repair the region in Linear (one `⟦tbd⟧` and one `⟦/tbd⟧`, in that order) or delete it entirely; the next sync rewrites it |
+
+Full reference: the External Tracker Integrations section of `tbd docs`.
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/packages/tbd/docs/shortcuts/standard/welcome-user.md
+++ b/packages/tbd/docs/shortcuts/standard/welcome-user.md
@@ -13,6 +13,13 @@ project.
 First, run `tbd status` to check the current state.
 Give a brief summary of the status (repository, sync status, integrations).
 
+If the summary shows an external tracker (Linear) **configured but missing a
+credential**, that means this project already syncs to Linear and the user just needs
+their own API key.
+Say so and offer `tbd shortcut setup-linear`—do not make them hunt for
+it. Mention it as an option, without derailing the welcome, if no tracker is configured
+at all.
+
 Then make the two-axis guidelines offer, one short question per axis:
 
 1. **Scope:** keep **all** standard guidelines active (recommended), or just a subset
@@ -73,6 +80,7 @@ For a project outside the agent’s current working directory, it can use
 | “Commit this code” | Reviews changes and commits properly (`tbd shortcut code-review-and-commit`) |
 | “Create a PR” | Creates a pull request with summary (`tbd shortcut create-or-update-pr-simple`) |
 | “Review this for best practices” | Performs a code review with guidelines |
+| “Set up Linear” / “Add my Linear key” | Walks through connecting this repo to Linear (`tbd shortcut setup-linear`) |
 
 ### Guidelines
 

--- a/packages/tbd/docs/shortcuts/system/skill-baseline.md
+++ b/packages/tbd/docs/shortcuts/system/skill-baseline.md
@@ -109,6 +109,9 @@ or want help → run `tbd shortcut welcome-user`
 | “Make the guidelines visible / customize doc X” | `tbd docs fork --category=general --category=<lang>` (recommended: general + the repo’s languages), or `tbd docs fork <name>` / `--all`; then edit in `docs/tbd/` |
 | “Update the guidelines to the latest” | `tbd docs update`; on conflicts ask the user, then `--merge` or `--keep-ours` |
 | “I deleted a forked doc file” | `tbd docs status` shows it `missing`; restore with `tbd docs fork <name> --force` or finalize with `tbd docs unfork <name>` |
+| **External Trackers** |  |
+| “Set up Linear” / “Connect this repo to Linear” | `tbd shortcut setup-linear` |
+| “My Linear sync isn’t working” / “Add my Linear key” | `tbd shortcut setup-linear` |
 | **Cleanup & Maintenance** |  |
 | “Clean up this code” / “Remove dead code” | `tbd shortcut code-cleanup-all` |
 | “Fix repository problems” | `tbd doctor --fix` |
@@ -228,16 +231,23 @@ mutation and make one call per group.
 | `tbd integration link/unlink <bead> [ref]` | Bind or sever a bead and an existing tracker item; unlink safely cancels pending writes for that pair before clearing the link |
 | `tbd integration comment <bead> "text"` | Author a comment offline; posted on next sync |
 
-When a user asks to “sync our specs and beads to Linear”: run `status` first.
-No API key → ask the user to create one at `linear.app/settings/api` and put it in a
-**gitignored** `.env` as `LINEAR_API_KEY=…` (never commit it).
-No config → add
-`integrations: { linear: { enabled: true, team_key: <THEIRS>, project: <optional>, user_map: <optional alias-to-email-or-UUID map>, policy: default } }`
-to `.tbd/config.yml`, re-check `status`, then `--dry-run sync --push`, `sync --push`,
-`sync`. Full details: the External Tracker Integrations section of `tbd docs`. Bulk runs
-over 20 creates / 40 updates refuse without `--yes`. Never echo credentials into output
-or commits. `--pull` never replays or performs provider writes; deferred claims and
-conflict notices remain journaled until the next full sync.
+**Setting Linear up at all — including “add my key” — is `tbd shortcut setup-linear`.**
+Run it rather than improvising; it detects which case applies and walks the user through
+only that case.
+
+The mental model it encodes: **config is shared, credentials are personal.** The
+`integrations` block in `.tbd/config.yml` (team, project, policy) is committed, so a
+teammate who clones already has it; `LINEAR_API_KEY` lives in the environment or a
+**gitignored** `.env` and is never committed.
+So a user joining a repo whose team already syncs needs *only* a key—never a config
+edit, and never `sync --push` (their links arrived with the clone; a full `sync` is the
+correct first command).
+Run `status` first in every case.
+Full details: the External Tracker Integrations section of `tbd docs`. Bulk runs over 20
+creates / 40 updates refuse without `--yes`. Never echo credentials into output or
+commits.
+`--pull` never replays or performs provider writes; deferred claims and conflict
+notices remain journaled until the next full sync.
 Link/inbound creation refuse a remote `tbd://bead/…` claim unless `--force` is explicit
 and the old claim was verified stale.
 Configured `project` scopes both creates and automatic inbound scans; an explicit

--- a/packages/tbd/docs/tbd-docs.md
+++ b/packages/tbd/docs/tbd-docs.md
@@ -1615,9 +1615,23 @@ One caveat: `tbd setup` run by a tbd version that predates this feature will dro
 The block is tracked in git, so `git checkout .tbd/config.yml` restores it, and the
 symptom is loud (the mirror stops working rather than misbehaving).
 
-Set `LINEAR_API_KEY` in your environment or in a **gitignored** `.env` at the repository
-root. tbd reads it but never writes it back, and refuses to treat an unignored `.env` as
+The block above is **committed**, so it is set up once per repository and everyone who
+clones inherits it. Credentials are the opposite: `LINEAR_API_KEY` is per person and per
+machine, set in the environment or in a **gitignored** `.env` at the repository root.
+tbd reads it but never writes it back, and refuses to treat an unignored `.env` as
 acceptable, because that is how a key gets committed.
+A teammate joining a repository that already syncs therefore needs only a key—no config
+edit at all.
+
+Check that `.env` is ignored *before* writing a key into it.
+`status` reports `.env: not present` when no file exists, which is not evidence that
+creating one would be safe:
+
+```bash
+git check-ignore -q .env && echo safe || echo "add .env to .gitignore first"
+```
+
+`tbd shortcut setup-linear` walks through all of this, including which case you are in.
 
 ```bash
 tbd integration status          # Is it configured, credentialed, reachable?
@@ -1909,27 +1923,58 @@ Maintainers run the API-driven live gate in `tests/qa/linear-integration.qa.md`;
 stable scenarios are the compatibility contract that a GitHub driver must reuse rather
 than redesign.
 
-### For agents: synchronizing specs and beads to Linear
+### For agents: setting up and synchronizing Linear
 
-The whole flow an agent needs when a user says “sync our specs and major beads to
-Linear”:
+**The guided walkthrough is `tbd shortcut setup-linear`.** It detects which of the cases
+below applies and covers only that one.
+Run it instead of improvising a setup sequence.
+
+The distinction that drives everything: **configuration is shared, credentials are
+personal.** The `integrations` block lives in `.tbd/config.yml`, which is committed, so
+everyone who clones the repository inherits the team, project, and policy.
+`LINEAR_API_KEY` lives in the environment or a gitignored `.env` and is never committed,
+so every person and agent supplies their own.
+
+`tbd integration status` separates the two, and its output is how you tell the cases
+apart:
+
+| `status` shows | Case | What is needed |
+| --- | --- | --- |
+| `No external tracker integrations are configured.` | First-time repository setup | Config, then a key |
+| `✓ enabled` / `✓ target`, `✗ credential` | **Joining a repo the team already set up** | Only your own key |
+| all `✓` | Working | Nothing |
+
+#### Joining a repository that already syncs
+
+The common case on a team, and the one that needs the least work.
+The `integrations` block arrived with the clone, and the bead↔issue links live in the
+beads themselves on the sync branch, so they arrived too.
+Supply a key and run a full sync:
 
 ```bash
-tbd integration status             # 1. Is Linear configured and reachable?
+tbd integration status                 # Confirms config is present, credential is not
+# add LINEAR_API_KEY to a gitignored .env, then:
+tbd --dry-run integration sync         # Preview
+tbd integration sync                   # Both directions; converges to `nothing to do`
 ```
 
-- If **no API key**: ask the user to create one at `linear.app/settings/api` and place
-  it in a **gitignored** `.env` at the repo root as `LINEAR_API_KEY=lin_api_…`, or
-  export it in the environment.
-  Never commit a key; `status` fails loudly if `.env` is not gitignored.
-- If **no config**: add the `integrations:` block above to `.tbd/config.yml` with the
-  user’s team key (and project, if they name one), then re-run `status` to verify the
-  team resolves.
+Do **not** re-run first-time setup here: editing `team_key` or `project` points this
+clone at a different place than the rest of the team.
+Do not reach for `sync --push` either—the links already exist, so the full `sync` is
+both correct and safer (it reconciles rather than projecting over the tracker).
+
+#### First-time setup for a repository
+
+Add the `integrations:` block shown under [Setup](#setup) with the user’s team key (and
+project, if they name one), add a key, verify, then stage the initial projection instead
+of creating every issue at once:
 
 ```bash
-tbd --dry-run integration sync --push  # 2. Preview the outbound set; stage with --bead/--limit
-tbd integration sync --push            # 3. Create/update the tracker issues
-tbd integration sync               # 4. Reconcile from then on; repeat at session end
+tbd integration status                             # 1. Config and key resolve; team exists
+tbd --dry-run integration sync --push              # 2. Preview the outbound set
+tbd integration sync --push --type epic --limit 5  # 3. A handful; look at them in Linear
+tbd integration sync --push                        # 4. Widen once the shape reads well
+tbd integration sync                               # 5. Reconcile from then on
 ```
 
 The default policy mirrors open epics and anything with an active plan spec — the right

--- a/skills/tbd/SKILL.md
+++ b/skills/tbd/SKILL.md
@@ -124,6 +124,9 @@ or want help → run `tbd shortcut welcome-user`
 | “Make the guidelines visible / customize doc X” | `tbd docs fork --category=general --category=<lang>` (recommended: general + the repo’s languages), or `tbd docs fork <name>` / `--all`; then edit in `docs/tbd/` |
 | “Update the guidelines to the latest” | `tbd docs update`; on conflicts ask the user, then `--merge` or `--keep-ours` |
 | “I deleted a forked doc file” | `tbd docs status` shows it `missing`; restore with `tbd docs fork <name> --force` or finalize with `tbd docs unfork <name>` |
+| **External Trackers** |  |
+| “Set up Linear” / “Connect this repo to Linear” | `tbd shortcut setup-linear` |
+| “My Linear sync isn’t working” / “Add my Linear key” | `tbd shortcut setup-linear` |
 | **Cleanup & Maintenance** |  |
 | “Clean up this code” / “Remove dead code” | `tbd shortcut code-cleanup-all` |
 | “Fix repository problems” | `tbd doctor --fix` |
@@ -243,16 +246,23 @@ mutation and make one call per group.
 | `tbd integration link/unlink <bead> [ref]` | Bind or sever a bead and an existing tracker item; unlink safely cancels pending writes for that pair before clearing the link |
 | `tbd integration comment <bead> "text"` | Author a comment offline; posted on next sync |
 
-When a user asks to “sync our specs and beads to Linear”: run `status` first.
-No API key → ask the user to create one at `linear.app/settings/api` and put it in a
-**gitignored** `.env` as `LINEAR_API_KEY=…` (never commit it).
-No config → add
-`integrations: { linear: { enabled: true, team_key: <THEIRS>, project: <optional>, user_map: <optional alias-to-email-or-UUID map>, policy: default } }`
-to `.tbd/config.yml`, re-check `status`, then `--dry-run sync --push`, `sync --push`,
-`sync`. Full details: the External Tracker Integrations section of `tbd docs`. Bulk runs
-over 20 creates / 40 updates refuse without `--yes`. Never echo credentials into output
-or commits. `--pull` never replays or performs provider writes; deferred claims and
-conflict notices remain journaled until the next full sync.
+**Setting Linear up at all — including “add my key” — is `tbd shortcut setup-linear`.**
+Run it rather than improvising; it detects which case applies and walks the user through
+only that case.
+
+The mental model it encodes: **config is shared, credentials are personal.** The
+`integrations` block in `.tbd/config.yml` (team, project, policy) is committed, so a
+teammate who clones already has it; `LINEAR_API_KEY` lives in the environment or a
+**gitignored** `.env` and is never committed.
+So a user joining a repo whose team already syncs needs *only* a key—never a config
+edit, and never `sync --push` (their links arrived with the clone; a full `sync` is the
+correct first command).
+Run `status` first in every case.
+Full details: the External Tracker Integrations section of `tbd docs`. Bulk runs over 20
+creates / 40 updates refuse without `--yes`. Never echo credentials into output or
+commits.
+`--pull` never replays or performs provider writes; deferred claims and conflict
+notices remain journaled until the next full sync.
 Link/inbound creation refuse a remote `tbd://bead/…` claim unless `--force` is explicit
 and the old claim was verified stale.
 Configured `project` scopes both creates and automatic inbound scans; an explicit


### PR DESCRIPTION
## Summary

**Stacked on #212** (base is `codex/linear-managed-block-markers`, so this diff shows
only the docs commit). Retarget to `main` once #212 merges.

Setting Linear up had no guided path. The manual's agent flow covered only first-time
repository setup, so the common team case had no coverage at all: joining a repository
that already syncs, where the committed `integrations` block arrives with the clone and
only a personal API key is missing. The command that case would have reached for
(`sync --push`) is the outbound-only mirror, which projects local values over the
tracker with no three-way reconcile.

- **New `tbd shortcut setup-linear`.** Reads `tbd integration status` and branches on
  four cases — nothing configured, configured-but-no-credential (the joining case),
  already working, deliberately disabled — then walks only that case.
- **Makes the underlying split explicit:** configuration is committed and shared,
  credentials are personal and never committed. That is what makes the joining case
  obvious instead of something each user re-derives.
- **Joiners are directed to a full `sync`, not `--push`,** and told not to touch
  `team_key` / `project` when teammates are already syncing.
- **`.env` is checked for gitignore *before* a key is written.** `integration status`
  reports `✓ .env: not present`, which reads as "all good" but says nothing about
  whether creating one is safe — today you learn otherwise only after the key is on
  disk. Filed as `tbd-sjta` to fix in the status check itself.

## Changes

| File | Change |
| --- | --- |
| `shortcuts/standard/setup-linear.md` | New shortcut |
| `tbd-docs.md` | Agent flow restructured around the three cases; joining walkthrough; pre-write `.env` check |
| `shortcuts/system/skill-baseline.md` | Route "set up Linear" / "add my Linear key" to the shortcut; replace the inlined setup recipe with the shared/personal model |
| `shortcuts/standard/welcome-user.md` | Surface Linear when status shows config without a credential |
| `skills/tbd/SKILL.md`, `.claude/`, `.agents/` | Regenerated installed skill surfaces |
| `.tbd/config.yml` | One line: register the new shortcut in the docs-cache manifest |

## Review of #212

This branch came out of a full review of #212 and the wider integration, published at
https://github.com/jlevy/tbd/pull/212#pullrequestreview-4931891999. Two findings there
are worth carrying into release planning, and neither is fixed here:

- **`tbd-8raq` (blocker for release).** The `max_nesting` exemption in `mirror.ts:202`
  turns a clean skip into a permanent hard failure: a linked bead past `max_nesting`
  whose selected ancestor is skipped makes `applyMirror` throw
  `parent <id> was not mirrored` on every run, and `assertIntegrationReportsHealthy`
  promotes that to a failing `tbd sync --push`. Reproduced with a probe test.
- **`tbd-dqiq`.** `--push` and full `sync` are two different engines behind one flag
  vocabulary — `runSync` has no outbound-only mode. The doc half of the mitigation is
  in this PR; consolidating the engines is the real fix.

Also filed: `tbd-bexc`, `tbd-fqf4`, `tbd-dhfm`, `tbd-sjta`, `tbd-bhv5`, `tbd-nfjq`,
`tbd-dj3t`.

## Validation

- `pnpm run ci`: format, lint, typecheck, build, and 134 test files / 1,973 tests pass
- Pre-commit and pre-push hooks passed
- `tbd shortcut setup-linear` loads from the local build and appears in
  `tbd shortcut --list`; skill surfaces regenerated from the formatted sources

Docs only — no source changes, so no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1xMRdzLmHaY2RFFoG2Pgt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and shortcut registration only; no CLI or sync behavior changes.
> 
> **Overview**
> Introduces **`tbd shortcut setup-linear`** as the single guided path for connecting a repo to Linear or fixing a broken sync. The new shortcut branches on `tbd integration status` (first-time setup, joining an already-configured repo, already working, or disabled) and covers credential safety (verify `.env` is gitignored before writing a key), staged first push for greenfield repos, and **full `integration sync` for joiners** instead of `sync --push`.
> 
> Agent-facing docs stop inlining manual config/key recipes. **Skill baselines** and installed **SKILL.md** surfaces gain an **External Trackers** routing table and point Linear setup at the shortcut, emphasizing that **integration config is committed and shared** while **`LINEAR_API_KEY` is personal**. **`tbd-docs.md`** restructures the agent Linear section around those cases; **`welcome-user`** surfaces setup when status shows config without a credential. **`.tbd/config.yml`** registers the shortcut in the docs cache manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7607469d65cd357e05682966afbd3a1cef2137d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->