### PR TITLE
chore: require Node.js 22.12 and harden release audits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,20 @@ permissions:
 
 jobs:
   test:
-    name: Test (${{ matrix.os }})
+    name: Test (${{ matrix.os }}, Node ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            node: 22.12.0
+          - os: ubuntu-latest
+            node: 24
+          - os: macos-latest
+            node: 24
+          - os: windows-latest
+            node: 24
     steps:
       - uses: actions/checkout@v6
 
@@ -24,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ matrix.node }}
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
@@ -57,6 +65,8 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+
+      - run: pnpm audit --prod
 
       # uv provides uvx for the pinned flowmark-rs Markdown check in format:check.
       # Full tag: setup-uv publishes no floating v8 major tag.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - run: pnpm audit --prod
+
       - run: pnpm build
 
       - run: pnpm publint

--- a/README.md
+++ b/README.md
@@ -312,7 +312,8 @@ tbd guidelines --add=<url> --name=my-team-rules
 ## Installation and Setup
 
 **Requirements:**
-- Node.js 22.12+
+
+- Node.js 22.12.0 or newer
 - Git 2.42+ (for orphan worktree support)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ tbd guidelines --add=<url> --name=my-team-rules
 ## Installation and Setup
 
 **Requirements:**
-- Node.js 20.12+
+- Node.js 22.12+
 - Git 2.42+ (for orphan worktree support)
 
 ```bash

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@ Development setup and workflows for `get-tbd` (the tbd CLI).
 
 ## Prerequisites
 
-- Node.js >= 22.12.0
+- Node.js 22.12.0 or newer
 - pnpm (will be installed automatically via corepack)
 
 ## Setup

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@ Development setup and workflows for `get-tbd` (the tbd CLI).
 
 ## Prerequisites
 
-- Node.js >= 20
+- Node.js >= 22.12.0
 - pnpm (will be installed automatically via corepack)
 
 ## Setup

--- a/docs/project/specs/active/plan-2026-08-10-external-tracker-integrations.md
+++ b/docs/project/specs/active/plan-2026-08-10-external-tracker-integrations.md
@@ -265,19 +265,17 @@ and the existing dependency set.
 
 | Need | Choice | Rationale |
 | --- | --- | --- |
-| `.env` parsing | **Node built-in `util.parseEnv`** | Node’s own dotenv-compatible parser: handles quotes, comments, `export` prefixes, and multiline values. It is the “library” answer without the dependency. Available since Node 20.12 / 21.7; see engines note below |
-| HTTP | **Native `fetch`** (Node ≥ 18) | Already the platform baseline; no undici/axios needed |
+| `.env` parsing | **Node built-in `util.parseEnv`** | Node’s own dotenv-compatible parser: handles quotes, comments, `export` prefixes, and multiline values. It is the “library” answer without the dependency and is available throughout tbd’s supported Node range |
+| HTTP | **Native `fetch`** | Available throughout tbd’s supported Node range; no undici/axios needed |
 | GraphQL | **Template strings over `fetch`** | The pilot needs ~6 queries and ~5 mutations. `@linear/sdk` brings typed models and pagination helpers but adds a dependency and its own release cadence for a surface this small. Revisit only if the query surface grows substantially |
 | Response/state validation | **`zod`** (already a dependency) | Same tool used for every other schema in the codebase |
 | Bridge-state files | **`yaml`** (already a dependency) | Same serializer as config and mappings |
 | GitHub REST | **Native `fetch`**, token via `gh auth token` fallback | Issues + PR linking is a handful of endpoints; Octokit is not warranted |
 | Secret masking, ref parsing, managed block | **Internal** (~30 lines each) | Trivial, and each has project-specific behavior worth owning |
 
-**Engines note:** `util.parseEnv` requires Node ≥ 20.12. Current engines say `>=20`.
-Bump `engines.node` to `>=20.12` in the same PR (a patch-level floor raise within the
-supported major; Node 20.12 shipped 2024-03). The alternative, shipping a fallback
-parser for 20.0–20.11, doubles the test surface to support Node versions nobody should
-be running.
+**Engines note:** tbd requires Node ≥ 22.12.0. This maintained runtime floor supports
+`util.parseEnv` directly, without a custom dotenv parser or a compatibility-only dynamic
+import path.
 
 What is deliberately **not** internal: quoting/escaping rules of dotenv files (use
 `util.parseEnv`), markdown rendering (not needed), and OAuth flows (out of scope; API
@@ -1331,7 +1329,8 @@ Shipped in Phase 1:
 - Commands: `tbd integration status` and `tbd integration sync --push`, with the bulk
   guard’s `--yes`.
 - `tbd doctor`: two non-fatal checks (integrations, parent hierarchy).
-- `engines.node`: `>=20` → `>=20.12` (for `util.parseEnv`).
+- `engines.node`: `>=22.12.0`; the bootstrap rejects older runtimes with an actionable
+  error before loading the CLI bundle.
 
 Phase 2 adds:
 
@@ -1413,8 +1412,8 @@ Validated live against the `tbd` Linear project: staged rollout (3 → 13 → 82
 bulk-guard refusal exercised, and a team move (0 creates, 80 updates, all keys refreshed
 `FIN-*` → `TBD-*`).
 
-- [x] `lib/env-file.ts` (`util.parseEnv`, no `process.env` mutation) + engines bump;
-  gitignore enforcement in status/doctor.
+- [x] `lib/env-file.ts` (`util.parseEnv`, no `process.env` mutation); gitignore
+  enforcement in status/doctor.
 - [x] `integrations/core/credentials.ts` with masking; secret-hygiene tests.
 - [x] `IntegrationsConfigSchema`; `integrations/core/registry.ts`.
 - [x] `cli/commands/integration.ts` on `BaseCommand`; `status` with probes, remedies,
@@ -1583,8 +1582,10 @@ Phase 2 extends the same structure:
 
 ## Rollout Plan
 
-1. ✅ Phase 1 landed with **no format bump** (links ride `extensions`) and the engines
-   bump. No behavior change for repositories without an `integrations` block.
+1. ✅ Phase 1 landed with **no format bump** (links ride `extensions`) and a Node
+   `>=22.12.0` runtime floor.
+   On supported runtimes, repositories without an `integrations` block remain inert and
+   offline.
 2. ✅ This repo is the pilot: 84 issues mirrored into the `tbd` project on the `TBD`
    team, through a staged rollout and a team move.
    Ongoing: keep mirroring as the epic set evolves.

--- a/docs/project/specs/active/valid-2026-08-09-bead-watch-release.md
+++ b/docs/project/specs/active/valid-2026-08-09-bead-watch-release.md
@@ -142,8 +142,8 @@ The exact procedure and evidence checklist live in
 
 - [ ] Repeat the passing isolated-prefix tarball smoke at the exact release-tag SHA and
   record the artifact checksum.
-- [ ] Run that exact packed artifact under the supported Node.js 20 runtime floor; CI
-  covers the built candidate under Node.js 24.
+- [ ] Run that exact packed artifact under the supported Node.js 22.12.0 runtime floor;
+  CI covers the built candidate under Node.js 22.12.0 and Node.js 24 on Linux.
 - [ ] Run one selected wake over a disposable private GitHub remote using the same
   SSH/HTTPS credential path as the intended operator.
 - [ ] Confirm the remote-tracking ref, local sync ref, `FETCH_HEAD`, caller worktree,

--- a/package.json
+++ b/package.json
@@ -4,9 +4,13 @@
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "engines": {
-    "node": ">=20.12"
+    "node": ">=22.12.0"
   },
   "pnpm": {
+    "overrides": {
+      "js-yaml@3": "3.15.1",
+      "js-yaml@4": "4.3.1"
+    },
     "onlyBuiltDependencies": [
       "esbuild",
       "lefthook"

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -49,8 +49,16 @@
   additive and mixed-version safe.
 - `tbd doctor` gains hierarchy and integration checks.
 
+### Changed
+
+- Node.js 22.12.0 is now the minimum supported runtime.
+  The CLI bootstrap reports an actionable version error before loading the application
+  on older Node releases, and CI exercises the minimum version on Linux.
+
 ### Fixed
 
+- Pin transitive `js-yaml` 3.x and 4.x to the patched 3.15.1 and 4.3.1 releases,
+  resolving CVE-2026-59870’s quadratic `!!omap` parsing path.
 - Every display prefix accepted by `init` and `setup --force` (including digits, dots,
   and underscores) is now parsed by issue and integration commands.
   Exact imported short IDs win before prefix stripping, preserving short IDs that

--- a/packages/tbd/docs/shortcuts/system/skill-minimal.md
+++ b/packages/tbd/docs/shortcuts/system/skill-minimal.md
@@ -6,7 +6,7 @@ description: >-
   best practices, planning features, setting up a Linear/external tracker integration
   or personal Linear API key, or viewing beads in a live browser.
 license: MIT
-compatibility: Requires Node.js 20.12+ and git. Install CLI first: npm install -g get-tbd@latest
+compatibility: Requires Node.js 22.12.0+ and git. Install CLI first: npm install -g get-tbd@latest
 metadata:
   author: jlevy
   repository: https://github.com/jlevy/tbd

--- a/packages/tbd/docs/shortcuts/system/skill-minimal.md
+++ b/packages/tbd/docs/shortcuts/system/skill-minimal.md
@@ -6,7 +6,7 @@ description: >-
   best practices, planning features, setting up a Linear/external tracker integration
   or personal Linear API key, or viewing beads in a live browser.
 license: MIT
-compatibility: Requires Node.js 22.12.0+ and git. Install CLI first: npm install -g get-tbd@latest
+compatibility: Requires Node.js 22.12.0 or newer and git. Install CLI first: npm install -g get-tbd@latest
 metadata:
   author: jlevy
   repository: https://github.com/jlevy/tbd

--- a/packages/tbd/docs/tbd-docs.md
+++ b/packages/tbd/docs/tbd-docs.md
@@ -74,7 +74,7 @@ but these map to unique ULID-based internal IDs for reliable sorting and storage
 
 **Requirements:**
 
-- Node.js 22.12+
+- Node.js 22.12.0 or newer
 - Git 2.42+ (for orphan worktree support)
 
 ```bash

