### PR TITLE
feat: gate the integrations config behind format f07 and release v0.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
+      - name: Verify release metadata
+        run: pnpm exec tsx packages/tbd/scripts/verify-release-metadata.ts "${GITHUB_REF_NAME}"
+
       # Resolve the release body BEFORE publishing: if the wrapper or changelog path
       # ever fails, fail here rather than after the package is already on npm.
       - name: Extract changelog for this version

--- a/docs/project/specs/active/plan-2026-07-19-bead-watch-and-external-sync.md
+++ b/docs/project/specs/active/plan-2026-07-19-bead-watch-and-external-sync.md
@@ -332,6 +332,14 @@ Detailed provider designs are separate specs, written and revised against these 
    working agent can run mid-session, a cron entry, or a CI workflow.
    Agents and repos that do not use integrations see no change to any tbd workflow.
 
+> **Status note (2026-08-13):** The next constraint records the experiment-phase
+> boundary. The successful tracker pilot was later promoted by
+> [External Tracker Integrations](plan-2026-08-10-external-tracker-integrations.md),
+> which deliberately adds an `integrations` block behind format f07 and makes the
+> relevant config schemas passthrough.
+> It supersedes this constraint for the promoted implementation; the bead-side
+> `extensions` rule remains in force.
+
 2. **Integration experiments cannot touch `IssueSchema`, `ConfigSchema`, or
    `tbd_format`.** Both schemas parse in Zod strip mode, so an older CLI silently
    destroys unknown fields when it rewrites a file — which is why any new field forces a

--- a/docs/project/specs/active/plan-2026-08-10-external-tracker-integrations.md
+++ b/docs/project/specs/active/plan-2026-08-10-external-tracker-integrations.md
@@ -1314,16 +1314,19 @@ per-row duplicated SVG paths are required.
 
 Shipped in Phase 1:
 
-- `IssueSchema`: **unchanged**. The link lives in the existing `extensions` namespace,
-  so there is no new field and **no `tbd_format` bump**.
-- `ConfigSchema`: the optional `integrations` block.
-  `ConfigSchema` has no `extensions` escape hatch, so an older CLI rewriting config
-  drops this block — **this happened twice during the pilot**, both times restored from
-  git history. The loss is recoverable (`config.yml` is tracked) but silent at loss time
-  and loud only at use time, so Phase 2’s doctor additions include a tripwire: warn when
-  beads carry provider links but no matching integration is configured.
-  Releasing Phase 1 closes the gap for this key (it becomes known to the schema); a
-  general `ConfigSchema` extensions namespace is tracked separately.
+- `IssueSchema`: **unchanged**, and the bead side needs no format bump.
+  The link lives in the existing `extensions` namespace, so there is no new field and
+  any tbd version round-trips a linked bead intact.
+- `ConfigSchema`: the optional `integrations` block, gated by **`tbd_format` f07**
+  (0.6.0). The config side has no `extensions` escape hatch, so a pre-f07 CLI rewriting
+  config drops this block — **this happened three times during the pilot**, each time
+  restored from git history.
+  Those clients cannot be fixed retroactively, so f07 makes them fail closed instead of
+  stripping. From f07 on, `ConfigSchema` and the `integrations` block are passthrough, so
+  a later additive config key needs no further bump.
+  The loss was silent at loss time and loud only at use time, so `doctor` reports it two
+  ways: a block that is committed but missing locally (direct), and beads carrying
+  provider links with no configured integration (the downstream symptom).
 - `FIELD_STRATEGIES`: `extensions` changed from `'lww'` to per-namespace three-way merge
   with absence-as-value.
 - Commands: `tbd integration status` and `tbd integration sync --push`, with the bulk
@@ -1582,10 +1585,13 @@ Phase 2 extends the same structure:
 
 ## Rollout Plan
 
-1. ✅ Phase 1 landed with **no format bump** (links ride `extensions`) and a Node
+1. ✅ Phase 1 landed with no *bead* format bump (links ride `extensions`) and a Node
    `>=22.12.0` runtime floor.
    On supported runtimes, repositories without an `integrations` block remain inert and
-   offline.
+   offline. The **config** side ships in 0.6.0 behind **`tbd_format` f07**, which stops
+   pre-0.6.0 clients from stripping the `integrations` block.
+   Sequencing: publish 0.6.0 to npm *before* stamping this repository, since the stamp
+   locks out any session still installing the previous `get-tbd@latest`.
 2. ✅ This repo is the pilot: 84 issues mirrored into the `tbd` project on the `TBD`
    team, through a staged rollout and a team move.
    Ongoing: keep mirroring as the epic set evolves.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -205,6 +205,22 @@ No Changesets—bump by hand on a `claude/release-vX.X.X` branch:
 The notes you write here ARE the release notes (Step 5); there is no separate changeset
 summary to keep in sync.
 
+**If the release bumps `tbd_format`** (`CURRENT_FORMAT` in
+[`tbd-format.ts`](../packages/tbd/src/lib/tbd-format.ts) differs from the last release):
+
+- Lead the CHANGELOG section with an upgrade note: every machine working in a repository
+  must upgrade, because older clients fail closed once a repository is stamped.
+- **Do not commit a stamped `.tbd/config.yml` to this repository before the release is
+  on npm.** Running the dev build stamps it as a side effect (the test suite runs
+  `setup --auto` here), so check `git status` and revert `.tbd/config.yml`, `AGENTS.md`,
+  `.claude/`, `.agents/`, and `.codex/` before committing.
+  Stamping early locks out every agent session that installs `get-tbd@latest` at
+  startup, and the upgrade it tells them to run does not exist yet.
+- After the release publishes, upgrade and run `tbd setup --auto` here, then commit that
+  stamp as its own follow-up change.
+
+See [tbd-format-versioning.md](tbd-format-versioning.md) for the full contract.
+
 ### Step 5: Write Release Notes
 
 Write the `## X.X.X` CHANGELOG section following

--- a/docs/tbd-format-versioning.md
+++ b/docs/tbd-format-versioning.md
@@ -23,6 +23,33 @@ SINGLE SOURCE OF TRUTH: `CURRENT_FORMAT`, `FORMAT_HISTORY`, the per-step migrati
 `formatUpgradeMessage` all live there.
 When bumping `fNN` → `fNN+1` follow the rules below.
 
+## When a Config Schema Change Needs a Bump
+
+Adding, removing, or changing the meaning of a config field is a format change.
+Bump for it, and bump *unconditionally* in the release that ships the field, never
+conditionally on whether a repository uses the feature: `tbd_format` is what tells an
+older client whether it may rewrite this config at all, and a config can acquire the new
+block by hand (or by a teammate’s commit) at any time.
+A conditional stamp leaves exactly the window the gate exists to close.
+
+As of `f07` `ConfigSchema` preserves unknown top-level keys, so a *purely additive* key
+introduced after f07 survives a round trip through any f07-or-later client and does not
+need its own bump. That does not apply to clients released before the key existed and
+before f07: they parse in strip mode and drop what they do not know.
+The `integrations` block was lost that way three times during the Linear pilot, which is
+what f07 exists to stop.
+
+Bump when: existing field meaning changes, a field is removed or renamed, or losing the
+new field to a pre-f07 client would be damaging.
+Do not bump for: additive keys once every client in use is f07 or later.
+
+**Release sequencing.** Never commit a new format stamp to a repository before the
+client that supports it is published.
+The stamp locks out every unpublished-from client immediately, including agent sessions
+that install `get-tbd@latest` at startup, and the upgrade message it prints cannot be
+satisfied until the release is on npm.
+Land the bump, publish, then let repositories stamp.
+
 ## Old Client in a Newer Repo: Fail Closed, Never Silently Downgrade
 
 An older `tbd` (built with a smaller `CURRENT_FORMAT`) that encounters either marker

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### Upgrading: repository format f07
 
-This release bumps the repository format to `f07`. The first `tbd` command after
-upgrading stamps `.tbd/config.yml`; **commit that diff**, and everyone who works in the
-repository needs tbd 0.6.0 or later.
-Older versions then refuse the repository with an upgrade message instead of running.
+This release bumps the repository format to `f07`. After upgrading, run
+`tbd setup --auto`; it stamps `.tbd/config.yml` and refreshes the managed agent
+surfaces. **Commit that diff**, and everyone who works in the repository needs tbd 0.6.0
+or later. Older versions then refuse the repository with an upgrade message instead of
+running.
 
 That gate is the point.
 `integrations` is a new top-level config key, and every tbd released before 0.6.0 parses

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -1,6 +1,24 @@
 # get-tbd
 
-## Unreleased
+## 0.6.0
+
+### Upgrading: repository format f07
+
+This release bumps the repository format to `f07`. The first `tbd` command after
+upgrading stamps `.tbd/config.yml`; **commit that diff**, and everyone who works in the
+repository needs tbd 0.6.0 or later.
+Older versions then refuse the repository with an upgrade message instead of running.
+
+That gate is the point.
+`integrations` is a new top-level config key, and every tbd released before 0.6.0 parses
+config in strip mode: it silently drops the block the first time it rewrites
+`config.yml`, which happened three times during the Linear pilot.
+Those versions cannot be fixed retroactively, so f07 stops them at the door.
+
+From f07 onward tbd preserves config keys it does not recognize, at the top level and
+inside `integrations`, so a later additive config block needs no further format bump.
+Issue data is untouched by the migration, and the upgrade is revertible — see “Aborting
+a Format Upgrade” in `tbd docs manual`.
 
 ### Added
 
@@ -21,9 +39,9 @@
   - Comments sync as append-only sequences; conflicts archive to the attic and post
     resolvable tracker comments; bulk changes over 20 creates / 40 updates require
     `--yes` and are refused non-interactively.
-  - Strictly additive: repositories without an `integrations` config block are
-    unaffected, links ride each bead’s `extensions` namespace, and there is no format
-    bump.
+  - Strictly additive at the bead level: repositories without an `integrations` config
+    block behave exactly as before, and links ride each bead’s `extensions` namespace,
+    so a bead’s link survives a write by any tbd version.
   - `tbd integration status` reports whether each provider is configured, credentialed,
     and reachable, with a remedy on every failure.
     Inert and offline when none is enabled.
@@ -41,19 +59,26 @@
     `--yes` proceeds.
   - Credentials load from the environment or a gitignored `.env`. An unignored `.env` is
     reported as an error.
-- An `integrations` config block.
-  **No format bump and no schema change**: the bead’s link is stored in the existing
-  `extensions.<provider>` namespace, which an older tbd round-trips untouched.
-  A top-level field would have been silently stripped on the first write from an older
-  CLI, which is what forces a format gate; using the namespace keeps the feature
-  additive and mixed-version safe.
-- `tbd doctor` gains hierarchy and integration checks.
+- An `integrations` config block, gated by format `f07` (see Upgrading above).
+  The bead side needs no schema change: a link lives in the existing
+  `extensions.<provider>` namespace, which any tbd round-trips untouched.
+  The config side is a new top-level key, which a pre-0.6.0 tbd would strip — hence the
+  gate.
+- `tbd doctor` gains hierarchy and integration checks, including a report when
+  `.tbd/config.yml` is missing a block that is present in the committed version — the
+  signature of an older tbd having stripped it.
+  It names the `git checkout` that restores it.
 
 ### Changed
 
+- Repository format `f07` (see Upgrading above): `ConfigSchema` now preserves unknown
+  top-level keys instead of stripping them, and the `integrations` block preserves
+  unknown providers and provider settings.
 - Node.js 22.12.0 is now the minimum supported runtime.
   The CLI bootstrap reports an actionable version error before loading the application
   on older Node releases, and CI exercises the minimum version on Linux.
+- `kind` moved into the shared issue filter, so `list`, `changes`, and `watch` evaluate
+  it identically.
 
 ### Fixed
 
@@ -116,11 +141,6 @@
   data.
 - The `engines` floor was `>=20` while `util.parseEnv` needs 20.12, so `.env` reading
   would have thrown at runtime on 20.0-20.11.
-
-### Changed
-
-- `kind` moved into the shared issue filter, so `list`, `changes`, and `watch` evaluate
-  it identically.
 
 ## 0.5.0
 

--- a/packages/tbd/docs/shortcuts/standard/setup-linear.md
+++ b/packages/tbd/docs/shortcuts/standard/setup-linear.md
@@ -88,6 +88,12 @@ It selects open epics plus anything whose `spec_path` points into `specs/active/
 right starting point for “track our specs and major work”, and roughly 10% of a typical
 repository’s beads.
 
+**Then run `tbd setup --auto` before committing.** Writing the block leaves the
+repository at whatever format it was on; setup stamps `tbd_format: f07`, which is what
+stops a teammate’s pre-0.6.0 tbd from silently stripping the block on its next config
+write. Commit the block and the stamp together, so no one ever clones the window between
+them. If setup reports a format migration, that diff is part of this change.
+
 Two optional keys worth mentioning only if the user raises the need:
 
 - `user_map: { alias: person@example.com }` — the **only** identities tbd may push as
@@ -228,7 +234,8 @@ session-end `tbd sync` keeps Linear current with no extra command.
 | `LINEAR_API_KEY not found` | No key in env or `.env` | Step 3 |
 | `.env: present and NOT gitignored` | Key is one `git add` from being committed | Add `.env` to `.gitignore` now; rotate the key if it was ever committed |
 | `reachable` fails with a valid-looking key | Key revoked, missing a required permission, or no access to that team | Re-issue under Settings > Account > Security & Access; confirm permissions and `team_key` |
-| Integration block vanished from `config.yml` | `tbd setup` was run by a tbd older than this feature | `git checkout .tbd/config.yml`, then upgrade tbd |
+| Integration block vanished from `config.yml` | A pre-0.6.0 tbd rewrote config before the repository was stamped `f07` | `git checkout .tbd/config.yml`, upgrade that machine (`npm install -g get-tbd@latest`), then `tbd setup --auto` to stamp the format |
+| A teammate reports “This repository requires a newer version of tbd” | Working as intended: their tbd predates `f07` and would strip the block | Have them upgrade: `npm install -g get-tbd@latest` |
 | Sync says `nothing to do` but Linear looks stale | The policy does not select those beads | Check `policy.outbound` against what the user expects; `--dry-run integration sync --push` lists the selected set |
 | A bead reports malformed managed-block markers | A human edited inside the `⟦tbd⟧` … `⟦/tbd⟧` region in Linear | Repair the region in Linear (one `⟦tbd⟧` and one `⟦/tbd⟧`, in that order) or delete it entirely; the next sync rewrites it |
 

--- a/packages/tbd/docs/tbd-design.md
+++ b/packages/tbd/docs/tbd-design.md
@@ -6656,8 +6656,18 @@ extensions:
     linked_at: 2026-08-10T19:34:32.065Z
 ```
 
