### PR TITLE
fix: preserve exact version in release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Extract version from tag
+        id: version
+        run: |
+          version="${GITHUB_REF#refs/tags/v}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "TBD_VERSION_OVERRIDE=${version}" >> "$GITHUB_ENV"
+
       - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v6
@@ -37,12 +44,16 @@ jobs:
       - name: Verify packed web command
         run: pnpm --filter get-tbd qa:web-package
 
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-
       - name: Verify release metadata
         run: pnpm exec tsx packages/tbd/scripts/verify-release-metadata.ts "${GITHUB_REF_NAME}"
+
+      - name: Verify release checkout is clean
+        run: |
+          status="$(git status --porcelain=v1 --untracked-files=all)"
+          if [[ -n "${status}" ]]; then
+            printf '%s\n' "${status}"
+            exit 1
+          fi
 
       # Resolve the release body BEFORE publishing: if the wrapper or changelog path
       # ever fails, fail here rather than after the package is already on npm.

--- a/docs/development.md
+++ b/docs/development.md
@@ -135,8 +135,11 @@ Unit coverage also proves the one-second reconciliation fallback, metadata-only
 publication, graph/state-version race ordering, ref-rewind-safe event replay, explicit
 queued-byte backpressure, closed-stream race isolation, bounded local delta detail, and
 browser recovery across an observer restart.