--- a/packages/tbd/docs/tbd-docs.md
+++ b/packages/tbd/docs/tbd-docs.md
@@ -74,7 +74,7 @@ but these map to unique ULID-based internal IDs for reliable sorting and storage
 
 **Requirements:**
 
-- Node.js 20.12+
+- Node.js 22.12+
 - Git 2.42+ (for orphan worktree support)
 
 ```bash

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -26,7 +26,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=20.12"
+    "node": ">=22.12.0"
   },
   "repository": {
     "type": "git",

--- a/packages/tbd/scripts/build-if-needed.mjs
+++ b/packages/tbd/scripts/build-if-needed.mjs
@@ -36,16 +36,25 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const packageDir = dirname(__dirname);
+const repoDir = dirname(dirname(packageDir));
 
 const BUILD_TARGET = join(packageDir, 'dist', 'bin.mjs');
-const SOURCE_DIRS = [join(packageDir, 'src')];
-const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts', '.js', '.mjs', '.cjs'];
+// The package build bundles code and copies/composes documentation. Both kinds of
+// input must invalidate dist; otherwise local tests can read stale bundled docs while
+// a clean CI checkout rebuilds them and observes different content.
+const SOURCE_DIRS = [
+  join(packageDir, 'src'),
+  join(packageDir, 'scripts'),
+  join(packageDir, 'docs'),
+];
+const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts', '.js', '.mjs', '.cjs', '.md'];
 
 // Config files that affect build output
 const CONFIG_FILES = [
   join(packageDir, 'tsdown.config.ts'),
   join(packageDir, 'tsconfig.json'),
   join(packageDir, 'package.json'),
+  join(repoDir, 'README.md'),
 ];
 
 /**

--- a/packages/tbd/src/cli/bin-bootstrap.cjs
+++ b/packages/tbd/src/cli/bin-bootstrap.cjs
@@ -1,4 +1,4 @@
-/* global __dirname */
+/* global __dirname, console, process */
 /**
  * CLI bootstrap entry point (CommonJS).
  *
@@ -14,19 +14,51 @@
 const path = require('node:path');
 const { pathToFileURL } = require('node:url');
 
-// Enable compile cache BEFORE loading any ESM modules.
-// This caches compiled bytecode on disk for faster subsequent runs.
-// Available in Node 22.8.0+, gracefully ignored in older versions.
-try {
-  const mod = require('node:module');
-  if (typeof mod.enableCompileCache === 'function') {
-    mod.enableCompileCache();
+const MINIMUM_NODE_VERSION = '22.12.0';
+const MINIMUM_NODE_PARTS = MINIMUM_NODE_VERSION.split('.').map(Number);
+
+/** Whether a Node version string satisfies the CLI's runtime floor. */
+function supportsNodeVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)([-+][0-9A-Za-z.-]+)?$/u.exec(version);
+  if (match === null) {
+    return false;
   }
-} catch {
-  // Silently ignore - caching is an optimization, not required.
+
+  const current = match.slice(1, 4).map(Number);
+  for (let index = 0; index < MINIMUM_NODE_PARTS.length; index += 1) {
+    if (current[index] !== MINIMUM_NODE_PARTS[index]) {
+      return current[index] > MINIMUM_NODE_PARTS[index];
+    }
+  }
+  return !match[4]?.startsWith('-');
 }
 
-// Load the bundled CLI binary (ESM with all deps bundled for fast startup).
-// bin.mjs runs runCli() as a side effect when imported.
-const binPath = path.join(__dirname, 'bin.mjs');
-import(pathToFileURL(binPath).href);
+function startCli() {
+  if (!supportsNodeVersion(process.versions.node)) {
+    console.error(
+      `tbd requires Node.js ${MINIMUM_NODE_VERSION} or newer; current runtime is ${process.versions.node}. Upgrade Node.js before running tbd.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  // Enable compile cache BEFORE loading any ESM modules.
+  // This caches compiled bytecode on disk for faster subsequent runs.
+  try {
+    const mod = require('node:module');
+    mod.enableCompileCache();
+  } catch {
+    // Caching is an optimization, not required.
+  }
+
+  // Load the bundled CLI binary (ESM with all deps bundled for fast startup).
+  // bin.mjs runs runCli() as a side effect when imported.
+  const binPath = path.join(__dirname, 'bin.mjs');
+  import(pathToFileURL(binPath).href);
+}
+
+if (require.main === module) {
+  startCli();
+}
+
+module.exports = { MINIMUM_NODE_VERSION, supportsNodeVersion };