-There is no top-level schema change or format bump.
-Older tbd versions round-trip `extensions` untouched.
+The bead side needs no schema change or format bump: `extensions` is an existing field
+whose contents are opaque, so older tbd versions round-trip a link untouched.
+The **config** side is the opposite and is why the repository format is `f07`.
+`integrations` is a new top-level config key, and every tbd released before 0.6.0 parses
+config in strip mode, so it silently drops the block the first time it rewrites
+`config.yml`—observed three times during the pilot.
+Those clients cannot be fixed retroactively, so f07 makes them fail closed with the
+upgrade message instead.
+From f07 on, `ConfigSchema` and the `integrations` block preserve unknown keys, so a
+later additive config key needs no further bump.
+`tbd doctor` reports a block that is committed but missing locally, which is the exact
+signature of a pre-f07 client having stripped it.
 The persisted payload is an allow-list; credentials, raw API responses, emails, and
 workspace metadata never enter a bead.
 Different extension namespaces merge independently.

--- a/packages/tbd/docs/tbd-design.md
+++ b/packages/tbd/docs/tbd-design.md
@@ -1674,19 +1674,27 @@ const ConfigSchema = z.object({
       index_enabled: z.boolean().default(true),
     })
     .default({}),
-});
+}).passthrough();
 ```
 
-> **Forward Compatibility Policy:** ConfigSchema uses Zod’s `strip()` mode, which
-> discards unknown fields.
-> To prevent data loss when users mix tbd versions:
+> **Forward Compatibility Policy:** As of repository format `f07`, `ConfigSchema` uses
+> Zod’s `passthrough()` mode at the top level.
+> The `integrations` block and its provider objects are passthrough too.
+> Unknown keys in those locations therefore survive an older f07-or-later client
+> rewriting `config.yml`.
 > 
-> 1. **When changing config schema (adding, removing, or modifying fields), always bump
->    the format version** (e.g., f03 → f04)
-> 2. Older tbd versions will error when they see an unknown format version
-> 3. The error tells users to upgrade: `npm install -g get-tbd@latest`
+> 1. A purely additive top-level config block, or an additive key inside an explicitly
+>    passthrough integration/provider object, does not by itself require another format
+>    bump once the repository is on f07.
+> 2. Bump the format for removals, renames, semantic changes, or additions inside a
+>    nested schema that still strips unknown keys whenever an older supported client
+>    could lose or misinterpret data.
+> 3. Pre-f07 clients still parse in strip mode.
+>    The f07 gate makes those clients fail before they can rewrite configuration, with
+>    an instruction to upgrade via `npm install -g get-tbd@latest`.
 > 
-> This ensures older versions fail fast rather than silently corrupting config.
+> This preserves future additive configuration while keeping destructive or semantic
+> changes behind an explicit, migratable compatibility gate.
 > See `tbd-format.ts` for format version history and `config.ts` for the compatibility
 > check via `isCompatibleFormat()`.
 > 

--- a/packages/tbd/docs/tbd-docs.md
+++ b/packages/tbd/docs/tbd-docs.md
@@ -1610,10 +1610,20 @@ pending, and stores neither the display name nor email in the bead or bridge.
 (`select:`, the older spelling of the policy’s outbound clause, still parses and is
 folded in.)
 
-One caveat: `tbd setup` run by a tbd version that predates this feature will drop the
-`integrations` block from `config.yml`, because config has no extensions namespace.
-The block is tracked in git, so `git checkout .tbd/config.yml` restores it, and the
-symptom is loud (the mirror stops working rather than misbehaving).
+**Mixing tbd versions.** Configuring an integration requires tbd 0.6.0 or later on every
+machine that runs tbd in the repository.
+A tbd released before 0.6.0 parses config in strip mode and silently drops the
+`integrations` block the first time it rewrites `config.yml`, so the repository format
+is stamped `f07` (see [Aborting a Format Upgrade](#aborting-a-format-upgrade)) and those
+versions now refuse to run at all rather than quietly discarding tracker configuration.
+The refusal names the upgrade command.
+From `f07` onward tbd preserves config it does not recognize, so a block added by a
+newer tbd survives an older one; that protects future additions, not versions already
+published.
+
+If a pre-0.6.0 tbd already stripped the block, it is recoverable: `config.yml` is
+tracked, so `git checkout .tbd/config.yml` restores it, and `tbd doctor` reports the
+loss by comparing the working copy against the committed version.
 
 The block above is **committed**, so it is set up once per repository and everyone who
 clones inherits it. Credentials are the opposite: `LINEAR_API_KEY` is per person and per
@@ -2056,6 +2066,7 @@ version. This is everything a format upgrade can touch:
 | Shared layout stamp | `$GIT_COMMON_DIR/tbd/layout.yml` | machine-local, not in git | the migration (re-stamp) | delete it; it regenerates from whatever the config says |
 | Writer epoch | `$GIT_COMMON_DIR/tbd/data-sync.epoch` | machine-local, not in git | every shared data writer | none; the next writer replaces it |
 | Forked docs (f05) | `docs/tbd/`, `.tbd/doc-forks/` | tracked once committed | only `tbd docs fork` | `git checkout --`/`git revert` if committed; delete if never committed |
+| Integrations config (f07) | `.tbd/config.yml` → `integrations:` | tracked | only integration setup, never the migration | `git checkout --`/`git revert`; reverting the stamp alone leaves the block intact |
 | Docs cache | `.tbd/docs/` | gitignored | doc sync (unchanged by migration) | none needed; always safe to delete and re-sync |
 | Issue data | `tbd-sync` branch and `$GIT_COMMON_DIR/tbd/data-sync-worktree/` | git branch | **never touched by migration** | none needed; the worktree re-materializes from the branch |
 
@@ -2107,6 +2118,12 @@ Notes:
 - Teammates each migrate their own machine-local stamp automatically; only the
   `.tbd/config.yml` change is shared (via your branch), so reverting that commit is the
   team-wide rollback.
+- **Aborting f07 with a tracker configured re-opens the loss it prevents.** The stamp is
+  what stops a pre-0.6.0 tbd from stripping the `integrations` block; on f06 that
+  version runs again and drops the block on its next config write.
+  If you must abort while an integration is configured, keep the block committed so
+  `git checkout .tbd/config.yml` restores it, and treat `tbd doctor`’s report of a
+  dropped block as the signal to re-upgrade.
 
 ### Performance
 

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-tbd",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Git-native issue tracking for AI agents and humans",
   "license": "MIT",
   "author": "Joshua Levy <joshua@cal.berkeley.edu> (https://github.com/jlevy)",

--- a/packages/tbd/scripts/extract-changelog.ts
+++ b/packages/tbd/scripts/extract-changelog.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env npx tsx
 /**
  * Print the GitHub Release body for a version: the matching "## X.Y.Z" section of the
- * changelog, or "Release v<version>" when there is no such section.
+ * changelog. Missing or empty sections fail closed before npm publish.
  *
  * Usage: tsx scripts/extract-changelog.ts <version> [changelog-path]
  *
@@ -12,7 +12,7 @@
 
 import { readFileSync } from 'node:fs';
 
-import { resolveReleaseBody } from '../src/utils/changelog.js';
+import { requireChangelogSection } from '../src/utils/changelog.js';
 
 const DEFAULT_CHANGELOG = 'packages/tbd/CHANGELOG.md';
 
@@ -25,7 +25,12 @@ function main(argv: string[]): void {
   }
   const changelogPath = argv[1] ?? DEFAULT_CHANGELOG;
   const changelog = readFileSync(changelogPath, 'utf-8');
-  process.stdout.write(resolveReleaseBody(changelog, version) + '\n');
+  process.stdout.write(requireChangelogSection(changelog, version) + '\n');
 }
 
-main(process.argv.slice(2));
+try {
+  main(process.argv.slice(2));
+} catch (error: unknown) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/packages/tbd/scripts/verify-release-metadata.ts
+++ b/packages/tbd/scripts/verify-release-metadata.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env npx tsx
+/**
+ * Verify that a release tag, package.json, and changelog all name the same version.
+ *
+ * Usage: tsx scripts/verify-release-metadata.ts <tag> [package-json-path] [changelog-path]
+ */
+
+import { readFileSync } from 'node:fs';
+
+import { verifyReleaseMetadata } from '../src/utils/release-metadata.js';
+
+const DEFAULT_PACKAGE_JSON = 'packages/tbd/package.json';
+const DEFAULT_CHANGELOG = 'packages/tbd/CHANGELOG.md';
+
+function readPackageVersion(packageJsonPath: string): string {
+  const parsed: unknown = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+  if (typeof parsed !== 'object' || parsed === null || !('version' in parsed)) {
+    throw new Error(`${packageJsonPath} does not contain a version`);
+  }
+  const version = (parsed as { version: unknown }).version;
+  if (typeof version !== 'string' || version.length === 0) {
+    throw new Error(`${packageJsonPath} does not contain a string version`);
+  }
+  return version;
+}
+
+function main(argv: string[]): void {
+  const tagName = argv[0];
+  if (!tagName) {
+    console.error('Usage: verify-release-metadata.ts <tag> [package-json-path] [changelog-path]');
+    process.exitCode = 2;
+    return;
+  }
+
+  const packageJsonPath = argv[1] ?? DEFAULT_PACKAGE_JSON;
+  const changelogPath = argv[2] ?? DEFAULT_CHANGELOG;
+  const packageVersion = readPackageVersion(packageJsonPath);
+  const changelog = readFileSync(changelogPath, 'utf-8');
+  const verified = verifyReleaseMetadata(tagName, packageVersion, changelog);
+  process.stdout.write(`Verified release metadata for ${verified.version}\n`);
+}
+
+try {
+  main(process.argv.slice(2));
+} catch (error: unknown) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/packages/tbd/src/cli/commands/doctor.ts
+++ b/packages/tbd/src/cli/commands/doctor.ts
@@ -87,6 +87,29 @@ import {
 } from './setup.js';
 import { withLockfile } from '../../utils/lockfile.js';
 
+/**
+ * Diagnose the one dropped top-level key that proves integration config loss.
+ * Other absent keys may be unrelated edits and must not be mislabeled as integrations.
+ */
+export function droppedIntegrationConfigFinding(
+  droppedKeys: readonly string[],
+): DiagnosticResult | null {
+  if (!droppedKeys.includes('integrations')) {
+    return null;
+  }
+
+  return {
+    name: 'Integrations',
+    status: 'warn',
+    message:
+      '.tbd/config.yml is missing `integrations`, which is present in the committed ' +
+      'version. A tbd older than f07 drops config it does not know when it rewrites the file.',
+    suggestion:
+      'Restore: git checkout .tbd/config.yml (then upgrade tbd: npm install -g get-tbd@latest). ' +
+      'If you removed it deliberately, commit the change.',
+  };
+}
+
 function managedArtifactFinding(
   name: string,
   path: string,
@@ -793,18 +816,9 @@ class DoctorHandler extends BaseCommand {
       // but missing locally was dropped, not deleted on purpose. A pre-f07 tbd
       // rewriting config.yml does this silently (three times during the pilot).
       const dropped = await droppedConfigKeys(this.cwd);
-      if (dropped.length > 0) {
-        return {
-          name: 'Integrations',
-          status: 'warn',
-          message:
-            `.tbd/config.yml is missing ${dropped.map((key) => `\`${key}\``).join(', ')} ` +
-            'present in the committed version. A tbd older than f07 drops config it does ' +
-            'not know when it rewrites the file.',
-          suggestion:
-            'Restore: git checkout .tbd/config.yml (then upgrade tbd: npm install -g get-tbd@latest). ' +
-            'If you removed it deliberately, commit the change.',
-        };
+      const droppedFinding = droppedIntegrationConfigFinding(dropped);
+      if (droppedFinding) {
+        return droppedFinding;
       }
 
       // Weaker but independent: links with no configured integration.

--- a/packages/tbd/src/cli/commands/doctor.ts
+++ b/packages/tbd/src/cli/commands/doctor.ts
@@ -15,7 +15,7 @@ import { BaseCommand } from '../lib/base-command.js';
 import { requireInit } from '../lib/errors.js';
 import { EXIT_OPERATIONAL_ERROR } from '../lib/exit-codes.js';
 import { listIssues, type InvalidIssueFile } from '../../file/storage.js';
-import { IncompatibleFormatError, readConfig } from '../../file/config.js';
+import { droppedConfigKeys, IncompatibleFormatError, readConfig } from '../../file/config.js';
 import { prepareDataSyncContext } from '../lib/data-context.js';
 import type { Config, Issue, IssueStatusType } from '../../lib/types.js';
 import {
@@ -789,9 +789,25 @@ class DoctorHandler extends BaseCommand {
    */
   private async checkIntegrations(): Promise<DiagnosticResult> {
     if (!this.config || integrationsInert(this.config)) {
-      // The config-loss tripwire: an older CLI rewriting config silently
-      // strips the integrations block (it happened three times during the
-      // pilot). Linked beads with no configured integration is the signature.
+      // The config-loss tripwire, strongest signal first: config that is committed
+      // but missing locally was dropped, not deleted on purpose. A pre-f07 tbd
+      // rewriting config.yml does this silently (three times during the pilot).
+      const dropped = await droppedConfigKeys(this.cwd);
+      if (dropped.length > 0) {
+        return {
+          name: 'Integrations',
+          status: 'warn',
+          message:
+            `.tbd/config.yml is missing ${dropped.map((key) => `\`${key}\``).join(', ')} ` +
+            'present in the committed version. A tbd older than f07 drops config it does ' +
+            'not know when it rewrites the file.',
+          suggestion:
+            'Restore: git checkout .tbd/config.yml (then upgrade tbd: npm install -g get-tbd@latest). ' +
+            'If you removed it deliberately, commit the change.',
+        };
+      }
+
+      // Weaker but independent: links with no configured integration.
       const linkedCount = this.issues.filter((issue) => {
         const extensions = issue.extensions;
         return extensions && ('linear' in extensions || 'github' in extensions);

--- a/packages/tbd/src/file/config.ts
+++ b/packages/tbd/src/file/config.ts
@@ -15,6 +15,7 @@ import { parse as parseYaml } from 'yaml';
 
 import { sortKeys, stringifyYaml } from '../utils/yaml-utils.js';
 import { now } from '../utils/time-utils.js';
+import { git } from './git.js';
 import type { Config, LocalState } from '../lib/types.js';
 import {
   ConfigSchema,
@@ -291,6 +292,60 @@ export async function findTbdRoot(startDir: string): Promise<string | null> {
 export async function isInitialized(baseDir: string): Promise<boolean> {
   const root = await findTbdRoot(baseDir);
   return root !== null;
+}
+
+/**
+ * Top-level config keys that are committed in git but absent from the working copy.
+ *
+ * A tbd older than f07 parses config in Zod strip mode, so it silently drops any block
+ * it does not know the first time it rewrites config.yml. That is how the `integrations`
+ * block was lost three times during the Linear pilot. The loss is recoverable, because
+ * config.yml is tracked, but it is silent when it happens and only becomes visible much
+ * later when a tracker stops syncing. Comparing the working copy against HEAD makes it
+ * loud immediately.
+ *
+ * Returns an empty array when there is no git repository, no commit, or no committed
+ * config, and when the committed format differs from the local one — a format migration
+ * legitimately adds and removes keys, and its own notice already asks for a commit.
+ */
+export async function droppedConfigKeys(baseDir: string): Promise<string[]> {
+  let committedRaw: string;
+  try {
+    // `HEAD:./path` resolves relative to -C, so this works from a subdirectory too.
+    committedRaw = await git('-C', baseDir, 'show', `HEAD:./${CONFIG_FILE}`);
+  } catch {
+    // No git repo, no commits, or config.yml is not tracked: nothing to compare.
+    return [];
+  }
+
+  let localRaw: string;
+  try {
+    localRaw = await readFile(join(baseDir, CONFIG_FILE), 'utf-8');
+  } catch {
+    return [];
+  }
+
+  let committed: RawConfig | null;
+  let local: RawConfig | null;
+  try {
+    committed = parseYaml(committedRaw) as RawConfig | null;
+    local = parseYaml(localRaw) as RawConfig | null;
+  } catch {
+    // An unparseable config is a different problem, reported by the config check.
+    return [];
+  }
+
+  if (!committed || !local) {
+    return [];
+  }
+
+  // A format change explains key differences on its own.
+  if (committed.tbd_format !== local.tbd_format) {
+    return [];
+  }
+
+  const localKeys = new Set(Object.keys(local));
+  return Object.keys(committed).filter((key) => !localKeys.has(key));
 }
 
 // =============================================================================

--- a/packages/tbd/src/lib/schemas.ts
+++ b/packages/tbd/src/lib/schemas.ts
@@ -139,7 +139,9 @@ export const ProviderName = z.enum(['linear', 'github']);
  * Stored under `extensions.<provider>` rather than as a top-level issue field.
  * `extensions` is already part of `BaseEntity` with opaque contents, so a tbd
  * that predates this feature round-trips the link untouched instead of silently
- * stripping it. That keeps the feature additive and needs no format bump.
+ * stripping it. That keeps the bead side additive, with no format bump.
+ * (The config side is the opposite: `integrations` is a new top-level config key,
+ * which is why the repository format is gated at f07. See tbd-format.ts.)
  *
  * The namespace key IS the provider, which makes "at most one link per provider"
  * structural rather than a rule the merge code has to enforce.
@@ -524,118 +526,134 @@ const IntegrationProviderBase = {
   max_nesting: z.number().int().min(1).max(5).default(2),
 };
 
-export const LinearIntegrationSchema = z.object({
-  ...IntegrationProviderBase,
-  /** Linear team key, e.g. "FIN". Required when enabled. */
-  team_key: z.string().min(1).optional(),
-  /**
-   * Linear project to file mirrored issues under, by name or slug id. Optional:
-   * without it, issues land in the team with no project.
-   */
-  project: z.string().min(1).optional(),
-  /**
-   * Push bead labels as Linear labels.
-   *
-   * Off by default, and deliberately so. A repository can carry a hundred-plus
-   * distinct bead labels, and creating one Linear label each pollutes a shared
-   * team namespace that other people and projects also use. The labels are
-   * already mirrored as structured data in the bead attachment, so turning this
-   * on only buys the ability to filter by them inside Linear.
-   *
-   * When enabled, mirrored labels are prefixed so they are identifiable and
-   * removable in bulk. tbd's own status carriers (`tbd:blocked`,
-   * `tbd:deferred`) are pushed regardless, because they encode status Linear
-   * has no state for.
-   */
-  mirror_labels: z.boolean().default(false),
-  /** Create labels that do not yet exist in the team on push. */
-  create_labels: z.boolean().default(true),
-  /** Maps a tbd assignee string to a Linear user email or UUID. */
-  user_map: z.record(z.string(), z.string()).default({}),
-});
+export const LinearIntegrationSchema = z
+  .object({
+    ...IntegrationProviderBase,
+    /** Linear team key, e.g. "FIN". Required when enabled. */
+    team_key: z.string().min(1).optional(),
+    /**
+     * Linear project to file mirrored issues under, by name or slug id. Optional:
+     * without it, issues land in the team with no project.
+     */
+    project: z.string().min(1).optional(),
+    /**
+     * Push bead labels as Linear labels.
+     *
+     * Off by default, and deliberately so. A repository can carry a hundred-plus
+     * distinct bead labels, and creating one Linear label each pollutes a shared
+     * team namespace that other people and projects also use. The labels are
+     * already mirrored as structured data in the bead attachment, so turning this
+     * on only buys the ability to filter by them inside Linear.
+     *
+     * When enabled, mirrored labels are prefixed so they are identifiable and
+     * removable in bulk. tbd's own status carriers (`tbd:blocked`,
+     * `tbd:deferred`) are pushed regardless, because they encode status Linear
+     * has no state for.
+     */
+    mirror_labels: z.boolean().default(false),
+    /** Create labels that do not yet exist in the team on push. */
+    create_labels: z.boolean().default(true),
+    /** Maps a tbd assignee string to a Linear user email or UUID. */
+    user_map: z.record(z.string(), z.string()).default({}),
+  })
+  // Passthrough for the same reason as the block above: a per-provider setting added
+  // by a newer tbd must survive this version rewriting config.yml.
+  .passthrough();
 
-export const GithubIntegrationSchema = z.object({
-  ...IntegrationProviderBase,
-  /** Repository as "owner/name". Required when enabled. */
-  repo: z.string().min(1).optional(),
-});
+export const GithubIntegrationSchema = z
+  .object({
+    ...IntegrationProviderBase,
+    /** Repository as "owner/name". Required when enabled. */
+    repo: z.string().min(1).optional(),
+  })
+  .passthrough();
 
-export const IntegrationsConfigSchema = z.object({
-  /**
-   * Include enabled integrations in plain `tbd sync`.
-   *
-   * On by default: enabling an integration IS the opt-in, and a second flag
-   * only creates a state where a configured tracker silently drifts. Set false
-   * to keep an integration configured but excluded from `tbd sync`, running
-   * `tbd integration sync` by hand instead.
-   */
-  sync_on_tbd_sync: z.boolean().default(true),
-  linear: LinearIntegrationSchema.optional(),
-  github: GithubIntegrationSchema.optional(),
-});
+export const IntegrationsConfigSchema = z
+  .object({
+    /**
+     * Include enabled integrations in plain `tbd sync`.
+     *
+     * On by default: enabling an integration IS the opt-in, and a second flag
+     * only creates a state where a configured tracker silently drifts. Set false
+     * to keep an integration configured but excluded from `tbd sync`, running
+     * `tbd integration sync` by hand instead.
+     */
+    sync_on_tbd_sync: z.boolean().default(true),
+    linear: LinearIntegrationSchema.optional(),
+    github: GithubIntegrationSchema.optional(),
+  })
+  // Passthrough so a provider this version does not know (a newer tbd's tracker)
+  // survives a read/write round trip instead of being silently dropped.
+  .passthrough();
 
-export const ConfigSchema = z.object({
-  /**
-   * Format version for the .tbd/ directory structure.
-   * See tbd-format.ts for version history and migration rules.
-   * Only bumped for breaking changes that require migration.
-   */
-  tbd_format: z.string().default('f01'),
+export const ConfigSchema = z
+  .object({
+    /**
+     * Format version for the .tbd/ directory structure.
+     * See tbd-format.ts for version history and migration rules.
+     * Only bumped for breaking changes that require migration.
+     */
+    tbd_format: z.string().default('f01'),
 
-  /**
-   * The tbd version that last ran `tbd setup` in this repo. Updated on every setup.
-   * Informational only; functional version gating is via `tbd_format`. See
-   * `tbd_upgrades` for the full history. (As of format f06; before f06 this was the
-   * install-time version and never changed.)
-   */
-  tbd_version: z.string(),
-  /**
-   * Ordered history (oldest first) of tbd versions that have run setup here. Appended
-   * on each setup when the version changes; informational. Seeded on the f06 migration
-   * from the prior `tbd_version` (without a timestamp). See tbd-format.ts.
-   */
-  tbd_upgrades: z.array(UpgradeEntrySchema).default([]),
-  sync: z
-    .object({
-      branch: GitBranchName.default('tbd-sync'),
-      remote: GitRemoteName.default('origin'),
-      storage: SyncStorage.default('git-common-dir-v1'),
-    })
-    .default({}),
-  display: z.object({
-    id_prefix: z.string().min(1).max(20), // Required: set during init --prefix or import
-  }),
-  settings: z
-    .object({
-      auto_sync: z.boolean().default(false),
-      /**
-       * How often to automatically sync documentation cache (in hours).
-       * - Default: 24 (sync once per day when actively using tbd)
-       * - Set to 0 to disable auto-sync
-       * - Only triggers when accessing docs (shortcut, guidelines, template commands)
-       */
-      doc_auto_sync_hours: z.number().default(24),
-      /**
-       * Whether to install the ensure-gh-cli.sh hook script during setup.
-       * When true (default), `tbd setup` installs a SessionStart hook that
-       * ensures the GitHub CLI is available in agent sessions.
-       * Set to false or use `tbd setup --no-gh-cli` to disable.
-       */
-      use_gh_cli: z.boolean().default(true),
-    })
-    .default({}),
-  /**
-   * Documentation cache configuration (consolidated).
-   * Contains files to sync and lookup paths.
-   * See DocsCacheSchema for structure details.
-   */
-  docs_cache: DocsCacheSchema.optional(),
-  /**
-   * External tracker integrations. Absent means no integration is configured and
-   * every integration command and check is inert.
-   */
-  integrations: IntegrationsConfigSchema.optional(),
-});
+    /**
+     * The tbd version that last ran `tbd setup` in this repo. Updated on every setup.
+     * Informational only; functional version gating is via `tbd_format`. See
+     * `tbd_upgrades` for the full history. (As of format f06; before f06 this was the
+     * install-time version and never changed.)
+     */
+    tbd_version: z.string(),
+    /**
+     * Ordered history (oldest first) of tbd versions that have run setup here. Appended
+     * on each setup when the version changes; informational. Seeded on the f06 migration
+     * from the prior `tbd_version` (without a timestamp). See tbd-format.ts.
+     */
+    tbd_upgrades: z.array(UpgradeEntrySchema).default([]),
+    sync: z
+      .object({
+        branch: GitBranchName.default('tbd-sync'),
+        remote: GitRemoteName.default('origin'),
+        storage: SyncStorage.default('git-common-dir-v1'),
+      })
+      .default({}),
+    display: z.object({
+      id_prefix: z.string().min(1).max(20), // Required: set during init --prefix or import
+    }),
+    settings: z
+      .object({
+        auto_sync: z.boolean().default(false),
+        /**
+         * How often to automatically sync documentation cache (in hours).
+         * - Default: 24 (sync once per day when actively using tbd)
+         * - Set to 0 to disable auto-sync
+         * - Only triggers when accessing docs (shortcut, guidelines, template commands)
+         */
+        doc_auto_sync_hours: z.number().default(24),
+        /**
+         * Whether to install the ensure-gh-cli.sh hook script during setup.
+         * When true (default), `tbd setup` installs a SessionStart hook that
+         * ensures the GitHub CLI is available in agent sessions.
+         * Set to false or use `tbd setup --no-gh-cli` to disable.
+         */
+        use_gh_cli: z.boolean().default(true),
+      })
+      .default({}),
+    /**
+     * Documentation cache configuration (consolidated).
+     * Contains files to sync and lookup paths.
+     * See DocsCacheSchema for structure details.
+     */
+    docs_cache: DocsCacheSchema.optional(),
+    /**
+     * External tracker integrations. Absent means no integration is configured and
+     * every integration command and check is inert.
+     */
+    integrations: IntegrationsConfigSchema.optional(),
+  })
+  // Preserve unknown top-level keys (f07+). A tbd that strips them silently discards
+  // a newer version's configuration the first time it rewrites config.yml — which is
+  // how the integrations block was lost three times during the Linear pilot. Keeping
+  // them means a future additive block needs no format bump. See tbd-format.ts.
+  .passthrough();
 
 // =============================================================================
 // Common-Dir Layout Schema
@@ -793,6 +811,7 @@ export const CONFIG_FIELD_ORDER = [
   'sync',
   'settings',
   'docs_cache',
+  'integrations',
 ] as const;
 
 /**

--- a/packages/tbd/src/lib/tbd-format.ts
+++ b/packages/tbd/src/lib/tbd-format.ts
@@ -6,11 +6,14 @@
  *
  * WHEN TO BUMP THE FORMAT VERSION:
  * - Bump when changes REQUIRE migration (deleting files, changing formats, moving files)
- * - **Bump when changing config schema** (adding, removing, or modifying fields)
+ * - Bump for config removals, renames, semantic changes, or additions inside a nested
+ *   schema that does not preserve unknown keys when an older client could lose data.
  * - **Bump when the shape of a generated agent-integration surface changes** (e.g. the
  *   managed AGENTS.md block). This same format is stamped there via
  *   AGENT_INTEGRATION_FORMAT (integration-paths.ts), so there is ONE format code across
  *   all tbd-managed surfaces.
+ * - Do NOT bump for a purely additive top-level config block, or a key inside an
+ *   explicitly passthrough schema, once the repository is on f07.
  * - Do NOT bump for additive changes that don't affect config.yml (new directories, etc.)
  *
  * HOW TO ADD A NEW FORMAT VERSION:
@@ -26,7 +29,8 @@
  * additions; it cannot protect against clients already published, which parse config
  * in strip mode and silently drop what they do not know. The format gate covers them:
  *
- * 1. When changing config schema, bump the format version (e.g., f03 → f04)
+ * 1. When making a destructive, semantic, or non-passthrough config change, bump the
+ *    format version (e.g., f07 → f08)
  * 2. config.ts checks format compatibility via isCompatibleFormat()
  * 3. Older tbd versions will error with "format 'fXX' is from a newer tbd version"
  * 4. The error tells users to upgrade: npm install -g get-tbd@latest

--- a/packages/tbd/src/lib/tbd-format.ts
+++ b/packages/tbd/src/lib/tbd-format.ts
@@ -21,8 +21,10 @@
  * 5. Add tests for the migration path
  *
  * FORWARD COMPATIBILITY POLICY:
- * ConfigSchema uses Zod's strip() mode, which discards unknown fields. To prevent
- * data loss when users mix tbd versions:
+ * As of f07 ConfigSchema preserves unknown top-level keys, so a config block added by
+ * a newer tbd survives a round trip through an older one. That protects future
+ * additions; it cannot protect against clients already published, which parse config
+ * in strip mode and silently drop what they do not know. The format gate covers them:
  *
  * 1. When changing config schema, bump the format version (e.g., f03 → f04)
  * 2. config.ts checks format compatibility via isCompatibleFormat()
@@ -30,6 +32,9 @@
  * 4. The error tells users to upgrade: npm install -g get-tbd@latest
  *
  * This ensures older versions fail fast rather than silently corrupting config.
+ * A purely additive config key no longer needs a bump once every client in use is
+ * f07 or later; bump when the meaning of existing fields changes, or when losing the
+ * new key to a pre-f07 client would be damaging.
  * See ConfigSchema in schemas.ts and checkFormatCompatibility() in config.ts.
  */
 
@@ -41,7 +46,7 @@
  * Current format version.
  * Bump this ONLY for breaking changes that require migration.
  */
-export const CURRENT_FORMAT = 'f06';
+export const CURRENT_FORMAT = 'f07';
 
 /**
  * Initial format version for configs that don't have tbd_format field.
@@ -126,6 +131,23 @@ export const FORMAT_HISTORY = {
       'when changed. Revert: restore .tbd/config.yml (git checkout) and delete ' +
       '$GIT_COMMON_DIR/tbd/layout.yml; it regenerates from the config.',
   },
+  f07: {
+    introduced: '0.6.0',
+    description: 'Adds the external tracker integrations config block and preserves unknown keys',
+    changes: [
+      'Added the optional integrations: block to config.yml (tracker config and policy)',
+      'ConfigSchema now preserves unknown top-level keys instead of stripping them',
+      'The integrations block and its provider entries preserve unknown keys too',
+    ],
+    migration:
+      'Metadata-only: stamps tbd_format f07 (the integrations block appears only when a ' +
+      'tracker is configured). The bump is what closes the door on pre-0.6.0 clients, ' +
+      'which parse config in strip mode and silently drop an integrations block when ' +
+      'they rewrite config.yml. From f07 onward unknown keys survive that round trip, so ' +
+      'additive config blocks no longer need a format bump. Revert: restore ' +
+      '.tbd/config.yml (git checkout) and delete $GIT_COMMON_DIR/tbd/layout.yml; it ' +
+      'regenerates from the config.',
+  },
 } as const;
 
 export type FormatVersion = keyof typeof FORMAT_HISTORY;
@@ -165,6 +187,10 @@ export interface RawConfig {
     files?: Record<string, string>;
     lookup_path?: string[];
   };
+  /** External tracker integrations (f07+). Opaque here; ConfigSchema owns its shape. */
+  integrations?: Record<string, unknown>;
+  /** Unknown keys are carried through migration rather than dropped (f07+). */
+  [key: string]: unknown;
 }
 
 /**
@@ -344,6 +370,35 @@ function migrate_f05_to_f06(config: RawConfig): MigrationResult {
   };
 }
 
+/**
+ * Migrate from f06 to f07.
+ * - Metadata-only stamp: the `integrations` block is written by `tbd integration`
+ *   setup, not by migration, so a repository with no tracker gains nothing but the
+ *   new format ID.
+ * - The bump is the point. `ConfigSchema` parses in Zod strip mode in every released
+ *   client before 0.6.0, so such a client silently drops an `integrations` block the
+ *   first time it rewrites config.yml (via `setup`, `config set`, or `import`). Those
+ *   clients cannot be fixed retroactively; stamping f07 makes them fail closed with
+ *   the upgrade message instead of quietly discarding tracker configuration.
+ * - f07 clients preserve unknown top-level keys, so a later additive config block does
+ *   not need its own bump.
+ */
+function migrate_f06_to_f07(config: RawConfig): MigrationResult {
+  const changes: string[] = [];
+  const migrated = { ...config };
+
+  migrated.tbd_format = 'f07';
+  changes.push('Updated tbd_format: f07');
+
+  return {
+    config: migrated,
+    fromFormat: 'f06',
+    toFormat: 'f07',
+    changed: changes.length > 0,
+    changes,
+  };
+}
+
 // =============================================================================
 // Public API
 // =============================================================================
@@ -435,6 +490,13 @@ export function migrateToLatest(config: RawConfig): MigrationResult {
     allChanges.push(...result.changes);
   }
 
+  if (currentFormat === 'f06') {
+    const result = migrate_f06_to_f07(current);
+    current = result.config;
+    currentFormat = 'f07' as FormatVersion;
+    allChanges.push(...result.changes);
+  }
+
   return {
     config: current,
     fromFormat,
@@ -521,6 +583,11 @@ export function describeMigration(fromFormat: FormatVersion): string[] {
   if (current === 'f05') {
     descriptions.push('f05 → f06: Add config upgrade history (tbd_upgrades)');
     current = 'f06';
+  }
+
+  if (current === 'f06') {
+    descriptions.push('f06 → f07: Add external tracker integrations config (stamp only)');
+    current = 'f07';
   }
 
   return descriptions;

--- a/packages/tbd/src/utils/changelog.ts
+++ b/packages/tbd/src/utils/changelog.ts
@@ -48,10 +48,23 @@ export function extractChangelogSection(changelog: string, version: string): str
 }
 
 /**
- * Resolve the release body for `version`, falling back to "Release v<version>" when the
- * changelog has no matching section.
+ * Return the release body for `version`, failing closed when the exact section is absent
+ * or contains no notes. A tag-triggered publish must never silently substitute a generic
+ * body because that can hide a tag/package/changelog version mismatch.
  */
-export function resolveReleaseBody(changelog: string, version: string): string {
+export function requireChangelogSection(changelog: string, version: string): string {
   const section = extractChangelogSection(changelog, version);
-  return section && section.trim() !== '' ? section : `Release v${version}`;
+  if (section === null) {
+    throw new Error(`No changelog section found for version ${version}`);
+  }
+
+  const hasReleaseNotes = section
+    .split('\n')
+    .slice(1)
+    .some((line) => line.trim() !== '');
+  if (!hasReleaseNotes) {
+    throw new Error(`Changelog section for version ${version} has no release notes`);
+  }
+
+  return section;
 }

--- a/packages/tbd/src/utils/release-metadata.ts
+++ b/packages/tbd/src/utils/release-metadata.ts
@@ -1,0 +1,34 @@
+/**
+ * Cross-check the three independent version sources used by a tag-triggered release.
+ */
+
+import { requireChangelogSection } from './changelog.js';
+
+export interface VerifiedReleaseMetadata {
+  version: string;
+  releaseBody: string;
+}
+
+/**
+ * Require an exact `v<package version>` tag and an exact, non-empty changelog section.
+ * Call this before any irreversible registry publish.
+ */
+export function verifyReleaseMetadata(
+  tagName: string,
+  packageVersion: string,
+  changelog: string,
+): VerifiedReleaseMetadata {
+  if (!tagName.startsWith('v') || tagName.length === 1) {
+    throw new Error(`Release tag must start with v and include a version; received ${tagName}`);
+  }
+
+  const version = tagName.slice(1);
+  if (version !== packageVersion) {
+    throw new Error(`Release tag ${tagName} does not match package version ${packageVersion}`);
+  }
+
+  return {
+    version,
+    releaseBody: requireChangelogSection(changelog, version),
+  };
+}

--- a/packages/tbd/tests/cli-advanced.tryscript.md
+++ b/packages/tbd/tests/cli-advanced.tryscript.md
@@ -277,7 +277,7 @@ settings:
 ```console
 $ tbd config show --json
 {
-  "tbd_format": "f06",
+  "tbd_format": "f07",
   "tbd_version": "[..]",
   "tbd_upgrades": [
     {

--- a/packages/tbd/tests/cli-format-compatibility.tryscript.md
+++ b/packages/tbd/tests/cli-format-compatibility.tryscript.md
@@ -44,6 +44,26 @@ Golden tests for fail-closed format compatibility behavior.
 $ tbd list 2>&1
 Error: This repository requires a newer version of tbd.
 Config format 'f99' is from a newer tbd version.
+This tbd version supports up to format 'f07'.
+Upgrade tbd: npm install -g get-tbd@latest
+? 1
+```
+
+* * *
+
+## The f07 Integrations Gate
+
+A tbd released before 0.6.0 parses config in strip mode, so it silently drops an
+`integrations` block the first time it rewrites `config.yml`. It cannot be fixed
+retroactively, so f07 makes it fail closed instead.
+This models such a client — one that supports up to f06 — meeting an f07 repository.
+
+# Test: A pre-0.6.0 client refuses an f07 repository instead of rewriting its config
+
+```console
+$ node -e 'const supported="f06"; const format="f07"; if (format > supported) { console.error("This repository requires a newer version of tbd."); console.error("Config format '"'"'"+format+"'"'"' is from a newer tbd version."); console.error("This tbd version supports up to format '"'"'"+supported+"'"'"'."); console.error("Upgrade tbd: npm install -g get-tbd@latest"); process.exit(1); }' 2>&1
+This repository requires a newer version of tbd.
+Config format 'f07' is from a newer tbd version.
 This tbd version supports up to format 'f06'.
 Upgrade tbd: npm install -g get-tbd@latest
 ? 1

--- a/packages/tbd/tests/cli-shared-common-dir-worktree.tryscript.md
+++ b/packages/tbd/tests/cli-shared-common-dir-worktree.tryscript.md
@@ -86,7 +86,7 @@ design:
 1. An f03 per-checkout sync worktree owns `tbd-sync`.
 2. A linked worktree cannot create its own per-checkout sync worktree because Git
    rejects the duplicate branch checkout.
-3. A new tbd write migrates the repository to the current (f06) common-dir layout.
+3. A new tbd write migrates the repository to the current (f07) common-dir layout.
 4. The main checkout and linked worktree both create issues through the same shared sync
    worktree.
 
@@ -119,17 +119,17 @@ own point-of-use notice (#135).
 
 ```console
 $ tbd create "Main checkout issue" --type=task
-• tbd_format f03 → f06: .tbd/config.yml updated in this checkout. Commit on this branch or merge main to publish the format upgrade.
+• tbd_format f03 → f07: .tbd/config.yml updated in this checkout. Commit on this branch or merge main to publish the format upgrade.
 • tbd-sync worktree was missing; auto-materialized it (fresh clone, or the worktree was removed).
 ✓ Created test-[SHORTID]: Main checkout issue
 ? 0
 ```
 
-# Test: Top-level config was migrated to f06 with common-dir storage
+# Test: Top-level config was migrated to f07 with common-dir storage
 
 ```console
 $ cat .tbd/config.yml
-tbd_format: f06
+tbd_format: f07
 tbd_version: legacy
 # tbd_upgrades: tbd versions that have run `tbd setup` in this repo (oldest first);
 # tbd_version above is the most recent. Informational; updated automatically by setup.
@@ -148,11 +148,11 @@ settings:
 ? 0
 ```
 
-# Test: Common-dir layout uses the same f06 format ID
+# Test: Common-dir layout uses the same f07 format ID
 
 ```console
 $ cat "$(git rev-parse --path-format=absolute --git-common-dir)/tbd/layout.yml"
-tbd_format: f06
+tbd_format: f07
 sync_storage: git-common-dir-v1
 data_sync_worktree: data-sync-worktree
 lock_profile: data-sync-v1
@@ -197,7 +197,7 @@ the same `tbd-afjh` notice as the main checkout did before bumping in place.
 
 ```console
 $ (cd agent && tbd create "Linked worktree issue" --type=bug)
-• tbd_format f03 → f06: .tbd/config.yml updated in this checkout. Commit on this branch or merge main to publish the format upgrade.
+• tbd_format f03 → f07: .tbd/config.yml updated in this checkout. Commit on this branch or merge main to publish the format upgrade.
 ✓ Created test-[SHORTID]: Linked worktree issue
 ? 0
 ```
@@ -235,15 +235,15 @@ Main checkout issue | task | open
 
 ## Older Client Compatibility Guard
 
-# Test: An f03-era client would reject the migrated f06 repository
+# Test: An f03-era client would reject the migrated f07 repository
 
 This uses the same format ordering contract as tbd itself: a client that only supports
-up to f03 must fail closed when it sees the f06 common-dir layout.
+up to f03 must fail closed when it sees the f07 common-dir layout.
 
 ```console
 $ node -e 'const fs=require("fs"); const format=fs.readFileSync(".tbd/config.yml","utf8").match(/^tbd_format: (\S+)/m)?.[1]; const supported="f03"; if (format !== undefined && format > supported) { console.error("This repository requires a newer version of tbd."); console.error("Config format '"'"'"+format+"'"'"' is from a newer tbd version."); console.error("This tbd version supports up to format '"'"'"+supported+"'"'"'."); console.error("Upgrade tbd: npm install -g get-tbd@latest"); process.exit(1); }'
 This repository requires a newer version of tbd.
-Config format 'f06' is from a newer tbd version.
+Config format 'f07' is from a newer tbd version.
 This tbd version supports up to format 'f03'.
 Upgrade tbd: npm install -g get-tbd@latest
 ? 1

--- a/packages/tbd/tests/common-dir-layout-doctor.test.ts
+++ b/packages/tbd/tests/common-dir-layout-doctor.test.ts
@@ -167,11 +167,11 @@ describeUnlessWindows('common-dir layout via CLI', { timeout: 30000 }, () => {
     it('treats an older-format layout as a pending migration and applies it on --fix', async () => {
       const layoutPath = join(dir, '.git', 'tbd', 'layout.yml');
       const original = await readFile(layoutPath, 'utf-8');
-      expect(original).toContain('tbd_format: f06');
+      expect(original).toContain('tbd_format: f07');
 
       // A layout behind the config (downgraded to f03 here) is the normal
       // mid-migration state, not a mismatch.
-      await writeFile(layoutPath, original.replace('tbd_format: f06', 'tbd_format: f03'));
+      await writeFile(layoutPath, original.replace('tbd_format: f07', 'tbd_format: f03'));
 
       // Plain doctor reports a pending migration: a warning (exit 0, so CI on
       // un-migrated repos is not broken), fixable.
@@ -183,21 +183,21 @@ describeUnlessWindows('common-dir layout via CLI', { timeout: 30000 }, () => {
       // doctor --fix applies the migration; layout is re-stamped to current.
       const fix = runTbd(dir, ['doctor', '--fix']);
       expect(fix.status).toBe(0);
-      expect(await readFile(layoutPath, 'utf-8')).toContain('tbd_format: f06');
+      expect(await readFile(layoutPath, 'utf-8')).toContain('tbd_format: f07');
     });
 
     it('does not false-positive on a healthy older repo; --fix fully migrates (never half)', async () => {
       // Downgrade BOTH config and layout to f04: a consistent pre-migration
-      // repo, exactly what an f06 client sees before the first write.
+      // repo, exactly what an f07 client sees before the first write.
       const configPath = join(dir, '.tbd', 'config.yml');
       const layoutPath = join(dir, '.git', 'tbd', 'layout.yml');
       await writeFile(
         configPath,
-        (await readFile(configPath, 'utf-8')).replace('tbd_format: f06', 'tbd_format: f04'),
+        (await readFile(configPath, 'utf-8')).replace('tbd_format: f07', 'tbd_format: f04'),
       );
       await writeFile(
         layoutPath,
-        (await readFile(layoutPath, 'utf-8')).replace('tbd_format: f06', 'tbd_format: f04'),
+        (await readFile(layoutPath, 'utf-8')).replace('tbd_format: f07', 'tbd_format: f04'),
       );
 
       // Plain doctor must NOT error on a healthy un-migrated repo (was exit 1).
@@ -206,13 +206,13 @@ describeUnlessWindows('common-dir layout via CLI', { timeout: 30000 }, () => {
       // The config marker on disk is untouched by a read-only doctor run.
       expect(await readFile(configPath, 'utf-8')).toContain('tbd_format: f04');
 
-      // --fix must produce a CONSISTENT f06 repo: BOTH config and layout
+      // --fix must produce a CONSISTENT f07 repo: BOTH config and layout
       // migrated, never layout-only (which would lock out older clients with
       // nothing to commit).
       const fix = runTbd(dir, ['doctor', '--fix']);
       expect(fix.status).toBe(0);
-      expect(await readFile(configPath, 'utf-8')).toContain('tbd_format: f06');
-      expect(await readFile(layoutPath, 'utf-8')).toContain('tbd_format: f06');
+      expect(await readFile(configPath, 'utf-8')).toContain('tbd_format: f07');
+      expect(await readFile(layoutPath, 'utf-8')).toContain('tbd_format: f07');
     });
 
     it('rewrites a corrupt layout.yml from config on --fix', async () => {
@@ -226,20 +226,20 @@ describeUnlessWindows('common-dir layout via CLI', { timeout: 30000 }, () => {
 
       const fix = runTbd(dir, ['doctor', '--fix']);
       expect(fix.status).toBe(0);
-      expect(await readFile(layoutPath, 'utf-8')).toContain('tbd_format: f06');
+      expect(await readFile(layoutPath, 'utf-8')).toContain('tbd_format: f07');
     });
 
     it('surfaces future-format layout as needing a newer tbd (no fix attempted)', async () => {
       const layoutPath = join(dir, '.git', 'tbd', 'layout.yml');
       const original = await readFile(layoutPath, 'utf-8');
-      await writeFile(layoutPath, original.replace('tbd_format: f06', 'tbd_format: f99'));
+      await writeFile(layoutPath, original.replace('tbd_format: f07', 'tbd_format: f99'));
 
       const fix = runTbd(dir, ['doctor', '--fix']);
       // Future-format markers are ✗ findings: scripts/CI must see exit 1 (tbd-r7rt).
       expect(fix.status).toBe(1);
       const out = fix.stdout + fix.stderr;
       expect(out).toMatch(/newer tbd|f99/i);
-      // Layout was not silently rewritten back to f06.
+      // Layout was not silently rewritten back to f07.
       const layout = await readFile(layoutPath, 'utf-8');
       expect(layout).toContain('tbd_format: f99');
     });
@@ -247,7 +247,7 @@ describeUnlessWindows('common-dir layout via CLI', { timeout: 30000 }, () => {
     it('surfaces future-format config as a newer-tbd error in checkConfig', async () => {
       const configPath = join(dir, '.tbd', 'config.yml');
       const original = await readFile(configPath, 'utf-8');
-      await writeFile(configPath, original.replace('tbd_format: f06', 'tbd_format: f99'));
+      await writeFile(configPath, original.replace('tbd_format: f07', 'tbd_format: f99'));
 
       const out = runTbd(dir, ['doctor']);
       // Future-format config is a ✗ finding: exit 1 (tbd-r7rt).
@@ -284,7 +284,7 @@ describeUnlessWindows('common-dir layout via CLI', { timeout: 30000 }, () => {
       expect(await exists(worktreePath)).toBe(true);
       expect(await exists(layoutPath)).toBe(true);
       const layout = await readFile(layoutPath, 'utf-8');
-      expect(layout).toContain('tbd_format: f06');
+      expect(layout).toContain('tbd_format: f07');
     });
 
     it('serializes concurrent doctor --fix init under the shared data-sync lock (tbd-p6zo)', async () => {
@@ -317,7 +317,7 @@ describeUnlessWindows('common-dir layout via CLI', { timeout: 30000 }, () => {
       expect(await exists(worktreePath)).toBe(true);
       expect(await exists(layoutPath)).toBe(true);
       const layout = await readFile(layoutPath, 'utf-8');
-      expect(layout).toContain('tbd_format: f06');
+      expect(layout).toContain('tbd_format: f07');
 
       const worktreeList = await gitIn(dir, 'worktree', 'list', '--porcelain');
       const sharedWorktreeLines = worktreeList
@@ -331,21 +331,21 @@ describeUnlessWindows('common-dir layout via CLI', { timeout: 30000 }, () => {
     it('prints a one-time stderr notice when this checkout migrates .tbd/config.yml to a newer tbd_format', async () => {
       const configPath = join(dir, '.tbd', 'config.yml');
       const original = await readFile(configPath, 'utf-8');
-      // The setup is f06; "downgrade" the on-disk format marker so the next mutating
+      // The setup is f07; "downgrade" the on-disk format marker so the next mutating
       // command sees a stale per-checkout config and migrates it back in place. This
       // matches a real sibling worktree on a branch that did not yet pick up the
       // main checkout's f03 → f04 commit.
-      await writeFile(configPath, original.replace('tbd_format: f06', 'tbd_format: f03'));
+      await writeFile(configPath, original.replace('tbd_format: f07', 'tbd_format: f03'));
 
       const create = runTbd(dir, ['create', 'sibling-bump probe', '--type', 'task']);
       expect(create.status).toBe(0);
       // The notice goes to stderr so it cannot pollute JSON output on stdout.
       expect(create.stderr).toContain('tbd_format');
-      expect(create.stderr).toContain('→ f06');
+      expect(create.stderr).toContain('→ f07');
       expect(create.stderr).toMatch(/commit on this branch or merge main/i);
-      // The on-disk config is now at f06 — the migration ran.
+      // The on-disk config is now at f07 — the migration ran.
       const after = await readFile(configPath, 'utf-8');
-      expect(after).toContain('tbd_format: f06');
+      expect(after).toContain('tbd_format: f07');
 
       // Second mutating call must NOT re-emit the notice: nothing left to migrate.
       const second = runTbd(dir, ['create', 'sibling-bump probe 2', '--type', 'task']);
@@ -354,7 +354,7 @@ describeUnlessWindows('common-dir layout via CLI', { timeout: 30000 }, () => {
     });
   });
 
-  describe('f04 → f06 upgrade (in-place config + layout migration)', () => {
+  describe('f04 → f07 upgrade (in-place config + layout migration)', () => {
     it('upgrades config and layout in place; the loop is revertible and repeatable', async () => {
       const configPath = join(dir, '.tbd', 'config.yml');
       const layoutPath = join(dir, '.git', 'tbd', 'layout.yml');
@@ -365,11 +365,11 @@ describeUnlessWindows('common-dir layout via CLI', { timeout: 30000 }, () => {
         // machine-local layout looks like.
         await writeFile(
           configPath,
-          (await readFile(configPath, 'utf-8')).replace('tbd_format: f06', 'tbd_format: f04'),
+          (await readFile(configPath, 'utf-8')).replace('tbd_format: f07', 'tbd_format: f04'),
         );
         await writeFile(
           layoutPath,
-          (await readFile(layoutPath, 'utf-8')).replace('tbd_format: f06', 'tbd_format: f04'),
+          (await readFile(layoutPath, 'utf-8')).replace('tbd_format: f07', 'tbd_format: f04'),
         );
 
         // A plain data command must succeed (NOT fail with a layout/config
@@ -377,9 +377,9 @@ describeUnlessWindows('common-dir layout via CLI', { timeout: 30000 }, () => {
         // one-time migration notice.
         const create = runTbd(dir, ['create', `upgrade probe ${round}`, '--type', 'task']);
         expect(create.status).toBe(0);
-        expect(create.stderr).toContain('f04 → f06');
-        expect(await readFile(configPath, 'utf-8')).toContain('tbd_format: f06');
-        expect(await readFile(layoutPath, 'utf-8')).toContain('tbd_format: f06');
+        expect(create.stderr).toContain('f04 → f07');
+        expect(await readFile(configPath, 'utf-8')).toContain('tbd_format: f07');
+        expect(await readFile(layoutPath, 'utf-8')).toContain('tbd_format: f07');
       };
 
       await migrateOnceFromF04(1);
@@ -393,40 +393,40 @@ describeUnlessWindows('common-dir layout via CLI', { timeout: 30000 }, () => {
     });
 
     it('read commands upgrade an older layout under the lock, preserving created_at', async () => {
-      // Config already f06 (e.g. a teammate committed the bump) but this
+      // Config already f07 (e.g. a teammate committed the bump) but this
       // machine's layout is still f04: a read must auto-upgrade, not error.
       // This is also the setup-path crash window (setup writes config before
       // the layout).
       const layoutPath = join(dir, '.git', 'tbd', 'layout.yml');
       const before = await readFile(layoutPath, 'utf-8');
       const createdAt = before.split('\n').find((l) => l.startsWith('created_at:'));
-      await writeFile(layoutPath, before.replace('tbd_format: f06', 'tbd_format: f04'));
+      await writeFile(layoutPath, before.replace('tbd_format: f07', 'tbd_format: f04'));
 
       const list = runTbd(dir, ['list', '--json']);
       expect(list.status).toBe(0);
       const after = await readFile(layoutPath, 'utf-8');
-      expect(after).toContain('tbd_format: f06');
+      expect(after).toContain('tbd_format: f07');
       expect(after).toContain(createdAt);
     });
 
-    it('completes an interrupted upgrade (layout already f06, config still f04)', async () => {
+    it('completes an interrupted upgrade (layout already f07, config still f04)', async () => {
       // The data-command crash window: ensureSharedDataSyncLayout re-stamps the
       // layout BEFORE writeConfig persists the config. A crash there leaves
-      // layout f06 + config f04; the next command must finish the migration,
+      // layout f07 + config f04; the next command must finish the migration,
       // not error on the mismatch.
       const configPath = join(dir, '.tbd', 'config.yml');
       await writeFile(
         configPath,
-        (await readFile(configPath, 'utf-8')).replace('tbd_format: f06', 'tbd_format: f04'),
+        (await readFile(configPath, 'utf-8')).replace('tbd_format: f07', 'tbd_format: f04'),
       );
       expect(await readFile(join(dir, '.git', 'tbd', 'layout.yml'), 'utf-8')).toContain(
-        'tbd_format: f06',
+        'tbd_format: f07',
       );
 
       const create = runTbd(dir, ['create', 'resume probe', '--type', 'task']);
       expect(create.status).toBe(0);
-      expect(create.stderr).toContain('f04 → f06');
-      expect(await readFile(configPath, 'utf-8')).toContain('tbd_format: f06');
+      expect(create.stderr).toContain('f04 → f07');
+      expect(await readFile(configPath, 'utf-8')).toContain('tbd_format: f07');
     });
 
     it('aborts via the documented recipe: restore config, delete layout.yml', async () => {
@@ -436,7 +436,7 @@ describeUnlessWindows('common-dir layout via CLI', { timeout: 30000 }, () => {
       const layoutPath = join(dir, '.git', 'tbd', 'layout.yml');
       await writeFile(
         configPath,
-        (await readFile(configPath, 'utf-8')).replace('tbd_format: f06', 'tbd_format: f04'),
+        (await readFile(configPath, 'utf-8')).replace('tbd_format: f07', 'tbd_format: f04'),
       );
       await rm(layoutPath);
 
@@ -445,11 +445,11 @@ describeUnlessWindows('common-dir layout via CLI', { timeout: 30000 }, () => {
       expect(await readFile(configPath, 'utf-8')).toContain('tbd_format: f04');
 
       // Re-running the upgrade from the aborted state works cleanly: the next
-      // command migrates the config and regenerates the layout at f06.
+      // command migrates the config and regenerates the layout at f07.
       const list = runTbd(dir, ['list', '--json']);
       expect(list.status).toBe(0);
-      expect(await readFile(configPath, 'utf-8')).toContain('tbd_format: f06');
-      expect(await readFile(layoutPath, 'utf-8')).toContain('tbd_format: f06');
+      expect(await readFile(configPath, 'utf-8')).toContain('tbd_format: f07');
+      expect(await readFile(layoutPath, 'utf-8')).toContain('tbd_format: f07');
     });
   });
 
@@ -476,7 +476,7 @@ describeUnlessWindows('common-dir layout via CLI', { timeout: 30000 }, () => {
       expect(list.status).toBe(0);
       expect(await exists(layoutPath)).toBe(true);
       const layout = await readFile(layoutPath, 'utf-8');
-      expect(layout).toContain('tbd_format: f06');
+      expect(layout).toContain('tbd_format: f07');
 
       // No direct .tbd/data-sync/ leakage: f04+ must fail closed, not fall back.
       expect(await exists(sharedDataSync)).toBe(true);

--- a/packages/tbd/tests/config.test.ts
+++ b/packages/tbd/tests/config.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, readFile, mkdir, writeFile } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -16,8 +17,10 @@ import {
   hasSeenWelcome,
   markWelcomeSeen,
   IncompatibleFormatError,
+  droppedConfigKeys,
 } from '../src/file/config.js';
 import { CONFIG_FILE } from '../src/lib/paths.js';
+import { CURRENT_FORMAT } from '../src/lib/tbd-format.js';
 import type { Config } from '../src/lib/types.js';
 
 describe('config operations', () => {
@@ -65,7 +68,7 @@ describe('config operations', () => {
 
   describe('stampSetupVersion', () => {
     const base: Config = {
-      tbd_format: 'f06',
+      tbd_format: CURRENT_FORMAT,
       tbd_version: '0.3.0',
       tbd_upgrades: [{ version: '0.3.0', at: '2026-06-12T00:00:00.000Z' }],
       sync: { branch: 'tbd-sync', remote: 'origin', storage: 'git-common-dir-v1' },
@@ -138,7 +141,7 @@ describe('config operations', () => {
       await expect(readConfig(tempDir)).rejects.toThrow(
         'This repository requires a newer version of tbd.\n' +
           "Config format 'f99' is from a newer tbd version.\n" +
-          "This tbd version supports up to format 'f06'.\n" +
+          "This tbd version supports up to format 'f07'.\n" +
           'Upgrade tbd: npm install -g get-tbd@latest',
       );
     });
@@ -149,7 +152,7 @@ describe('config operations', () => {
       await initConfig(tempDir, '3.0.0', 'test');
 
       const config: Config = {
-        tbd_format: 'f06',
+        tbd_format: CURRENT_FORMAT,
         tbd_version: '3.1.0',
         tbd_upgrades: [{ version: '3.0.0' }, { version: '3.1.0', at: '2026-06-12T00:00:00.000Z' }],
         sync: { branch: 'custom-branch', remote: 'upstream', storage: 'git-common-dir-v1' },
@@ -171,6 +174,53 @@ describe('config operations', () => {
       expect(read.sync.storage).toBe('git-common-dir-v1');
       expect(read.display.id_prefix).toBe('td');
       expect(read.settings.auto_sync).toBe(true);
+    });
+
+    /**
+     * The f07 forward-compatibility contract. Before f07 the config schema parsed in
+     * strip mode, so a tbd that did not know a block silently discarded it on its next
+     * write — how the integrations block was lost three times during the Linear pilot.
+     */
+    it('preserves an unknown top-level block across a read/write round trip', async () => {
+      await initConfig(tempDir, '3.0.0', 'test');
+      const configPath = join(tempDir, CONFIG_FILE);
+
+      const original = await readFile(configPath, 'utf-8');
+      await writeFile(
+        configPath,
+        `${original}future_block:\n  written_by: a newer tbd\n  keep: true\n`,
+      );
+
+      const read = await readConfig(tempDir);
+      await writeConfig(tempDir, read);
+
+      const rewritten = await readFile(configPath, 'utf-8');
+      expect(rewritten).toContain('future_block:');
+      expect(rewritten).toContain('written_by: a newer tbd');
+    });
+
+    it('preserves an unknown provider and provider setting inside integrations', async () => {
+      await initConfig(tempDir, '3.0.0', 'test');
+      const configPath = join(tempDir, CONFIG_FILE);
+
+      const original = await readFile(configPath, 'utf-8');
+      await writeFile(
+        configPath,
+        `${original}integrations:\n` +
+          '  linear:\n' +
+          '    enabled: true\n' +
+          '    team_key: FIN\n' +
+          '    future_setting: keep me\n' +
+          '  jira:\n' +
+          '    enabled: true\n',
+      );
+
+      await writeConfig(tempDir, await readConfig(tempDir));
+
+      const rewritten = await readFile(configPath, 'utf-8');
+      expect(rewritten).toContain('future_setting: keep me');
+      expect(rewritten).toContain('jira:');
+      expect(rewritten).toContain('team_key: FIN');
     });
   });
 
@@ -220,6 +270,81 @@ describe('config operations', () => {
       const state = await readLocalState(tempDir);
       expect(state.welcome_seen).toBe(true);
       expect(state.last_sync_at).toBe('2026-01-01T00:00:00Z');
+    });
+  });
+
+  /**
+   * Detects the silent loss directly rather than by its downstream symptom: a block
+   * that is committed but absent locally was dropped by a client that did not know it.
+   */
+  describe('droppedConfigKeys', () => {
+    const gitInit = (dir: string) => {
+      execFileSync('git', ['init', '--initial-branch=main'], { cwd: dir, stdio: 'pipe' });
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+      execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
+      execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+    };
+    const commitAll = (dir: string, message: string) => {
+      execFileSync('git', ['add', '-A'], { cwd: dir });
+      execFileSync('git', ['commit', '-m', message], { cwd: dir, stdio: 'pipe' });
+    };
+
+    const writeConfigWith = async (extra: string) => {
+      const configPath = join(tempDir, CONFIG_FILE);
+      const base = await readFile(configPath, 'utf-8');
+      await writeFile(configPath, base + extra);
+    };
+
+    it('reports a committed integrations block that the working copy lost', async () => {
+      gitInit(tempDir);
+      await initConfig(tempDir, '3.0.0', 'test');
+      await writeConfigWith('integrations:\n  linear:\n    enabled: true\n    team_key: FIN\n');
+      commitAll(tempDir, 'Configure Linear');
+
+      // Simulate a pre-f07 client rewriting config: the block it did not know is gone.
+      const configPath = join(tempDir, CONFIG_FILE);
+      const stripped = (await readFile(configPath, 'utf-8')).split('integrations:')[0] ?? '';
+      await writeFile(configPath, stripped);
+
+      expect(await droppedConfigKeys(tempDir)).toEqual(['integrations']);
+    });
+
+    it('reports nothing when the working copy matches the commit', async () => {
+      gitInit(tempDir);
+      await initConfig(tempDir, '3.0.0', 'test');
+      await writeConfigWith('integrations:\n  linear:\n    enabled: true\n');
+      commitAll(tempDir, 'Configure Linear');
+
+      expect(await droppedConfigKeys(tempDir)).toEqual([]);
+    });
+
+    it('stays quiet when the format changed, since a migration adds and removes keys', async () => {
+      gitInit(tempDir);
+      await initConfig(tempDir, '3.0.0', 'test');
+      await writeConfigWith('integrations:\n  linear:\n    enabled: true\n');
+      commitAll(tempDir, 'Configure Linear');
+
+      const configPath = join(tempDir, CONFIG_FILE);
+      const stripped = (await readFile(configPath, 'utf-8'))
+        .split('integrations:')[0]
+        ?.replace(`tbd_format: ${CURRENT_FORMAT}`, 'tbd_format: f99');
+      await writeFile(configPath, stripped ?? '');
+
+      expect(await droppedConfigKeys(tempDir)).toEqual([]);
+    });
+
+    it('stays quiet outside a git repository', async () => {
+      await initConfig(tempDir, '3.0.0', 'test');
+      expect(await droppedConfigKeys(tempDir)).toEqual([]);
+    });
+
+    it('stays quiet when config.yml has never been committed', async () => {
+      gitInit(tempDir);
+      await writeFile(join(tempDir, 'README.md'), '# fixture\n');
+      commitAll(tempDir, 'Initial commit');
+      await initConfig(tempDir, '3.0.0', 'test');
+
+      expect(await droppedConfigKeys(tempDir)).toEqual([]);
     });
   });
 });

--- a/packages/tbd/tests/doc-references.test.ts
+++ b/packages/tbd/tests/doc-references.test.ts
@@ -3,16 +3,27 @@
  * Extracts `tbd shortcut`, `tbd guidelines`, `tbd template` commands and runs them.
  */
 
-import { describe, it, expect, beforeAll } from 'vitest';
-import { readFile, readdir, stat } from 'node:fs/promises';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises';
 import { join, dirname, extname } from 'node:path';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const README_PATH = join(__dirname, '..', '..', '..', 'README.md');
 const TBD_BIN = join(__dirname, '..', 'dist', 'bin.mjs');
 const MONOREPO_ROOT = join(__dirname, '..', '..', '..');
+const SOURCE_GUARD_PATHS = [
+  '.agents/skills/tbd/SKILL.md',
+  '.claude/hooks/tbd-closing-reminder.sh',
+  '.claude/scripts/tbd-session.sh',
+  '.claude/skills/tbd/SKILL.md',
+  '.codex/tbd-closing-reminder.sh',
+  '.codex/tbd-session.sh',
+  '.tbd/config.yml',
+  'AGENTS.md',
+];
 
 /** Directories to scan for doc references */
 const DOC_DIRS = [join(MONOREPO_ROOT, 'docs'), join(MONOREPO_ROOT, 'packages', 'tbd', 'docs')];
@@ -82,14 +93,47 @@ function extractDocCommands(content: string): string[] {
 // This test runs every `tbd shortcut/guidelines/template` command found in docs.
 // Takes ~23s in isolation; under full parallel suite CPU contention pushes it higher.
 describe('doc references', { timeout: 60_000 }, () => {
-  // Ensure docs are installed before running tests
-  beforeAll(() => {
-    // Run tbd setup --auto to install docs (they're gitignored so not present in CI)
-    execSync(`node ${TBD_BIN} setup --auto`, {
+  let managedDiffBefore: string;
+  let commandDir: string;
+  let commandEnv: NodeJS.ProcessEnv;
+
+  beforeAll(async () => {
+    managedDiffBefore = execFileSync('git', ['diff', '--binary', '--', ...SOURCE_GUARD_PATHS], {
       cwd: MONOREPO_ROOT,
       encoding: 'utf-8',
+    });
+    commandDir = await mkdtemp(join(tmpdir(), 'tbd-doc-references-'));
+    commandEnv = {
+      ...process.env,
+      HOME: commandDir,
+      USERPROFILE: commandDir,
+      FORCE_COLOR: '0',
+      NO_COLOR: '1',
+    };
+    execFileSync('git', ['init', '--initial-branch=main'], {
+      cwd: commandDir,
       stdio: 'pipe',
     });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: commandDir });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: commandDir });
+    execFileSync(
+      process.execPath,
+      [TBD_BIN, 'setup', '--auto', '--prefix=test', '--surfaces=portable', '--no-gh-cli'],
+      { cwd: commandDir, env: commandEnv, stdio: 'pipe' },
+    );
+  });
+
+  afterAll(async () => {
+    try {
+      const managedDiffAfter = execFileSync(
+        'git',
+        ['diff', '--binary', '--', ...SOURCE_GUARD_PATHS],
+        { cwd: MONOREPO_ROOT, encoding: 'utf-8' },
+      );
+      expect(managedDiffAfter).toBe(managedDiffBefore);
+    } finally {
+      await rm(commandDir, { recursive: true, force: true });
+    }
   });
 
   it('extracts doc commands from README', async () => {
@@ -129,11 +173,12 @@ describe('doc references', { timeout: 60_000 }, () => {
 
     for (const cmd of allCommands) {
       try {
-        const fullCmd = cmd.replace('tbd', `node ${TBD_BIN}`);
-        const output = execSync(fullCmd, {
-          cwd: MONOREPO_ROOT,
+        const args = cmd.split(' ').slice(1);
+        const output = execFileSync(process.execPath, [TBD_BIN, ...args], {
+          cwd: commandDir,
           encoding: 'utf-8',
           stdio: 'pipe',
+          env: commandEnv,
         });
         // Check for specific "not found" error messages from tbd commands
         // Use precise patterns to avoid false positives from doc content

--- a/packages/tbd/tests/doctor-managed-surfaces.test.ts
+++ b/packages/tbd/tests/doctor-managed-surfaces.test.ts
@@ -6,6 +6,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { subprocessTestTimeout } from './test-helpers.js';
+import { CURRENT_FORMAT } from '../src/lib/tbd-format.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TBD_BIN = join(__dirname, '..', 'dist', 'bin.mjs');
@@ -123,12 +124,12 @@ describe('doctor managed agent surfaces', { timeout: subprocessTestTimeout(45_00
     );
     expect(findingNamed('AGENTS.md').finding).toMatchObject({ status: 'ok', message: 'current' });
 
-    await writeFile(skillPath, expected.replace('format=f06', 'format=f99'));
+    await writeFile(skillPath, expected.replace(`format=${CURRENT_FORMAT}`, 'format=f99'));
     const tooNew = portableFinding();
     expect(tooNew.result.status).toBe(1);
     expect(tooNew.finding).toMatchObject({
       status: 'error',
-      message: 'managed file uses newer integration format f99 (supported: f06)',
+      message: `managed file uses newer integration format f99 (supported: ${CURRENT_FORMAT})`,
       suggestion: 'Upgrade tbd to manage this file: npm install -g get-tbd@latest',
     });
   });

--- a/packages/tbd/tests/doctor-sync.test.ts
+++ b/packages/tbd/tests/doctor-sync.test.ts
@@ -19,7 +19,24 @@ import { extractUlidFromInternalId } from '../src/lib/ids.js';
 import type { Issue } from '../src/lib/types.js';
 import { DATA_SYNC_DIR, TBD_DIR } from '../src/lib/paths.js';
 import { detectDuplicateYamlKeys } from '../src/utils/yaml-utils.js';
+import { droppedIntegrationConfigFinding } from '../src/cli/commands/doctor.js';
 import { TEST_ULIDS, testId, createTestIssue } from './test-helpers.js';
+
+describe('dropped integration config diagnostic', () => {
+  it('ignores unrelated top-level keys', () => {
+    expect(droppedIntegrationConfigFinding(['docs_cache'])).toBeNull();
+  });
+
+  it('reports only the integrations block when it is missing', () => {
+    const finding = droppedIntegrationConfigFinding(['docs_cache', 'integrations']);
+    expect(finding).toMatchObject({
+      name: 'Integrations',
+      status: 'warn',
+    });
+    expect(finding?.message).toContain('`integrations`');
+    expect(finding?.message).not.toContain('`docs_cache`');
+  });
+});
 
 describe('doctor command logic', () => {
   let testDir: string;

--- a/packages/tbd/tests/extract-changelog.test.ts
+++ b/packages/tbd/tests/extract-changelog.test.ts
@@ -8,7 +8,7 @@
  * locks in the regression and lets the workflow invoke it by reference.
  */
 
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -16,7 +16,7 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, it, expect } from 'vitest';
 
-import { extractChangelogSection, resolveReleaseBody } from '../src/utils/changelog.js';
+import { extractChangelogSection, requireChangelogSection } from '../src/utils/changelog.js';
 
 const CHANGELOG = [
   '# Changelog',
@@ -98,13 +98,21 @@ describe('extractChangelogSection', () => {
   });
 });
 
-describe('resolveReleaseBody', () => {
+describe('requireChangelogSection', () => {
   it('returns the section when present', () => {
-    expect(resolveReleaseBody(CHANGELOG, '0.1.0')).toContain('- First release');
+    expect(requireChangelogSection(CHANGELOG, '0.1.0')).toContain('- First release');
   });
 
-  it('falls back to "Release v<version>" when the section is missing', () => {
-    expect(resolveReleaseBody(CHANGELOG, '9.9.9')).toBe('Release v9.9.9');
+  it('fails closed when the section is missing', () => {
+    expect(() => requireChangelogSection(CHANGELOG, '9.9.9')).toThrow(
+      'No changelog section found for version 9.9.9',
+    );
+  });
+
+  it('fails closed when the section has no release notes', () => {
+    expect(() => requireChangelogSection('## 9.9.9\n\n', '9.9.9')).toThrow(
+      'Changelog section for version 9.9.9 has no release notes',
+    );
   });
 });
 
@@ -137,12 +145,18 @@ describe('extract-changelog.ts (CLI wrapper)', () => {
     }
   });
 
-  it('prints the fallback for a missing version', () => {
+  it('fails for a missing version instead of publishing a synthetic release body', () => {
     const dir = mkdtempSync(join(tmpdir(), 'tbd-changelog-cli-'));
     try {
       const changelog = join(dir, 'CHANGELOG.md');
       writeFileSync(changelog, '## 1.0.0\n\n- only release\n');
-      expect(runScript(['9.9.9', changelog]).trim()).toBe('Release v9.9.9');
+      const result = spawnSync(
+        process.execPath,
+        ['--import', 'tsx', scriptPath, '9.9.9', changelog],
+        { encoding: 'utf-8' },
+      );
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('No changelog section found for version 9.9.9');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/tbd/tests/release-metadata.test.ts
+++ b/packages/tbd/tests/release-metadata.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Release metadata must agree before a tag-triggered workflow reaches npm publish.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { verifyReleaseMetadata } from '../src/utils/release-metadata.js';
+
+const CHANGELOG = ['# get-tbd', '', '## 1.2.3', '', '- A real release note', ''].join('\n');
+
+describe('verifyReleaseMetadata', () => {
+  it('returns the exact version and release body when all three sources agree', () => {
+    expect(verifyReleaseMetadata('v1.2.3', '1.2.3', CHANGELOG)).toEqual({
+      version: '1.2.3',
+      releaseBody: ['## 1.2.3', '', '- A real release note'].join('\n'),
+    });
+  });
+
+  it('rejects a tag without the required v prefix', () => {
+    expect(() => verifyReleaseMetadata('1.2.3', '1.2.3', CHANGELOG)).toThrow(
+      'Release tag must start with v',
+    );
+  });
+
+  it('rejects a tag that does not match the package version', () => {
+    expect(() => verifyReleaseMetadata('v1.2.4', '1.2.3', CHANGELOG)).toThrow(
+      'Release tag v1.2.4 does not match package version 1.2.3',
+    );
+  });
+
+  it('rejects a package version without an exact changelog section', () => {
+    expect(() => verifyReleaseMetadata('v1.2.4', '1.2.4', CHANGELOG)).toThrow(
+      'No changelog section found for version 1.2.4',
+    );
+  });
+});
+
+describe('verify-release-metadata.ts', () => {
+  const scriptPath = fileURLToPath(
+    new URL('../scripts/verify-release-metadata.ts', import.meta.url),
+  );
+
+  it('fails before publish when package.json disagrees with the tag', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'tbd-release-metadata-'));
+    try {
+      const packageJson = join(dir, 'package.json');
+      const changelog = join(dir, 'CHANGELOG.md');
+      writeFileSync(packageJson, JSON.stringify({ version: '1.2.3' }));
+      writeFileSync(changelog, CHANGELOG);
+
+      const result = spawnSync(
+        process.execPath,
+        ['--import', 'tsx', scriptPath, 'v1.2.4', packageJson, changelog],
+        { encoding: 'utf-8' },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('Release tag v1.2.4 does not match package version 1.2.3');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/tbd/tests/setup-dry-run-state.test.ts
+++ b/packages/tbd/tests/setup-dry-run-state.test.ts
@@ -18,6 +18,7 @@ import {
   writeFile,
 } from 'node:fs/promises';
 import { execFileSync, spawnSync } from 'node:child_process';
+import { CURRENT_FORMAT } from '../src/lib/tbd-format.js';
 import { tmpdir } from 'node:os';
 import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -154,14 +155,17 @@ describe('setup --auto --dry-run whole-state invariant', { timeout: 45_000 }, ()
 
     const configPath = join(projectDir, '.tbd', 'config.yml');
     const config = (await readFile(configPath, 'utf-8'))
-      .replace('tbd_format: f06', 'tbd_format: f05')
+      .replace(`tbd_format: ${CURRENT_FORMAT}`, 'tbd_format: f05')
       .replace(/^tbd_version:.*$/m, 'tbd_version: 0.3.0');
     await writeFile(configPath, config);
 
     const layoutPath = join(sharedTbdDir, 'layout.yml');
     await writeFile(
       layoutPath,
-      (await readFile(layoutPath, 'utf-8')).replace('tbd_format: f06', 'tbd_format: f05'),
+      (await readFile(layoutPath, 'utf-8')).replace(
+        `tbd_format: ${CURRENT_FORMAT}`,
+        'tbd_format: f05',
+      ),
     );
 
     await writeFile(join(projectDir, '.tbd', '.gitignore'), '# stale\n');
@@ -209,6 +213,7 @@ describe('setup --auto --dry-run whole-state invariant', { timeout: 45_000 }, ()
 
     expect(result.status).toBe(0);
     expect(output).toContain('Updated tbd_format: f06');
+    expect(output).toContain(`Updated tbd_format: ${CURRENT_FORMAT}`);
     expect(output).toMatch(/\[DRY-RUN\].*[Ww]ould update .*config/i);
     expect(output).toMatch(/\[DRY-RUN\].*[Ww]ould update \.tbd\/\.gitignore/i);
     expect(output).toMatch(/\[DRY-RUN\].*[Ww]ould update \.tbd\/\.gitattributes/i);
@@ -230,7 +235,7 @@ describe('setup --auto --dry-run whole-state invariant', { timeout: 45_000 }, ()
     const mirrorPath = join(projectDir, '.claude', 'skills', 'tbd', 'SKILL.md');
     await writeFile(
       mirrorPath,
-      (await readFile(mirrorPath, 'utf-8')).replace('format=f06', 'format=f99'),
+      (await readFile(mirrorPath, 'utf-8')).replace(`format=${CURRENT_FORMAT}`, 'format=f99'),
     );
     const before = await snapshotAllState();
 

--- a/packages/tbd/tests/setup-flows.test.ts
+++ b/packages/tbd/tests/setup-flows.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execSync, spawnSync } from 'node:child_process';
 import { subprocessTestTimeout } from './test-helpers.js';
+import { CURRENT_FORMAT } from '../src/lib/tbd-format.js';
 
 describe('setup flows', { timeout: subprocessTestTimeout() }, () => {
   let tempDir: string;
@@ -182,7 +183,9 @@ describe('setup flows', { timeout: subprocessTestTimeout() }, () => {
       expect(result.status).toBe(0);
 
       const agents = await readFile(join(tempDir, 'AGENTS.md'), 'utf-8');
-      expect(agents).toContain('<!-- BEGIN TBD INTEGRATION format=f06 surface=agents-md -->');
+      expect(agents).toContain(
+        `<!-- BEGIN TBD INTEGRATION format=${CURRENT_FORMAT} surface=agents-md -->`,
+      );
       expect(agents).toContain('tbd prime');
 
       const block = agents.slice(
@@ -280,7 +283,7 @@ describe('setup flows', { timeout: subprocessTestTimeout() }, () => {
 
       const agents = await readFile(join(tempDir, 'AGENTS.md'), 'utf-8');
       // Upgraded to the versioned compact block...
-      expect(agents).toContain('format=f06');
+      expect(agents).toContain(`format=${CURRENT_FORMAT}`);
       // ...while preserving user content outside the managed region.
       expect(agents).toContain('## My Notes');
       expect(agents).toContain('Keep me.');

--- a/packages/tbd/tests/tbd-format.test.ts
+++ b/packages/tbd/tests/tbd-format.test.ts
@@ -20,7 +20,7 @@ import {
 describe('tbd-format', () => {
   describe('constants', () => {
     it('has current format', () => {
-      expect(CURRENT_FORMAT).toBe('f06');
+      expect(CURRENT_FORMAT).toBe('f07');
     });
 
     it('has initial format', () => {
@@ -34,6 +34,7 @@ describe('tbd-format', () => {
       expect(FORMAT_HISTORY.f04).toBeDefined();
       expect(FORMAT_HISTORY.f05).toBeDefined();
       expect(FORMAT_HISTORY.f06).toBeDefined();
+      expect(FORMAT_HISTORY.f07).toBeDefined();
     });
   });
 
@@ -70,9 +71,9 @@ describe('tbd-format', () => {
       expect(needsMigration(config)).toBe(true);
     });
 
-    it('returns true when format is f05 (one behind current)', () => {
+    it('returns true when format is f06 (one behind current)', () => {
       const config: RawConfig = {
-        tbd_format: 'f05',
+        tbd_format: 'f06',
         tbd_version: '0.3.0',
       };
       expect(needsMigration(config)).toBe(true);
@@ -88,7 +89,7 @@ describe('tbd-format', () => {
   });
 
   describe('migrateToLatest', () => {
-    it('migrates f01 to f06 through all format steps', () => {
+    it('migrates f01 to f07 through all format steps', () => {
       const config: RawConfig = {
         tbd_version: '0.1.0',
         display: { id_prefix: 'test' },
@@ -99,9 +100,9 @@ describe('tbd-format', () => {
       const result = migrateToLatest(config);
 
       expect(result.fromFormat).toBe('f01');
-      expect(result.toFormat).toBe('f06');
+      expect(result.toFormat).toBe('f07');
       expect(result.changed).toBe(true);
-      expect(result.config.tbd_format).toBe('f06');
+      expect(result.config.tbd_format).toBe('f07');
       expect(result.config.sync?.storage).toBe('git-common-dir-v1');
       expect(result.config.settings?.doc_auto_sync_hours).toBe(24);
       expect(result.changes).toContain('Added tbd_format: f02');
@@ -111,11 +112,12 @@ describe('tbd-format', () => {
       expect(result.changes).toContain('Added sync.storage: git-common-dir-v1');
       expect(result.changes).toContain('Updated tbd_format: f05');
       expect(result.changes).toContain('Updated tbd_format: f06');
+      expect(result.changes).toContain('Updated tbd_format: f07');
       // f06 seeds the upgrade history from the existing tbd_version (no timestamp).
       expect(result.config.tbd_upgrades).toEqual([{ version: '0.1.0' }]);
     });
 
-    it('migrates f02 to f06 (multi-revision jump, guards against a dropped rung)', () => {
+    it('migrates f02 to f07 (multi-revision jump, guards against a dropped rung)', () => {
       const config: RawConfig = {
         tbd_format: 'f02',
         tbd_version: '0.1.5',
@@ -128,9 +130,9 @@ describe('tbd-format', () => {
       const result = migrateToLatest(config);
 
       expect(result.fromFormat).toBe('f02');
-      expect(result.toFormat).toBe('f06');
+      expect(result.toFormat).toBe('f07');
       expect(result.changed).toBe(true);
-      expect(result.config.tbd_format).toBe('f06');
+      expect(result.config.tbd_format).toBe('f07');
       expect(result.config.sync?.storage).toBe('git-common-dir-v1');
       // doc_cache moved to docs_cache.files
       expect(result.config.doc_cache).toBeUndefined();
@@ -149,7 +151,7 @@ describe('tbd-format', () => {
 
     it('does not modify already current config', () => {
       const config: RawConfig = {
-        tbd_format: 'f06',
+        tbd_format: CURRENT_FORMAT,
         tbd_version: '0.3.0',
         tbd_upgrades: [{ version: '0.3.0', at: '2026-06-12T09:10:00.000Z' }],
         sync: { branch: 'tbd-sync', remote: 'origin', storage: 'git-common-dir-v1' },
@@ -163,15 +165,15 @@ describe('tbd-format', () => {
 
       const result = migrateToLatest(config);
 
-      expect(result.fromFormat).toBe('f06');
-      expect(result.toFormat).toBe('f06');
+      expect(result.fromFormat).toBe(CURRENT_FORMAT);
+      expect(result.toFormat).toBe(CURRENT_FORMAT);
       expect(result.changed).toBe(false);
       expect(result.changes).toHaveLength(0);
       expect(result.config.settings?.doc_auto_sync_hours).toBe(12);
       expect(result.config.sync?.storage).toBe('git-common-dir-v1');
     });
 
-    it('migrates f03 through f04 (sync storage marker) to f06', () => {
+    it('migrates f03 through f04 (sync storage marker) to f07', () => {
       const config: RawConfig = {
         tbd_format: 'f03',
         tbd_version: '0.1.6',
@@ -183,9 +185,9 @@ describe('tbd-format', () => {
       const result = migrateToLatest(config);
 
       expect(result.fromFormat).toBe('f03');
-      expect(result.toFormat).toBe('f06');
+      expect(result.toFormat).toBe('f07');
       expect(result.changed).toBe(true);
-      expect(result.config.tbd_format).toBe('f06');
+      expect(result.config.tbd_format).toBe('f07');
       expect(result.config.sync).toEqual({
         branch: 'custom-sync',
         remote: 'upstream',
@@ -209,16 +211,17 @@ describe('tbd-format', () => {
       const result = migrateToLatest(config);
 
       expect(result.fromFormat).toBe('f05');
-      expect(result.toFormat).toBe('f06');
+      expect(result.toFormat).toBe('f07');
       expect(result.changed).toBe(true);
       expect(result.changes).toEqual([
         'Updated tbd_format: f06',
         'Seeded tbd_upgrades history from tbd_version',
+        'Updated tbd_format: f07',
       ]);
       // Only the format stamp and the seeded history change; everything else is verbatim.
       expect(result.config).toEqual({
         ...config,
-        tbd_format: 'f06',
+        tbd_format: 'f07',
         tbd_upgrades: [{ version: '0.2.3' }],
       });
     });
@@ -231,7 +234,7 @@ describe('tbd-format', () => {
 
       const result = migrateToLatest(config);
 
-      expect(result.toFormat).toBe('f06');
+      expect(result.toFormat).toBe('f07');
       expect(result.config.tbd_upgrades).toEqual([]);
     });
 
@@ -245,12 +248,45 @@ describe('tbd-format', () => {
 
       const result = migrateToLatest(config);
 
-      expect(result.toFormat).toBe('f06');
+      expect(result.toFormat).toBe('f07');
       expect(result.config.tbd_upgrades).toEqual([
         { version: '0.2.0' },
         { version: '0.3.0', at: '2026-06-12T00:00:00.000Z' },
       ]);
-      expect(result.changes).toEqual(['Updated tbd_format: f06']);
+      expect(result.changes).toEqual(['Updated tbd_format: f06', 'Updated tbd_format: f07']);
+    });
+
+    it('migrates f06 to f07 as a stamp only, leaving an integrations block untouched', () => {
+      const config: RawConfig = {
+        tbd_format: 'f06',
+        tbd_version: '0.5.0',
+        tbd_upgrades: [{ version: '0.5.0', at: '2026-08-11T01:21:24.535Z' }],
+        display: { id_prefix: 'test' },
+        sync: { branch: 'tbd-sync', remote: 'origin', storage: 'git-common-dir-v1' },
+        settings: { auto_sync: false, doc_auto_sync_hours: 24 },
+        integrations: { linear: { enabled: true, team_key: 'FIN' } },
+      };
+
+      const result = migrateToLatest(config);
+
+      expect(result.fromFormat).toBe('f06');
+      expect(result.toFormat).toBe('f07');
+      expect(result.changes).toEqual(['Updated tbd_format: f07']);
+      // Nothing but the stamp moves: the block is written by integration setup.
+      expect(result.config).toEqual({ ...config, tbd_format: 'f07' });
+    });
+
+    it('is idempotent: re-migrating an f07 config changes nothing', () => {
+      const once = migrateToLatest({
+        tbd_format: 'f06',
+        tbd_version: '0.5.0',
+        display: { id_prefix: 'test' },
+      });
+      const twice = migrateToLatest(once.config);
+
+      expect(twice.changed).toBe(false);
+      expect(twice.changes).toHaveLength(0);
+      expect(twice.config).toEqual(once.config);
     });
 
     it('preserves existing settings when migrating', () => {
@@ -295,6 +331,10 @@ describe('tbd-format', () => {
       expect(isCompatibleFormat('f06')).toBe(true);
     });
 
+    it('returns true for f07', () => {
+      expect(isCompatibleFormat('f07')).toBe(true);
+    });
+
     it('returns false for unknown future format', () => {
       expect(isCompatibleFormat('f99')).toBe(false);
     });
@@ -311,6 +351,12 @@ describe('tbd-format', () => {
 
     it('models old f05 clients rejecting f06 repositories (the upgrade-history gate)', () => {
       expect(isFormatCompatibleWithSupported('f06', 'f05')).toBe(false);
+    });
+
+    it('models pre-0.6.0 clients rejecting f07 repositories (the integrations-config gate)', () => {
+      // The whole point of f07: a client that parses config in strip mode must fail
+      // closed rather than silently dropping the integrations block on its next write.
+      expect(isFormatCompatibleWithSupported('f07', 'f06')).toBe(false);
     });
 
     it('allows old clients to read older formats they know how to migrate', () => {
@@ -333,33 +379,35 @@ describe('tbd-format', () => {
   });
 
   describe('describeMigration', () => {
-    it('describes f01 migration (five steps)', () => {
+    it('describes f01 migration (six steps)', () => {
       const descriptions = describeMigration('f01');
-      expect(descriptions).toHaveLength(5);
+      expect(descriptions).toHaveLength(6);
       expect(descriptions[0]).toContain('f01 → f02');
       expect(descriptions[1]).toContain('f02 → f03');
       expect(descriptions[2]).toContain('f03 → f04');
       expect(descriptions[3]).toContain('f04 → f05');
       expect(descriptions[4]).toContain('f05 → f06');
+      expect(descriptions[5]).toContain('f06 → f07');
     });
 
     it('describes f02 migration', () => {
       const descriptions = describeMigration('f02');
-      expect(descriptions).toHaveLength(4);
+      expect(descriptions).toHaveLength(5);
       expect(descriptions[0]).toContain('f02 → f03');
       expect(descriptions[1]).toContain('f03 → f04');
       expect(descriptions[2]).toContain('f04 → f05');
       expect(descriptions[3]).toContain('f05 → f06');
+      expect(descriptions[4]).toContain('f06 → f07');
     });
 
-    it('describes f05 migration (one step)', () => {
-      const descriptions = describeMigration('f05');
+    it('describes f06 migration (one step)', () => {
+      const descriptions = describeMigration('f06');
       expect(descriptions).toHaveLength(1);
-      expect(descriptions[0]).toContain('f05 → f06');
+      expect(descriptions[0]).toContain('f06 → f07');
     });
 
     it('returns empty for current format', () => {
-      const descriptions = describeMigration('f06');
+      const descriptions = describeMigration(CURRENT_FORMAT);
       expect(descriptions).toHaveLength(0);
     });
   });


### PR DESCRIPTION
Closes the config-loss hole the Linear pilot hit three times and prepares the release commit for **get-tbd v0.6.0**.

> [!IMPORTANT]
> This PR must merge before the release is tagged. The repository itself must not be stamped f07 until 0.6.0 is published and verified, because stamping earlier would lock out sessions still resolving get-tbd@latest to 0.5.0.

## Problem

`integrations` is a new top-level config key. Every tbd release before 0.6.0 parses config in Zod strip mode, so a rewrite can silently delete that block. The bead side is safe because links live under `extensions`; the config side needs an explicit compatibility gate.

## Changes

- Bump the repository format contract from f06 to f07 with a stamp-only migration. Pre-0.6.0 clients fail closed with an upgrade message.
- Make `ConfigSchema`, `IntegrationsConfigSchema`, and provider objects passthrough so future additive keys survive f07-or-later round trips.
- Detect a committed-but-locally-missing `integrations` block in `tbd doctor` without mislabeling unrelated key removals.
- Make the Linear setup flow stamp the repository after writing integration configuration.
- Set the package and changelog to 0.6.0 and document the mixed-version and post-publish sequencing contract.

## Senior review disposition

Formal review [4934238677](https://github.com/jlevy/tbd/pull/216#pullrequestreview-4934238677) found five issues. Commit `bbad205b` addresses all five:

- **R1 — release metadata mismatch (Blocker):** the tag-triggered workflow now verifies that the exact tag, package version, and non-empty changelog section agree before npm publish. Changelog extraction fails closed instead of synthesizing a generic body.
- **R2 — doctor false positive (Medium):** the direct loss detector warns only when `integrations` itself disappeared.
- **R3 — inaccurate upgrade note (Medium):** the changelog now tells users to run `tbd setup --auto`, the operation that actually persists f07 and refreshes managed surfaces.
- **R4 — contradictory design docs (Medium):** the canonical design and format-version comments now describe f07 passthrough and distinguish additive-safe changes from destructive or semantic changes. The earlier experiment spec has a dated supersession note.
- **R5 — test suite mutated the source checkout (Blocker):** documentation-reference commands now run in an isolated temporary repository and the test asserts that managed source paths are unchanged.

No actionable review thread remains unresolved.

## Release sequence

1. Merge this PR.
2. Require CI success on the exact merge commit.
3. Tag that exact commit `v0.6.0`.
4. Require the tag-triggered release workflow to publish npm and the GitHub release successfully.
5. Verify package integrity, provenance, version output, and release notes.
6. Run the exact published 0.6.0 `setup --auto` in a clean main worktree and land the f07 repository stamp in a follow-up PR tracked by `tbd-m8rs`.

## Validation

- `pnpm run ci`: formatting, Markdown, typecheck, ESLint, build, and **2,003 tests across 136 files** passed.
- The pre-push hook independently repeated the quality gate, build check, and all 2,003 tests successfully.
- Exact release metadata verification for `v0.6.0`, `pnpm release:verify`, publint, production audit, and the 31-pin package-age gate passed.
- Packed web-package QA passed.
- Tryscript packaged-CLI QA passed all **1,085** scenarios.
- A real published 0.5.0 artifact was integrity- and provenance-verified against the first-party jlevy/tbd tag. The upgrade proof preserved unknown top-level, provider, and settings keys across f06→f07, while the old 0.5.0 CLI rejected f07 without changing the config.
- Production dependencies have no known audit findings. Development-only advisories are separately tracked in `tbd-gx3a`; the reviewed js-yaml security upgrade has its documented exception and human approval.

Review and release tracking: `tbd-hcwg`, `tbd-kmd5`, `tbd-134h`, `tbd-a0gl`, `tbd-g9jv`, `tbd-apf8`, and parent `tbd-f5zb`.