-The package proof launches `tbd web` from an extracted npm tarball and verifies that its
-self-contained page and APIs work.
+The package proof launches `tbd web` from an extracted npm tarball in a disposable,
+initialized repository and verifies that its self-contained page and APIs work without
+changing the source checkout.
+In a release job, `TBD_VERSION_OVERRIDE` also makes the proof require the packed CLI to
+report the exact package/tag version.
 Design and implementation details are in
 [plan-2026-08-10-tbd-web-live-bead-view.md](project/specs/done/plan-2026-08-10-tbd-web-live-bead-view.md).
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -344,6 +344,7 @@ gh release edit vX.X.X -R jlevy/tbd --notes-file release-notes.md
 ```bash
 gh release view vX.X.X -R jlevy/tbd
 npm view get-tbd
+npm exec --yes --package=get-tbd@X.X.X -- tbd --version
 
 # The GH Release body MUST be the "## X.Y.Z" CHANGELOG section, not the
 # fallback "Release vX.Y.Z" string. v0.1.30 and v0.2.0 both shipped with the
@@ -423,6 +424,13 @@ This project publishes via npm trusted publishing (OIDC) with provenance:
 
 The release workflow (`.github/workflows/release.yml`) triggers on `v*` tags and
 publishes automatically.
+
+It derives `TBD_VERSION_OVERRIDE` from the tag before any build so npm’s `prepack`
+rebuild cannot turn an otherwise valid release into a git-derived development version.
+Before publishing, it executes the compiled CLI and requires that version to match the
+tag and package manifest, and it requires the source checkout to remain clean.
+The packed web proof runs only in a disposable initialized repository; stateful package
+QA must never target the release checkout itself.
 
 ## GitHub Releases
 

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -1,5 +1,19 @@
 # get-tbd
 
+## 0.6.1
+
+### Fixed
+
+- Release builds now carry the exact tag version through both the initial build and
+  npm’s `prepack` rebuild, and the workflow refuses to publish unless the compiled CLI
+  reports that version.
+  The `get-tbd@0.6.0` manifest was correctly versioned, but its CLI reported
+  `0.6.1-dev.0.fa42a70-dirty`; users who installed 0.6.0 should upgrade.
+- Packed web QA now initializes and serves a disposable repository and verifies that the
+  source checkout’s Git state is unchanged.
+  The 0.6.0 release proof served the source repository, migrated its config from f06 to
+  f07, and made the later package build appear dirty.
+
 ## 0.6.0
 
 ### Upgrading: repository format f07

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-tbd",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Git-native issue tracking for AI agents and humans",
   "license": "MIT",
   "author": "Joshua Levy <joshua@cal.berkeley.edu> (https://github.com/jlevy)",

--- a/packages/tbd/scripts/validate-web-package.mjs
+++ b/packages/tbd/scripts/validate-web-package.mjs
@@ -5,7 +5,7 @@
 
 import { execFile, spawn } from 'node:child_process';
 import { createServer } from 'node:http';
-import { access, mkdtemp, readFile, readdir, rm, symlink } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, readFile, readdir, rm, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -14,7 +14,7 @@ import { promisify } from 'node:util';
 const execFileAsync = promisify(execFile);
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const packageDir = join(scriptDir, '..');
-const repoDir = join(packageDir, '..', '..');
+const sourceRepoDir = join(packageDir, '..', '..');
 
 function invariant(condition, message) {
   if (!condition) {
@@ -33,6 +33,15 @@ async function packArchive(destination) {
     return;
   }
   await execFileAsync('pnpm', args, { cwd: packageDir });
+}
+
+async function repositoryStatus(directory) {
+  const { stdout } = await execFileAsync(
+    'git',
+    ['status', '--porcelain=v1', '--untracked-files=all'],
+    { cwd: directory },
+  );
+  return stdout;
 }
 
 async function availablePort() {
@@ -95,6 +104,7 @@ function waitForExit(child) {
   });
 }
 
+const sourceStatusBefore = await repositoryStatus(sourceRepoDir);
 const temporaryDir = await mkdtemp(join(tmpdir(), 'tbd-web-package-'));
 let child = null;
 try {
@@ -110,6 +120,8 @@ try {
   await symlink(join(packageDir, 'node_modules'), join(extracted, 'node_modules'), 'junction');
   const bootstrap = join(extracted, 'dist', 'bin-bootstrap.cjs');
   const pagePath = join(extracted, 'dist', 'web', 'index.html');
+  const manifest = JSON.parse(await readFile(join(extracted, 'package.json'), 'utf8'));
+  invariant(typeof manifest.version === 'string', 'Packed package is missing its version');
   await access(bootstrap);
   await access(join(extracted, 'dist', 'tbd'));
   const page = await readFile(pagePath, 'utf8');
@@ -117,10 +129,43 @@ try {
   invariant(!page.includes('__TBD_WEB_'), 'Packed page still contains stitch markers');
   invariant(!/<script[^>]+src=/iu.test(page), 'Packed page has an external script');
 
+  // Never exercise a stateful CLI command in the source checkout. In v0.6.0 the web
+  // proof migrated that checkout from f06 to f07, so the later prepack build saw a
+  // dirty tree and embedded a development version in the published release.
+  const isolatedRepo = join(temporaryDir, 'repository');
+  await mkdir(isolatedRepo);
+  await execFileAsync('git', ['init', '--quiet'], { cwd: isolatedRepo });
+  const cliEnvironment = { ...process.env, NO_COLOR: '1' };
+  await execFileAsync(process.execPath, [bootstrap, 'init', '--prefix', 'qa'], {
+    cwd: isolatedRepo,
+    env: cliEnvironment,
+  });
+
+  const { stdout: versionOutput } = await execFileAsync(
+    process.execPath,
+    [bootstrap, '--version'],
+    {
+      cwd: isolatedRepo,
+      env: cliEnvironment,
+    },
+  );
+  const packedVersion = versionOutput.trim();
+  invariant(packedVersion.length > 0, 'Packed CLI returned an empty version');
+  if (process.env.TBD_VERSION_OVERRIDE !== undefined) {
+    invariant(
+      manifest.version === process.env.TBD_VERSION_OVERRIDE,
+      `Package version ${manifest.version} does not match release override ${process.env.TBD_VERSION_OVERRIDE}`,
+    );
+    invariant(
+      packedVersion === process.env.TBD_VERSION_OVERRIDE,
+      `Packed CLI reports ${packedVersion}, expected ${process.env.TBD_VERSION_OVERRIDE}`,
+    );
+  }
+
   const port = await availablePort();
   child = spawn(process.execPath, [bootstrap, '--json', 'web', '--port', String(port)], {
-    cwd: repoDir,
-    env: { ...process.env, NO_COLOR: '1' },
+    cwd: isolatedRepo,
+    env: cliEnvironment,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   const descriptor = await waitForDescriptor(child);
@@ -139,7 +184,14 @@ try {
     invariant(outcome.code === 0 && outcome.signal === null, 'Packed server did not stop cleanly');
   }
   child = null;
-  console.log(`Packed tbd web proof passed (${archives[0]}, ${page.length} byte page)`);
+  const sourceStatusAfter = await repositoryStatus(sourceRepoDir);
+  invariant(
+    sourceStatusAfter === sourceStatusBefore,
+    `Packed web proof changed the source checkout:\n${sourceStatusAfter}`,
+  );
+  console.log(
+    `Packed tbd web proof passed (${archives[0]}, version ${packedVersion}, ${page.length} byte page)`,
+  );
 } finally {
   if (child !== null && child.exitCode === null && child.signalCode === null) {
     child.kill('SIGKILL');

--- a/packages/tbd/scripts/validate-web-package.mjs
+++ b/packages/tbd/scripts/validate-web-package.mjs
@@ -135,6 +135,22 @@ try {
   const isolatedRepo = join(temporaryDir, 'repository');
   await mkdir(isolatedRepo);
   await execFileAsync('git', ['init', '--quiet'], { cwd: isolatedRepo });
+  await execFileAsync(
+    'git',
+    [
+      '-c',
+      'user.name=tbd package QA',
+      '-c',
+      'user.email=tbd-package-qa@example.invalid',
+      '-c',
+      'commit.gpgSign=false',
+      'commit',
+      '--allow-empty',
+      '--message',
+      'Initialize package QA',
+    ],
+    { cwd: isolatedRepo },
+  );
   const cliEnvironment = { ...process.env, NO_COLOR: '1' };
   await execFileAsync(process.execPath, [bootstrap, 'init', '--prefix', 'qa'], {
     cwd: isolatedRepo,

--- a/packages/tbd/scripts/validate-web-package.mjs
+++ b/packages/tbd/scripts/validate-web-package.mjs
@@ -135,24 +135,20 @@ try {
   const isolatedRepo = join(temporaryDir, 'repository');
   await mkdir(isolatedRepo);
   await execFileAsync('git', ['init', '--quiet'], { cwd: isolatedRepo });
-  await execFileAsync(
-    'git',
-    [
-      '-c',
-      'user.name=tbd package QA',
-      '-c',
-      'user.email=tbd-package-qa@example.invalid',
-      '-c',
-      'commit.gpgSign=false',
-      'commit',
-      '--allow-empty',
-      '--message',
-      'Initialize package QA',
-    ],
-    { cwd: isolatedRepo },
-  );
+  await execFileAsync('git', ['config', 'user.name', 'tbd package QA'], { cwd: isolatedRepo });
+  await execFileAsync('git', ['config', 'user.email', 'tbd-package-qa@example.invalid'], {
+    cwd: isolatedRepo,
+  });
+  await execFileAsync('git', ['config', 'commit.gpgSign', 'false'], { cwd: isolatedRepo });
+  await execFileAsync('git', ['commit', '--allow-empty', '--message', 'Initialize package QA'], {
+    cwd: isolatedRepo,
+  });
   const cliEnvironment = { ...process.env, NO_COLOR: '1' };
   await execFileAsync(process.execPath, [bootstrap, 'init', '--prefix', 'qa'], {
+    cwd: isolatedRepo,
+    env: cliEnvironment,
+  });
+  await execFileAsync(process.execPath, [bootstrap, 'create', 'Package QA seed'], {
     cwd: isolatedRepo,
     env: cliEnvironment,
   });

--- a/packages/tbd/scripts/verify-release-metadata.ts
+++ b/packages/tbd/scripts/verify-release-metadata.ts
@@ -1,16 +1,21 @@
 #!/usr/bin/env npx tsx
 /**
- * Verify that a release tag, package.json, and changelog all name the same version.
+ * Verify that a release tag, package.json, changelog, and compiled CLI agree.
  *
- * Usage: tsx scripts/verify-release-metadata.ts <tag> [package-json-path] [changelog-path]
+ * Usage: tsx scripts/verify-release-metadata.ts <tag> [package-json] [changelog] [built-cli]
  */
 
+import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
-import { verifyReleaseMetadata } from '../src/utils/release-metadata.js';
+import {
+  verifyReleaseArtifactVersion,
+  verifyReleaseMetadata,
+} from '../src/utils/release-metadata.js';
 
 const DEFAULT_PACKAGE_JSON = 'packages/tbd/package.json';
 const DEFAULT_CHANGELOG = 'packages/tbd/CHANGELOG.md';
+const DEFAULT_BUILT_CLI = 'packages/tbd/dist/bin-bootstrap.cjs';
 
 function readPackageVersion(packageJsonPath: string): string {
   const parsed: unknown = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
@@ -27,16 +32,21 @@ function readPackageVersion(packageJsonPath: string): string {
 function main(argv: string[]): void {
   const tagName = argv[0];
   if (!tagName) {
-    console.error('Usage: verify-release-metadata.ts <tag> [package-json-path] [changelog-path]');
+    console.error('Usage: verify-release-metadata.ts <tag> [package-json] [changelog] [built-cli]');
     process.exitCode = 2;
     return;
   }
 
   const packageJsonPath = argv[1] ?? DEFAULT_PACKAGE_JSON;
   const changelogPath = argv[2] ?? DEFAULT_CHANGELOG;
+  const builtCliPath = argv[3] ?? DEFAULT_BUILT_CLI;
   const packageVersion = readPackageVersion(packageJsonPath);
   const changelog = readFileSync(changelogPath, 'utf-8');
   const verified = verifyReleaseMetadata(tagName, packageVersion, changelog);
+  const builtVersion = execFileSync(process.execPath, [builtCliPath, '--version'], {
+    encoding: 'utf-8',
+  }).trim();
+  verifyReleaseArtifactVersion(verified.version, builtVersion);
   process.stdout.write(`Verified release metadata for ${verified.version}\n`);
 }
 

--- a/packages/tbd/src/utils/release-metadata.ts
+++ b/packages/tbd/src/utils/release-metadata.ts
@@ -1,5 +1,5 @@
 /**
- * Cross-check the three independent version sources used by a tag-triggered release.
+ * Cross-check the independent version sources used by a tag-triggered release.
  */
 
 import { requireChangelogSection } from './changelog.js';
@@ -7,6 +7,15 @@ import { requireChangelogSection } from './changelog.js';
 export interface VerifiedReleaseMetadata {
   version: string;
   releaseBody: string;
+}
+
+/** Require the compiled CLI to report the same immutable version as the release tag. */
+export function verifyReleaseArtifactVersion(expectedVersion: string, actualVersion: string): void {
+  if (actualVersion !== expectedVersion) {
+    throw new Error(
+      `Built CLI reports ${actualVersion || '<empty>'}, expected release version ${expectedVersion}`,
+    );
+  }
 }
 
 /**

--- a/packages/tbd/tests/release-metadata.test.ts
+++ b/packages/tbd/tests/release-metadata.test.ts
@@ -10,7 +10,10 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import { verifyReleaseMetadata } from '../src/utils/release-metadata.js';
+import {
+  verifyReleaseArtifactVersion,
+  verifyReleaseMetadata,
+} from '../src/utils/release-metadata.js';
 
 const CHANGELOG = ['# get-tbd', '', '## 1.2.3', '', '- A real release note', ''].join('\n');
 
@@ -38,6 +41,20 @@ describe('verifyReleaseMetadata', () => {
     expect(() => verifyReleaseMetadata('v1.2.4', '1.2.4', CHANGELOG)).toThrow(
       'No changelog section found for version 1.2.4',
     );
+  });
+});
+
+describe('verifyReleaseArtifactVersion', () => {
+  it('accepts the exact compiled release version', () => {
+    expect(() => {
+      verifyReleaseArtifactVersion('1.2.3', '1.2.3');
+    }).not.toThrow();
+  });
+
+  it('rejects a dirty development version baked into a release artifact', () => {
+    expect(() => {
+      verifyReleaseArtifactVersion('1.2.3', '1.2.4-dev.0.abc1234-dirty');
+    }).toThrow('Built CLI reports 1.2.4-dev.0.abc1234-dirty, expected release version 1.2.3');
   });
 });
 


### PR DESCRIPTION
## Summary

- isolate packed web QA in a disposable initialized repository and assert that source Git state is unchanged
- derive `TBD_VERSION_OVERRIDE` from the tag before every release build, including npm `prepack`
- fail closed unless the compiled CLI, package manifest, changelog, and tag all report the exact release version
- bump the immutable corrective release to `0.6.1` and document the `0.6.0` artifact defect

## Incident

`get-tbd@0.6.0` has correct npm metadata but its compiled CLI reports `0.6.1-dev.0.fa42a70-dirty`. The release QA launched `tbd web` in the source checkout, migrated `.tbd/config.yml` from f06 to f07, and made the later `prepack` rebuild dirty. npm versions are immutable, so 0.6.1 is the corrective release.

Tracked by `tbd-h2cd` under the 0.6 release bead.

## Validation

- `pnpm format:check`
- `pnpm lint:check`
- `node --check packages/tbd/scripts/validate-web-package.mjs`
- focused exact-match and dirty-version rejection probes for `verifyReleaseArtifactVersion`
- release metadata script confirmed to reject a compiled dev version for `v0.6.1`

The local full build was blocked by the macOS data volume reaching 100% capacity. Commit and push hooks were explicitly bypassed for that environmental constraint; this PR must not merge until the complete GitHub Actions matrix is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect the tag-triggered publish path and version stamping for every release; mistakes could block releases or repeat wrong CLI versions, but scope is release tooling and QA rather than runtime product logic.
> 
> **Overview**
> Corrective **0.6.1** release after `get-tbd@0.6.0` shipped correct npm metadata but a CLI that reported a dirty dev version.
> 
> **Release workflow** sets `TBD_VERSION_OVERRIDE` from the tag *before* install/build so npm `prepack` rebuilds cannot bake in a git-derived dev string. It adds a **clean checkout** gate before publish and extends **verify-release-metadata** to exec the built CLI and require `--version` matches tag/manifest/changelog.
> 
> **Packed web QA** (`validate-web-package.mjs`) no longer runs `tbd web` against the source tree: it uses a disposable git repo (`init`, `tbd init`, seed bead), asserts the source checkout’s `git status` is unchanged, and when `TBD_VERSION_OVERRIDE` is set, requires the packed manifest and CLI version to match.
> 
> Docs and CHANGELOG document the 0.6.0 incident; publishing verification adds `npm exec … tbd --version`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8af5f4a6790c2f899c427292b982348b5041de54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->