--- a/packages/tbd/tests/integration-files.test.ts
+++ b/packages/tbd/tests/integration-files.test.ts
@@ -105,13 +105,21 @@ describe('integration file formats', () => {
     });
 
     it('keeps the minimal skill runtime requirement aligned with the package', async () => {
-      const content = await readFile(join(shortcutsSystemDir, 'skill-minimal.md'), 'utf-8');
+      const sourcePath = join(__dirname, '..', 'docs', 'shortcuts', 'system', 'skill-minimal.md');
+      const bundledPath = join(shortcutsSystemDir, 'skill-minimal.md');
+      const [sourceContent, bundledContent] = await Promise.all([
+        readFile(sourcePath, 'utf-8'),
+        readFile(bundledPath, 'utf-8'),
+      ]);
       const packageJson = JSON.parse(
         await readFile(join(__dirname, '..', 'package.json'), 'utf-8'),
       ) as { engines: { node: string } };
       const minimumNode = packageJson.engines.node.replace(/^>=/u, '');
+      const requirement = `Requires Node.js ${minimumNode} or newer and git`;
 
-      expect(content).toContain(`Requires Node.js ${minimumNode}+ and git`);
+      expect(sourceContent).toContain(requirement);
+      expect(bundledContent).toContain(requirement);
+      expect(bundledContent).toBe(sourceContent);
     });
 
     it('includes the natural-language browser request in installed onboarding', async () => {

--- a/packages/tbd/tests/node-version.test.ts
+++ b/packages/tbd/tests/node-version.test.ts
@@ -1,0 +1,41 @@
+/** Runtime-floor tests for the CommonJS CLI bootstrap. */
+
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { MINIMUM_NODE_VERSION, supportsNodeVersion } = require('../src/cli/bin-bootstrap.cjs') as {
+  MINIMUM_NODE_VERSION: string;
+  supportsNodeVersion: (version: string) => boolean;
+};
+
+describe('CLI Node.js runtime floor', () => {
+  it('matches the package engine and accepts supported versions', async () => {
+    const [packageJsonText, workspacePackageJsonText] = await Promise.all([
+      readFile(new URL('../package.json', import.meta.url), 'utf8'),
+      readFile(new URL('../../../package.json', import.meta.url), 'utf8'),
+    ]);
+    const packageJson = JSON.parse(packageJsonText) as { engines: { node: string } };
+    const workspacePackageJson = JSON.parse(workspacePackageJsonText) as {
+      engines: { node: string };
+    };
+
+    expect(MINIMUM_NODE_VERSION).toBe('22.12.0');
+    expect(packageJson.engines.node).toBe(`>=${MINIMUM_NODE_VERSION}`);
+    expect(workspacePackageJson.engines.node).toBe(packageJson.engines.node);
+    expect(supportsNodeVersion('22.12.0')).toBe(true);
+    expect(supportsNodeVersion('22.12.0+local')).toBe(true);
+    expect(supportsNodeVersion('22.12.1')).toBe(true);
+    expect(supportsNodeVersion('24.0.0')).toBe(true);
+    expect(supportsNodeVersion('26.0.0')).toBe(true);
+  });
+
+  it('rejects older and malformed versions', () => {
+    expect(supportsNodeVersion('20.19.0')).toBe(false);
+    expect(supportsNodeVersion('22.11.0')).toBe(false);
+    expect(supportsNodeVersion('22.12.0-rc.1')).toBe(false);
+    expect(supportsNodeVersion('not-a-version')).toBe(false);
+  });
+});

--- a/packages/tbd/tsdown.config.ts
+++ b/packages/tbd/tsdown.config.ts
@@ -22,7 +22,7 @@ const pinnedVersion = (
 const commonOptions = {
   format: ['esm'] as 'esm'[],
   platform: 'node' as const,
-  target: 'node20' as const,
+  target: 'node22' as const,
   sourcemap: true,
   dts: true,
   define: {
@@ -66,7 +66,7 @@ export default defineConfig([
   {
     format: ['cjs'] as 'cjs'[],
     platform: 'node' as const,
-    target: 'node20' as const,
+    target: 'node22' as const,
     sourcemap: true,
     dts: false,
     entry: { 'bin-bootstrap': 'src/cli/bin-bootstrap.cjs' },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  js-yaml@3: 3.15.1
+  js-yaml@4: 4.3.1
+
 importers:
 
   .:
@@ -1246,12 +1250,12 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -2099,7 +2103,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2872,7 +2876,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -2936,12 +2940,12 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/tests/qa/watch-infrastructure-release.qa.md
+++ b/tests/qa/watch-infrastructure-release.qa.md
@@ -62,7 +62,7 @@ platform and any optional Linear sandbox experiment.
 
 ## Prerequisites
 
-- Node.js 20 or newer, pnpm 10, and Git 2.42 or newer.
+- Node.js 22.12.0 or newer, pnpm 10, and Git 2.42 or newer.
 - A clean checkout of the release commit.
 - For Phase 2, a disposable private GitHub repository and credentials that match the
   intended operator environment.
@@ -378,7 +378,7 @@ CI is the automated floor; this phase samples the actual artifact and shell inte
 | Item | Check | Status |
 | --- | --- | --- |
 | Cross-platform built candidate | CI runs the full disposable-topology smoke on macOS, Ubuntu, and Windows. | Automated |
-| Minimum runtime | Exact packed artifact passes under the supported Node.js 20 floor. | ⏳ |
+| Minimum runtime | Exact packed artifact passes under the supported Node.js 22.12.0 floor. | ⏳ |
 | macOS | Packed smoke passes; unattended recipe parses and runs under system Bash 3.2. | ⏳ |
 | Ubuntu | Packed smoke and one real-remote wake pass. | ⏳ |
 | Windows | Packed smoke passes through PowerShell/Git; `.cmd` shim and CRLF docs extraction remain valid. | ⏳ |


### PR DESCRIPTION
## Summary

- require Node.js 22.12.0 or newer and fail before ESM startup with an actionable version message
- align package engines, build target, documentation, changelog, and CI with the new baseline
- test Ubuntu at the exact Node 22.12.0 floor plus Node 24 on Ubuntu, macOS, and Windows
- pin patched js-yaml 3.15.1 and 4.3.1 resolutions and enforce production audits in CI and releases
- keep Linear completely opt-in: ordinary setup and commands remain inert when no integration is configured

## Validation

- pnpm run ci: 1,984 tests passed
- pnpm release:verify
- pnpm check:package-age
- pnpm audit --prod: no known vulnerabilities
- pnpm --filter get-tbd qa:web-package
- publint: all good
- packed npm consumer: clean production audit, js-yaml 3.15.1 resolved through gray-matter, CLI and fresh-repository integration status smoke passed
- Node 20.20.2 packed-CLI smoke exits with the intended Node 22.12 upgrade message

## Supply-chain exception

The high-severity GHSA-5p4m-2wfm-xmqj / CVE-2026-59870 advisory affects production through gray-matter. Patched js-yaml 3.15.1 and 4.3.1 were about 17 hours short of the normal 14-day cool-off when reviewed. We made a narrow exception after verifying the same long-standing maintainer and npm signing key, npm gitHeads matching upstream release commits, focused source/test/dist changes with no install scripts or dependency additions, and the official advisory naming these exact versions as patched.

Exception approved and reviewed by Joshua Levy (github.com/jlevy). Full development-only audit findings remain tracked in tbd-gx3a; the production graph is clean.

Refs: tbd-laoa, tbd-6gy0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking runtime change drops Node 20.x support for all CLI users; supply-chain pins and audit gates are low-risk but the engines bump affects every install and CI consumer.
> 
> **Overview**
> **Raises the supported Node.js floor to 22.12.0** across workspace and package `engines`, bundled build targets (`node22`), and user-facing docs. The CommonJS **`bin-bootstrap.cjs`** now rejects older runtimes with a clear error **before** loading the ESM CLI, with **`node-version.test.ts`** keeping the bootstrap floor aligned with `package.json`.
> 
> **CI and release hardening:** the test matrix runs **Node 22.12.0 on Ubuntu** (plus Node 24 on Linux/macOS/Windows), and **`pnpm audit --prod`** runs in the coverage and release workflows. **pnpm overrides** pin transitive **`js-yaml`** 3.x/4.x to patched releases for CVE-2026-59870.
> 
> **Build correctness:** **`build-if-needed.mjs`** treats `docs/`, `scripts/`, root `README.md`, and `.md` sources as build inputs so local `dist` cannot serve stale bundled documentation. The minimal skill test asserts source and bundled copies stay in sync with the new Node requirement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f92bfa5b3dd5d39d1ddf08a2902f4da7890e119e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->