### PR TITLE
fix: make repository upgrades repeatable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
       - name: Run packed web proof
         run: pnpm --filter get-tbd qa:web-package
 
+      - name: Run packed upgrade proof
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == 24 }}
+        run: pnpm --filter get-tbd qa:upgrade-package
+
   coverage:
     name: Coverage & Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Verify packed web command
         run: pnpm --filter get-tbd qa:web-package
 
+      - name: Verify packaged upgrades
+        run: pnpm --filter get-tbd qa:upgrade-package
+
       - name: Verify release metadata
         run: pnpm exec tsx packages/tbd/scripts/verify-release-metadata.ts "${GITHUB_REF_NAME}"
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -126,6 +126,7 @@ pnpm --filter get-tbd exec vitest run \
   tests/web-*.test.ts tests/cli-web.test.ts tests/bead-web-css.test.ts
 pnpm --filter get-tbd exec tryscript run tests/cli-web.tryscript.md
 pnpm --filter get-tbd qa:web-package
+pnpm --filter get-tbd qa:upgrade-package
 ```
 
 The spawned-process acceptance test creates real writer and viewer clones, proves the

--- a/docs/project/specs/active/plan-2026-05-24-multi-agent-skills-hooks-setup.md
+++ b/docs/project/specs/active/plan-2026-05-24-multi-agent-skills-hooks-setup.md
@@ -319,7 +319,9 @@ parity, not graceful degradation:
 Generated skill text should prefer a local command when available, then a pinned
 fallback appropriate to the package manager:
 
-1. `mycli <command>` when already on `PATH`.
+1. `mycli <command>` when already on `PATH` and its numeric SemVer core is at least the
+   repository-pinned version.
+   A stale or malformed local version falls through to the pinned runner.
 2. A pinned zero-install fallback such as:
    - `npx --yes my-package@<version> mycli <command>` for npm packages.
    - `uvx --from my-package@<version> mycli <command>` for Python packages distributed
@@ -334,13 +336,15 @@ fallback appropriate to the package manager:
 the currently running tbd version (`PINNED_NPM_VERSION`, the clean published semver from
 `version.ts`), so a team and its agents all reproduce the same version.
 The generated session script (`.codex/tbd-session.sh`, `.claude/scripts/tbd-session.sh`)
-already does this via `npx --yes get-tbd@${PINNED_NPM_VERSION}`. An audit (2026-06-02,
-`tbd-shsb`) confirmed the remaining `@latest` usages are **all correct as-is** and must
-**not** be pinned: the forward-compatibility “requires a newer tbd” errors in
-`doctor.ts`, `setup.ts`, and `tbd-format.ts` exist precisely to fetch a newer release,
-and the first-install bootstrap one-liner in `output.ts` (Getting Started) is for a user
-who has no tbd yet. Pinning any of these to the running version would be a bug.
-So no code change is needed here beyond the already-pinned session script.
+does this via a version-aware local check followed by
+`npx --yes get-tbd@${PINNED_NPM_VERSION}`. An audit (2026-06-02, `tbd-shsb`) confirmed
+the remaining `@latest` usages are **all correct as-is** and must **not** be pinned: the
+forward-compatibility “requires a newer tbd” errors in `doctor.ts`, `setup.ts`, and
+`tbd-format.ts` exist precisely to fetch a newer release, and the first-install
+bootstrap one-liner in `output.ts` (Getting Started) is for a user who has no tbd yet.
+Pinning any of these to the running version would be a bug.
+The version-aware selector preserves that boundary while preventing a stale local CLI
+from shadowing the pinned fallback.
 
 Never recommend an unpinned network runner from generated agent instructions unless the
 user explicitly opts into that behavior.
@@ -563,7 +567,7 @@ These were open questions; resolved 2026-05-25 so the beads are unambiguous:
   treated as legacy format 1, and the new compact block is format 2. (`tbd-slsp`,
   `tbd-y84j`)
 
-Revised 2026-06-02:
+Revised through 2026-08-14:
 
 - **Single `--surfaces=<comma-list>` selector, default all** — replaces the per-agent
   flag taxonomy (`--claude`/`--codex`/`--cursor`/`--agents-md`/`--all`/`--skip-*`). With
@@ -586,11 +590,12 @@ Revised 2026-06-02:
   surface is self-contained and Codex hooks never reference `.claude/`. The guideline
   treats this as a valid alternative to a shared neutral script.
   (`tbd-orup`)
-- **Version pinning is already correct; no change needed** — the session script pins to
-  `PINNED_NPM_VERSION`; the remaining `@latest` usages are forward-compatibility upgrade
-  errors or the first-install bootstrap, all of which legitimately want the newest
-  release and must not be pinned.
-  (`tbd-shsb`)
+- **Version-aware local selection** — the session and closing hooks use a local `tbd`
+  only when its numeric SemVer core satisfies `PINNED_NPM_VERSION`; stale or malformed
+  clients fall through to the exact pin.
+  The remaining `@latest` usages are forward-compatibility upgrade errors or the
+  first-install bootstrap, all of which legitimately want the newest release and must
+  not be pinned. (`tbd-shsb`, revised 2026-08-14 by `tbd-2ezq`)
 
 ## Self-Upgrade and Forward-Compatibility (Tier-2 behavior)
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -205,6 +205,13 @@ No Changesets—bump by hand on a `claude/release-vX.X.X` branch:
 The notes you write here ARE the release notes (Step 5); there is no separate changeset
 summary to keep in sync.
 
+Before publishing every release, run `pnpm qa:upgrade-package`. It packs the candidate
+with the release version and upgrades disposable repositories created by the exact
+published same-format and previous-format baselines.
+Update `TBD_UPGRADE_SAME_FORMAT_FROM`, `TBD_UPGRADE_COMMON_FROM`, or
+`TBD_UPGRADE_PREVIOUS_FORMAT_FROM` when validating a different usage or compatibility
+boundary.
+
 **If the release bumps `tbd_format`** (`CURRENT_FORMAT` in
 [`tbd-format.ts`](../packages/tbd/src/lib/tbd-format.ts) differs from the last release):
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "upgrade:major": "ncu --cooldown 14 --target latest --interactive --format group",
     "check:package-age": "node scripts/check-package-age.mjs",
     "qa:watch-release": "pnpm --filter get-tbd qa:watch-release",
+    "qa:upgrade-package": "pnpm --filter get-tbd qa:upgrade-package",
     "tbd": "TBD_DEV_VERSION=$(node packages/tbd/scripts/git-version.mjs) tsx packages/tbd/src/cli/bin.ts",
     "tbd:bin": "node packages/tbd/dist/bin.js",
     "test:install": "pnpm --filter get-tbd test:install",

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -1,5 +1,40 @@
 # get-tbd
 
+## 0.6.2
+
+### Fixed
+
+- **Version-aware generated hooks**: Session and closing hooks now use a local `tbd`
+  only when its numeric SemVer core satisfies the repository pin.
+  A stale or malformed installation falls through to the exact pinned `get-tbd` package,
+  so patch upgrades and repository-format upgrades no longer dead-end merely because an
+  older global CLI is still on `PATH`.
+- **Idempotent setup**: Repeated `tbd setup --auto` runs no longer classify the current
+  `.claude/scripts/tbd-session.sh` hooks as legacy, remove them, and then reinstall the
+  same entries while claiming cleanup work occurred.
+- **Clear upgrade handoff**: Setup now reports the previous and current tbd versions
+  when it stamps an existing repository and explicitly tells the operator to review and
+  commit the generated changes.
+  Identical reruns remain quiet.
+- **Consistent setup CLI**: Fresh setup and Beads migration now run their follow-up
+  import and dashboard with the current CLI process instead of dispatching to whichever
+  `tbd` happens to be on `PATH`, which could be an older, format-incompatible
+  installation.
+
+### Changed
+
+- **Verified upgrade paths**: Release packages are now exercised against the published
+  0.6.1 same-format baseline, the common 0.4.2 upgrade path, and the final 0.5.0 f06
+  baseline. The proof covers config and issue preservation, generated surfaces,
+  idempotent reruns, same-format backward compatibility, and the older client failing
+  closed after f07.
+
+### Security
+
+- **Dependency posture**: No dependencies or lockfile entries changed.
+  Packaged upgrade QA fetches only exact historical first-party `get-tbd` tarballs with
+  their lifecycle scripts disabled and reuses the frozen workspace dependency tree.
+
 ## 0.6.1
 
 ### Fixed

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-tbd",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Git-native issue tracking for AI agents and humans",
   "license": "MIT",
   "author": "Joshua Levy <joshua@cal.berkeley.edu> (https://github.com/jlevy)",
@@ -60,6 +60,7 @@
     "test:tryscript:update": "tryscript run --update 'tests/**/*.tryscript.md'",
     "qa:watch-release": "pnpm build && pnpm qa:watch-release:built",
     "qa:watch-release:built": "tsx scripts/validate-watch-release.ts",
+    "qa:upgrade-package": "node scripts/validate-upgrade-package.mjs",
     "qa:web-package": "node scripts/validate-web-package.mjs",
     "qa:linear-live": "pnpm build && tsx scripts/validate-linear-integration-live.ts",
     "bench": "tsx scripts/benchmark.ts",

--- a/packages/tbd/scripts/validate-upgrade-package.mjs
+++ b/packages/tbd/scripts/validate-upgrade-package.mjs
@@ -1,0 +1,514 @@
+#!/usr/bin/env node
+/* global console, process */
+
+/**
+ * Prove a packed candidate upgrades real published repositories safely.
+ *
+ * Three baselines exercise the real-world path and distinct compatibility contracts:
+ * - the latest same-format patch (0.6.1 / f07), whose older client must keep working;
+ * - the common pre-f07 release (0.4.2 / f06), whose client must fail closed after upgrade;
+ * - the last pre-f07 release (0.5.0 / f06), which guards the immediate format boundary.
+ */
+
+import { execFile } from 'node:child_process';
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { delimiter, dirname, isAbsolute, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+
+const execFileAsync = promisify(execFile);
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const packageDir = join(scriptDir, '..');
+const sourceRepoDir = join(packageDir, '..', '..');
+const sameFormatBaseline = process.env.TBD_UPGRADE_SAME_FORMAT_FROM ?? '0.6.1';
+const commonUpgradeBaseline = process.env.TBD_UPGRADE_COMMON_FROM ?? '0.4.2';
+const previousFormatBaseline = process.env.TBD_UPGRADE_PREVIOUS_FORMAT_FROM ?? '0.5.0';
+const managedUpgradePaths = new Set([
+  '.agents/skills/tbd/SKILL.md',
+  '.claude/.gitignore',
+  '.claude/hooks/tbd-closing-reminder.sh',
+  '.claude/scripts/ensure-gh-cli.sh',
+  '.claude/scripts/tbd-session.sh',
+  '.claude/settings.json',
+  '.claude/skills/tbd/SKILL.md',
+  '.codex/ensure-gh-cli.sh',
+  '.codex/hooks.json',
+  '.codex/tbd-closing-reminder.sh',
+  '.codex/tbd-session.sh',
+  '.tbd/.gitattributes',
+  '.tbd/.gitignore',
+  '.tbd/config.yml',
+  'AGENTS.md',
+]);
+
+function invariant(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function run(command, args, options = {}) {
+  return execFileAsync(command, args, {
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+    ...options,
+  });
+}
+
+async function runPackageManager(command, args, options = {}) {
+  if (process.platform === 'win32') {
+    return run(process.env.ComSpec ?? 'cmd.exe', ['/d', '/c', `${command}.cmd`, ...args], {
+      windowsHide: true,
+      ...options,
+    });
+  }
+  return run(command, args, options);
+}
+
+function withoutAmbientNpmConfig() {
+  return Object.fromEntries(
+    Object.entries(process.env).filter(([name]) => !/^npm_config_/iu.test(name)),
+  );
+}
+
+async function repositoryStatus(directory) {
+  const { stdout } = await run('git', ['status', '--porcelain=v1', '--untracked-files=all'], {
+    cwd: directory,
+  });
+  return stdout;
+}
+
+async function git(directory, ...args) {
+  const { stdout } = await run('git', args, { cwd: directory });
+  return stdout.trim();
+}
+
+async function invokeCli(cli, repository, home, args) {
+  const options = {
+    cwd: repository,
+    env: {
+      ...process.env,
+      CODEX_HOME: join(home, '.codex'),
+      FORCE_COLOR: '0',
+      HOME: home,
+      NO_COLOR: '1',
+      PATH: `${cli.launcherDir}${delimiter}${process.env.PATH ?? ''}`,
+      USERPROFILE: home,
+    },
+  };
+  try {
+    const { stdout, stderr } = await run(process.execPath, [cli.cliPath, ...args], options);
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    return {
+      code: typeof error.code === 'number' ? error.code : 1,
+      stdout: typeof error.stdout === 'string' ? error.stdout : '',
+      stderr: typeof error.stderr === 'string' ? error.stderr : String(error),
+    };
+  }
+}
+
+async function packCandidate(destination, version) {
+  const env = { ...process.env, TBD_VERSION_OVERRIDE: version };
+  // Build explicitly instead of depending on prepack: security-conscious developer
+  // environments commonly export ignore-scripts, but an explicit project build is safe
+  // and the candidate proof must never package stale or missing dist output.
+  await runPackageManager('pnpm', ['build'], { cwd: packageDir, env });
+  await runPackageManager('pnpm', ['pack', '--pack-destination', destination], {
+    cwd: packageDir,
+    // The explicit build above is the only trusted project script this proof needs.
+    env: { ...env, NPM_CONFIG_IGNORE_SCRIPTS: 'true' },
+  });
+}
+
+async function packPublished(destination, version) {
+  // Exact historical first-party artifacts only; npm pack does not run lifecycle scripts.
+  await runPackageManager(
+    'npm',
+    ['pack', `get-tbd@${version}`, '--pack-destination', destination, '--ignore-scripts'],
+    {
+      cwd: destination,
+      // pnpm exports its config as npm_config_* variables to child scripts. In
+      // particular, an ambient `before` policy can hide the historical baseline we
+      // intentionally selected. Exact first-party versions are exempt from the
+      // third-party cool-off and are fetched without lifecycle scripts.
+      env: withoutAmbientNpmConfig(),
+    },
+  );
+}
+
+async function findOnlyArchive(directory) {
+  const archives = (await readdir(directory)).filter((entry) => entry.endsWith('.tgz'));
+  invariant(
+    archives.length === 1,
+    `Expected one archive in ${directory}, found ${archives.length}`,
+  );
+  return join(directory, archives[0]);
+}
+
+async function extractPackage(archive, destination, dependencyTree) {
+  await mkdir(destination, { recursive: true });
+  await run('tar', ['-xzf', archive, '-C', destination]);
+  const extracted = join(destination, 'package');
+  await symlink(dependencyTree, join(extracted, 'node_modules'), 'junction');
+  const manifest = JSON.parse(await readFile(join(extracted, 'package.json'), 'utf8'));
+  invariant(manifest.name === 'get-tbd', `Unexpected package name ${String(manifest.name)}`);
+  const bin = typeof manifest.bin === 'string' ? manifest.bin : manifest.bin?.tbd;
+  invariant(typeof bin === 'string', `get-tbd@${String(manifest.version)} has no tbd binary`);
+  const cliPath = join(extracted, bin);
+  await access(cliPath);
+  const launcherDir = join(destination, 'qa-bin');
+  await mkdir(launcherDir);
+  if (process.platform === 'win32') {
+    await writeFile(
+      join(launcherDir, 'tbd.cmd'),
+      `@echo off\r\n"${process.execPath}" "${cliPath}" %*\r\n`,
+    );
+  } else {
+    await symlink(cliPath, join(launcherDir, 'tbd'));
+  }
+  return { cliPath, launcherDir, manifest };
+}
+
+async function initializeRepository(repository) {
+  await mkdir(repository, { recursive: true });
+  await git(repository, 'init', '--initial-branch=main');
+  await git(repository, 'config', 'user.name', 'tbd upgrade QA');
+  await git(repository, 'config', 'user.email', 'tbd-upgrade-qa@example.invalid');
+  await git(repository, 'config', 'commit.gpgSign', 'false');
+  await git(repository, 'commit', '--allow-empty', '--message', 'Initialize upgrade QA');
+}
+
+async function addPreservationProbes(configPath) {
+  const config = parseYaml(await readFile(configPath, 'utf8'));
+  config.upgrade_qa = { preserve: 'top-level-value' };
+  config.integrations = {
+    ...(config.integrations ?? {}),
+    upgrade_qa_provider: {
+      custom: { preserve: 'provider-value' },
+      enabled: false,
+    },
+  };
+  await writeFile(configPath, stringifyYaml(config, { lineWidth: 0 }));
+}
+
+async function snapshotIssueData(repository) {
+  const commonDirOutput = await git(repository, 'rev-parse', '--git-common-dir');
+  const commonDir = isAbsolute(commonDirOutput)
+    ? commonDirOutput
+    : resolve(repository, commonDirOutput);
+  const dataDir = join(commonDir, 'tbd', 'data-sync-worktree', '.tbd', 'data-sync');
+  const snapshot = {};
+  for (const relativeDir of ['issues', 'mappings']) {
+    const directory = join(dataDir, relativeDir);
+    for (const filename of (await readdir(directory)).sort()) {
+      snapshot[`${relativeDir}/${filename}`] = await readFile(join(directory, filename), 'utf8');
+    }
+  }
+  return snapshot;
+}
+
+async function validateScenario({
+  candidate,
+  candidateVersion,
+  expectedBaselineFormat,
+  expectOldClientToWork,
+  root,
+  baseline,
+  baselineVersion,
+  name,
+}) {
+  const repository = join(root, `${name}-repository`);
+  const home = join(root, `${name}-home`);
+  await initializeRepository(repository);
+  await mkdir(home, { recursive: true });
+
+  const baselineSetup = await invokeCli(baseline, repository, home, [
+    'setup',
+    '--auto',
+    '--prefix=qa',
+  ]);
+  invariant(
+    baselineSetup.code === 0,
+    `${name}: baseline setup failed\n${baselineSetup.stdout}\n${baselineSetup.stderr}`,
+  );
+  const create = await invokeCli(baseline, repository, home, [
+    'create',
+    'Upgrade QA seed',
+    '--type=task',
+  ]);
+  invariant(
+    create.code === 0,
+    `${name}: baseline create failed\n${create.stdout}\n${create.stderr}`,
+  );
+
+  const configPath = join(repository, '.tbd', 'config.yml');
+  const baselineConfig = parseYaml(await readFile(configPath, 'utf8'));
+  invariant(
+    baselineConfig.tbd_format === expectedBaselineFormat,
+    `${name}: expected ${expectedBaselineFormat}, found ${String(baselineConfig.tbd_format)}`,
+  );
+  await addPreservationProbes(configPath);
+  await git(repository, 'add', '--all');
+  await git(repository, 'commit', '--message', `Record ${baselineVersion} baseline`);
+  invariant((await repositoryStatus(repository)) === '', `${name}: baseline repository is dirty`);
+  const issueDataBefore = await snapshotIssueData(repository);
+
+  const firstUpgrade = await invokeCli(candidate, repository, home, ['setup', '--auto']);
+  const firstOutput = firstUpgrade.stdout + firstUpgrade.stderr;
+  invariant(
+    firstUpgrade.code === 0,
+    `${name}: candidate setup failed\n${firstUpgrade.stdout}\n${firstUpgrade.stderr}`,
+  );
+  invariant(
+    !firstOutput.includes('Cleaned up legacy'),
+    `${name}: candidate misclassified current hooks as legacy`,
+  );
+  invariant(
+    firstOutput.includes(`Recorded tbd setup version`) && firstOutput.includes(candidateVersion),
+    `${name}: candidate did not report the setup version transition`,
+  );
+  invariant(
+    firstOutput.includes('Review and commit the generated repository changes.'),
+    `${name}: candidate omitted the commit action`,
+  );
+
+  const upgradedConfig = parseYaml(await readFile(configPath, 'utf8'));
+  invariant(upgradedConfig.tbd_format === 'f07', `${name}: candidate did not produce f07`);
+  invariant(
+    upgradedConfig.tbd_version === candidateVersion,
+    `${name}: config reports ${String(upgradedConfig.tbd_version)}, expected ${candidateVersion}`,
+  );
+  invariant(
+    upgradedConfig.upgrade_qa?.preserve === 'top-level-value',
+    `${name}: top-level config probe was lost`,
+  );
+  invariant(
+    upgradedConfig.integrations?.upgrade_qa_provider?.custom?.preserve === 'provider-value',
+    `${name}: provider config probe was lost`,
+  );
+  const upgrades = upgradedConfig.tbd_upgrades ?? [];
+  invariant(
+    upgrades.at(-1)?.version === candidateVersion,
+    `${name}: upgrade history does not end at ${candidateVersion}`,
+  );
+  invariant(
+    JSON.stringify(await snapshotIssueData(repository)) === JSON.stringify(issueDataBefore),
+    `${name}: setup changed issue or mapping data`,
+  );
+
+  // Stage inside the disposable repository so the snapshot also covers any newly
+  // generated, previously untracked files.
+  await git(repository, 'add', '--all');
+  const changedFiles = (await git(repository, 'diff', '--cached', '--name-only'))
+    .split('\n')
+    .filter(Boolean);
+  const unexpectedFiles = changedFiles.filter((path) => !managedUpgradePaths.has(path));
+  invariant(
+    unexpectedFiles.length === 0,
+    `${name}: upgrade changed non-managed paths: ${unexpectedFiles.join(', ')}`,
+  );
+  for (const expected of [
+    '.tbd/config.yml',
+    '.claude/scripts/tbd-session.sh',
+    '.codex/tbd-session.sh',
+  ]) {
+    invariant(changedFiles.includes(expected), `${name}: expected ${expected} in the upgrade diff`);
+  }
+  const sessionScript = await readFile(
+    join(repository, '.claude', 'scripts', 'tbd-session.sh'),
+    'utf8',
+  );
+  invariant(sessionScript.includes('tbd_version_at_least'), `${name}: version guard is missing`);
+  invariant(
+    sessionScript.includes(`get-tbd@${candidateVersion}`),
+    `${name}: session fallback is not pinned to ${candidateVersion}`,
+  );
+
+  const firstDiff = await git(repository, 'diff', '--cached', '--binary');
+  const repeatedUpgrade = await invokeCli(candidate, repository, home, ['setup', '--auto']);
+  invariant(
+    repeatedUpgrade.code === 0,
+    `${name}: repeated candidate setup failed\n${repeatedUpgrade.stdout}\n${repeatedUpgrade.stderr}`,
+  );
+  invariant(
+    !(repeatedUpgrade.stdout + repeatedUpgrade.stderr).includes('Cleaned up legacy'),
+    `${name}: repeated setup claimed legacy cleanup`,
+  );
+  invariant(
+    !(repeatedUpgrade.stdout + repeatedUpgrade.stderr).includes('Recorded tbd setup version'),
+    `${name}: repeated setup recorded a duplicate version`,
+  );
+  invariant(
+    (await git(repository, 'diff', '--binary')) === '',
+    `${name}: repeated setup changed files after the staged upgrade snapshot`,
+  );
+  invariant(
+    (await git(repository, 'diff', '--cached', '--binary')) === firstDiff,
+    `${name}: repeated setup changed the upgrade diff`,
+  );
+
+  const configBeforeOldClient = await readFile(configPath, 'utf8');
+  const oldClientArgs = expectOldClientToWork
+    ? ['status']
+    : ['create', 'Rejected stale-client write'];
+  const oldClient = await invokeCli(baseline, repository, home, oldClientArgs);
+  if (expectOldClientToWork) {
+    invariant(
+      oldClient.code === 0,
+      `${name}: same-format baseline stopped working\n${oldClient.stdout}\n${oldClient.stderr}`,
+    );
+  } else {
+    invariant(oldClient.code !== 0, `${name}: pre-f07 client accepted the f07 repository`);
+    invariant(
+      /newer version of tbd|newer tbd version|supports up to format/iu.test(
+        oldClient.stdout + oldClient.stderr,
+      ),
+      `${name}: pre-f07 rejection omitted the upgrade explanation`,
+    );
+  }
+  invariant(
+    (await readFile(configPath, 'utf8')) === configBeforeOldClient,
+    `${name}: old client changed config while checking compatibility`,
+  );
+  if (!expectOldClientToWork) {
+    invariant(
+      JSON.stringify(await snapshotIssueData(repository)) === JSON.stringify(issueDataBefore),
+      `${name}: pre-f07 client changed issue or mapping data`,
+    );
+  }
+
+  const list = await invokeCli(candidate, repository, home, ['list', '--json']);
+  invariant(
+    list.code === 0 && list.stdout.includes('Upgrade QA seed'),
+    `${name}: seed issue missing`,
+  );
+  console.log(
+    `Packed upgrade proof passed: ${baselineVersion} (${expectedBaselineFormat}) -> ${candidateVersion} (f07)`,
+  );
+}
+
+const sourceStatusBefore = await repositoryStatus(sourceRepoDir);
+const temporaryDir = await mkdtemp(join(tmpdir(), 'tbd-upgrade-package-'));
+try {
+  const manifest = JSON.parse(await readFile(join(packageDir, 'package.json'), 'utf8'));
+  const candidateVersion = manifest.version;
+  invariant(typeof candidateVersion === 'string', 'Candidate package has no version');
+
+  const dependencyTree = await realpath(join(packageDir, 'node_modules'));
+  const candidateArchiveDir = join(temporaryDir, 'candidate-archive');
+  const sameArchiveDir = join(temporaryDir, 'same-format-archive');
+  const commonArchiveDir = join(temporaryDir, 'common-upgrade-archive');
+  const previousArchiveDir = join(temporaryDir, 'previous-format-archive');
+  await Promise.all([
+    mkdir(candidateArchiveDir),
+    mkdir(sameArchiveDir),
+    mkdir(commonArchiveDir),
+    mkdir(previousArchiveDir),
+  ]);
+  await packCandidate(candidateArchiveDir, candidateVersion);
+  await Promise.all([
+    packPublished(sameArchiveDir, sameFormatBaseline),
+    packPublished(commonArchiveDir, commonUpgradeBaseline),
+    packPublished(previousArchiveDir, previousFormatBaseline),
+  ]);
+
+  const candidate = await extractPackage(
+    await findOnlyArchive(candidateArchiveDir),
+    join(temporaryDir, 'candidate'),
+    dependencyTree,
+  );
+  invariant(
+    candidate.manifest.version === candidateVersion,
+    `Packed candidate manifest reports ${String(candidate.manifest.version)}`,
+  );
+  const candidateVersionResult = await invokeCli(
+    candidate,
+    sourceRepoDir,
+    join(temporaryDir, 'candidate-version-home'),
+    ['--version'],
+  );
+  invariant(
+    candidateVersionResult.code === 0 && candidateVersionResult.stdout.trim() === candidateVersion,
+    `Packed candidate CLI does not report ${candidateVersion}`,
+  );
+
+  const sameFormatPackage = await extractPackage(
+    await findOnlyArchive(sameArchiveDir),
+    join(temporaryDir, 'same-format'),
+    dependencyTree,
+  );
+  invariant(
+    sameFormatPackage.manifest.version === sameFormatBaseline,
+    `Same-format baseline resolved to ${String(sameFormatPackage.manifest.version)}`,
+  );
+  const commonUpgradePackage = await extractPackage(
+    await findOnlyArchive(commonArchiveDir),
+    join(temporaryDir, 'common-upgrade'),
+    dependencyTree,
+  );
+  invariant(
+    commonUpgradePackage.manifest.version === commonUpgradeBaseline,
+    `Common upgrade baseline resolved to ${String(commonUpgradePackage.manifest.version)}`,
+  );
+  const previousFormatPackage = await extractPackage(
+    await findOnlyArchive(previousArchiveDir),
+    join(temporaryDir, 'previous-format'),
+    dependencyTree,
+  );
+  invariant(
+    previousFormatPackage.manifest.version === previousFormatBaseline,
+    `Previous-format baseline resolved to ${String(previousFormatPackage.manifest.version)}`,
+  );
+
+  await validateScenario({
+    baseline: sameFormatPackage,
+    baselineVersion: sameFormatBaseline,
+    candidate,
+    candidateVersion,
+    expectedBaselineFormat: 'f07',
+    expectOldClientToWork: true,
+    name: 'same-format',
+    root: temporaryDir,
+  });
+  await validateScenario({
+    baseline: commonUpgradePackage,
+    baselineVersion: commonUpgradeBaseline,
+    candidate,
+    candidateVersion,
+    expectedBaselineFormat: 'f06',
+    expectOldClientToWork: false,
+    name: 'common-upgrade',
+    root: temporaryDir,
+  });
+  await validateScenario({
+    baseline: previousFormatPackage,
+    baselineVersion: previousFormatBaseline,
+    candidate,
+    candidateVersion,
+    expectedBaselineFormat: 'f06',
+    expectOldClientToWork: false,
+    name: 'format-change',
+    root: temporaryDir,
+  });
+
+  const sourceStatusAfter = await repositoryStatus(sourceRepoDir);
+  invariant(
+    sourceStatusAfter === sourceStatusBefore,
+    `Packed upgrade proof changed the source checkout:\n${sourceStatusAfter}`,
+  );
+} finally {
+  await rm(temporaryDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+}

--- a/packages/tbd/src/cli/commands/import.ts
+++ b/packages/tbd/src/cli/commands/import.ts
@@ -35,7 +35,7 @@ import {
 } from '../../file/workspace.js';
 import { withDataSyncContext } from '../lib/data-context.js';
 
-interface ImportOptions {
+export interface ImportOptions {
   beadsDir?: string;
   merge?: boolean;
   verbose?: boolean;
@@ -753,6 +753,16 @@ class ImportHandler extends BaseCommand {
   }
 }
 
+/** Run import inside the current CLI process so callers never dispatch to another PATH version. */
+export async function runImport(
+  command: Command,
+  file: string | undefined,
+  options: ImportOptions,
+): Promise<void> {
+  const handler = new ImportHandler(command);
+  await handler.run(file, options);
+}
+
 export const importCommand = new Command('import')
   .description(
     'Import issues from JSONL file or workspace.\n' +
@@ -770,6 +780,5 @@ export const importCommand = new Command('import')
   .option('--outbox', 'Shortcut for --workspace=outbox --clear-on-success')
   .option('--clear-on-success', 'Delete workspace after successful import')
   .action(async (file, options, command) => {
-    const handler = new ImportHandler(command);
-    await handler.run(file, options);
+    await runImport(command, file, options);
   });

--- a/packages/tbd/src/cli/commands/prime.ts
+++ b/packages/tbd/src/cli/commands/prime.ts
@@ -25,7 +25,7 @@ import type { Issue } from '../../lib/types.js';
 import { DocCache, generateShortcutDirectory } from '../../file/doc-cache.js';
 import { loadDataContext } from '../lib/data-context.js';
 
-interface PrimeOptions {
+export interface PrimeOptions {
   export?: boolean;
   brief?: boolean;
 }
@@ -432,11 +432,16 @@ class PrimeHandler extends BaseCommand {
   }
 }
 
+/** Run prime inside the current CLI process so callers never dispatch to another PATH version. */
+export async function runPrime(command: Command, options: PrimeOptions = {}): Promise<void> {
+  const handler = new PrimeHandler(command);
+  await handler.run(options);
+}
+
 export const primeCommand = new Command('prime')
   .description('Show full orientation with workflow context')
   .option('--export', 'Output default content (ignores PRIME.md override)')
   .option('--brief', 'Output abbreviated orientation (~35 lines) for constrained contexts')
   .action(async (options: PrimeOptions, command) => {
-    const handler = new PrimeHandler(command);
-    await handler.run(options);
+    await runPrime(command, options);
   });

--- a/packages/tbd/src/cli/commands/setup.ts
+++ b/packages/tbd/src/cli/commands/setup.ts
@@ -14,7 +14,6 @@
 
 import { Command } from 'commander';
 import { readFile, mkdir, access, rm, rename, chmod, readdir } from 'node:fs/promises';
-import { spawnSync } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isDeepStrictEqual } from 'node:util';
@@ -22,7 +21,8 @@ import { writeFile } from 'atomically';
 
 import { BaseCommand } from '../lib/base-command.js';
 import { CLIError } from '../lib/errors.js';
-import { loadSkillContent } from './prime.js';
+import { loadSkillContent, runPrime } from './prime.js';
+import { runImport } from './import.js';
 import { insertAfterFrontmatter } from '../../utils/markdown-utils.js';
 import { pathExists } from '../../utils/file-utils.js';
 import { ensureGitignorePatterns } from '../../utils/gitignore-utils.js';
@@ -254,6 +254,28 @@ interface SetupCodexOptions {
 }
 
 /**
+ * Shell helper shared by generated hooks that select between a local tbd and the
+ * repository-pinned fallback. Compare numeric SemVer cores so a matching development
+ * build is accepted and a genuinely newer local CLI is never downgraded.
+ */
+const TBD_VERSION_AT_LEAST_FUNCTION = `tbd_version_at_least() {
+  node -e '
+const parse = (version) => {
+  const match = /^(\\d+)\\.(\\d+)\\.(\\d+)(?:[-+]|$)/u.exec(version);
+  return match === null ? null : match.slice(1).map(Number);
+};
+const installed = parse(process.argv[1]);
+const required = parse(process.argv[2]);
+if (installed === null || required === null) process.exit(1);
+for (let index = 0; index < 3; index += 1) {
+  if (installed[index] > required[index]) process.exit(0);
+  if (installed[index] < required[index]) process.exit(1);
+}
+process.exit(0);
+' "$1" "$2"
+}`;
+
+/**
  * Script to ensure tbd CLI is installed and run tbd prime.
  * Installed to project .claude/scripts/tbd-session.sh.
  * Runs on SessionStart and PreCompact to ensure tbd is available and provide orientation.
@@ -274,19 +296,33 @@ const TBD_SESSION_SCRIPT = `#!/bin/bash
 # Prefer common local bin locations.
 export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
 
-# Local-first: use tbd if it is already on PATH.
+${TBD_VERSION_AT_LEAST_FUNCTION}
+
+# Local-first when the installed CLI satisfies this repository's pin. An older CLI may
+# be unable to read a newer tbd_format, so let the exact pinned fallback handle upgrades.
+installed_tbd_version=""
 if command -v tbd &> /dev/null; then
+    installed_tbd_version=$(tbd --version 2>/dev/null || true)
+fi
+if [ -n "$installed_tbd_version" ] && tbd_version_at_least "$installed_tbd_version" "${PINNED_NPM_VERSION}"; then
     tbd prime "$@"
     exit $?
 fi
 
 # Pinned zero-install fallback. Never use an unpinned runner here.
 if command -v npx &> /dev/null; then
+    if [ -n "$installed_tbd_version" ]; then
+        echo "[tbd] Local tbd $installed_tbd_version does not satisfy repository pin ${PINNED_NPM_VERSION}; using pinned fallback." >&2
+    fi
     npx --yes get-tbd@${PINNED_NPM_VERSION} prime "$@"
     exit $?
 fi
 
-echo "[tbd] tbd CLI not found and npx is unavailable."
+if [ -n "$installed_tbd_version" ]; then
+    echo "[tbd] Local tbd $installed_tbd_version does not satisfy repository pin ${PINNED_NPM_VERSION}, and npx is unavailable."
+else
+    echo "[tbd] tbd CLI not found and npx is unavailable."
+fi
 echo "[tbd] Install it with: npm install -g get-tbd@${PINNED_NPM_VERSION}"
 exit 1
 `;
@@ -296,18 +332,25 @@ exit 1
  * Always uses project-relative paths so hooks work in any environment
  * (local dev, Claude Code Cloud, etc.).
  */
+const CLAUDE_TBD_SESSION_COMMAND = 'bash .claude/scripts/tbd-session.sh';
+const CLAUDE_TBD_PRECOMPACT_COMMAND = `${CLAUDE_TBD_SESSION_COMMAND} --brief`;
+const CURRENT_CLAUDE_TBD_HOOK_COMMANDS = new Set([
+  CLAUDE_TBD_SESSION_COMMAND,
+  CLAUDE_TBD_PRECOMPACT_COMMAND,
+]);
+
 const CLAUDE_SESSION_HOOKS = {
   hooks: {
     SessionStart: [
       {
         matcher: '',
-        hooks: [{ type: 'command', command: 'bash .claude/scripts/tbd-session.sh' }],
+        hooks: [{ type: 'command', command: CLAUDE_TBD_SESSION_COMMAND }],
       },
     ],
     PreCompact: [
       {
         matcher: '',
-        hooks: [{ type: 'command', command: 'bash .claude/scripts/tbd-session.sh --brief' }],
+        hooks: [{ type: 'command', command: CLAUDE_TBD_PRECOMPACT_COMMAND }],
       },
     ],
   },
@@ -351,9 +394,14 @@ if [[ "$command" == git\\ push* ]] || [[ "$command" == *"&& git push"* ]] || [[ 
   repo_root=$(git rev-parse --show-toplevel 2>/dev/null) && cd "$repo_root"
   if [ -d ".tbd" ]; then
     # Same local-first, version-pinned fallback as tbd-session.sh, so the
-    # reminder still fires when tbd is not on the hook's PATH.
+    # reminder still fires when tbd is missing or too old for this repository.
     export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
+    ${TBD_VERSION_AT_LEAST_FUNCTION}
+    installed_tbd_version=""
     if command -v tbd &> /dev/null; then
+      installed_tbd_version=$(tbd --version 2>/dev/null || true)
+    fi
+    if [ -n "$installed_tbd_version" ] && tbd_version_at_least "$installed_tbd_version" "${PINNED_NPM_VERSION}"; then
       tbd closing
     elif command -v npx &> /dev/null; then
       npx --yes get-tbd@${PINNED_NPM_VERSION} closing
@@ -1440,6 +1488,7 @@ class SetupDefaultHandler extends BaseCommand {
     if (hasTbd) {
       // Already initialized flow - check for migrations
       const { config, migrated, changes } = await readConfigWithMigration(projectDir);
+      const previousVersion = config.tbd_version ?? 'unknown';
       console.log(`  ${colors.success('✓')} tbd initialized (prefix: ${config.display.id_prefix})`);
 
       // Apply --no-gh-cli flag to config if specified
@@ -1484,6 +1533,12 @@ class SetupDefaultHandler extends BaseCommand {
       // the stamped config (the migration notice has already fired).
       if (!this.ctx.dryRun && (versionStamped || ghCliChanged)) {
         await writeConfig(projectDir, stamped);
+        if (versionStamped) {
+          console.log(
+            `  ${colors.success('✓')} Recorded tbd setup version ${previousVersion} → ${VERSION}`,
+          );
+          console.log(colors.dim('      Review and commit the generated repository changes.'));
+        }
         if (ghCliChanged) {
           console.log(`  ${colors.success('✓')} Disabled gh CLI auto-setup`);
         }
@@ -1666,11 +1721,9 @@ class SetupDefaultHandler extends BaseCommand {
     try {
       await access(jsonlPath);
       // Import directly from the JSONL file (tbd is already initialized)
-      const result = spawnSync('tbd', ['import', jsonlPath, '--verbose'], {
-        cwd,
-        stdio: 'inherit',
-      });
-      if (result.status !== 0) {
+      try {
+        await runImport(this.cmd, jsonlPath, { verbose: true });
+      } catch {
         console.log(colors.warn('Warning: Some issues may not have imported correctly'));
       }
     } catch {
@@ -1693,7 +1746,7 @@ class SetupDefaultHandler extends BaseCommand {
     this.showWhatsNext(colors);
 
     // Show dashboard after setup
-    spawnSync('tbd', ['prime'], { stdio: 'inherit' });
+    await runPrime(this.cmd);
 
     // Mark welcome as seen since the user got the full onboarding experience
     try {
@@ -1786,7 +1839,7 @@ class SetupDefaultHandler extends BaseCommand {
     this.showWhatsNext(colors);
 
     // Show dashboard after setup
-    spawnSync('tbd', ['prime'], { stdio: 'inherit' });
+    await runPrime(this.cmd);
 
     // Mark welcome as seen since the user got the full onboarding experience
     try {
@@ -2003,10 +2056,14 @@ class SetupAutoHandler extends BaseCommand {
     return hookList.filter((entry) => {
       // Check if any hook command matches legacy patterns
       const hasLegacyCommand = entry.hooks?.some((hook) => {
-        if (!hook.command) {
+        const command = hook.command;
+        if (!command) {
           return false;
         }
-        return LEGACY_TBD_HOOK_PATTERNS.some((pattern) => pattern.test(hook.command!));
+        if (CURRENT_CLAUDE_TBD_HOOK_COMMANDS.has(command)) {
+          return false;
+        }
+        return LEGACY_TBD_HOOK_PATTERNS.some((pattern) => pattern.test(command));
       });
       // Keep entries that DON'T have legacy commands
       return !hasLegacyCommand;

--- a/packages/tbd/src/cli/commands/setup.ts
+++ b/packages/tbd/src/cli/commands/setup.ts
@@ -259,20 +259,34 @@ interface SetupCodexOptions {
  * build is accepted and a genuinely newer local CLI is never downgraded.
  */
 const TBD_VERSION_AT_LEAST_FUNCTION = `tbd_version_at_least() {
-  node -e '
-const parse = (version) => {
-  const match = /^(\\d+)\\.(\\d+)\\.(\\d+)(?:[-+]|$)/u.exec(version);
-  return match === null ? null : match.slice(1).map(Number);
-};
-const installed = parse(process.argv[1]);
-const required = parse(process.argv[2]);
-if (installed === null || required === null) process.exit(1);
-for (let index = 0; index < 3; index += 1) {
-  if (installed[index] > required[index]) process.exit(0);
-  if (installed[index] < required[index]) process.exit(1);
-}
-process.exit(0);
-' "$1" "$2"
+  local version_pattern='^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\\+[0-9A-Za-z.-]+)?$'
+  local installed_major installed_minor installed_patch
+  local required_major required_minor required_patch
+
+  if [[ $1 =~ $version_pattern ]]; then
+    installed_major=\${BASH_REMATCH[1]}
+    installed_minor=\${BASH_REMATCH[2]}
+    installed_patch=\${BASH_REMATCH[3]}
+  else
+    return 1
+  fi
+  if [[ $2 =~ $version_pattern ]]; then
+    required_major=\${BASH_REMATCH[1]}
+    required_minor=\${BASH_REMATCH[2]}
+    required_patch=\${BASH_REMATCH[3]}
+  else
+    return 1
+  fi
+
+  if (( installed_major != required_major )); then
+    (( installed_major > required_major ))
+    return
+  fi
+  if (( installed_minor != required_minor )); then
+    (( installed_minor > required_minor ))
+    return
+  fi
+  (( installed_patch >= required_patch ))
 }`;
 
 /**

--- a/packages/tbd/tests/setup-flows.test.ts
+++ b/packages/tbd/tests/setup-flows.test.ts
@@ -4,12 +4,14 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, rm, mkdir, writeFile, readFile, access, realpath } from 'node:fs/promises';
+import { mkdtemp, rm, mkdir, writeFile, readFile, access, realpath, chmod } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 import { execSync, spawnSync } from 'node:child_process';
 import { subprocessTestTimeout } from './test-helpers.js';
 import { CURRENT_FORMAT } from '../src/lib/tbd-format.js';
+
+const itUnix = process.platform === 'win32' ? it.skip : it;
 
 describe('setup flows', { timeout: subprocessTestTimeout() }, () => {
   let tempDir: string;
@@ -99,6 +101,28 @@ describe('setup flows', { timeout: subprocessTestTimeout() }, () => {
       const { readConfig } = await import('../src/file/config.js');
       const config = await readConfig(tempDir);
       expect(config.display.id_prefix).toBe('custom');
+    });
+
+    itUnix('keeps post-setup commands on the running CLI version', async () => {
+      initGitRepo();
+      const fakeBin = join(tempDir, 'foreign-bin');
+      const marker = join(tempDir, 'foreign-tbd-was-run');
+      await mkdir(fakeBin);
+      await writeFile(
+        join(fakeBin, 'tbd'),
+        '#!/bin/bash\nprintf "invoked\\n" > "$TBD_FOREIGN_MARKER"\nexit 99\n',
+      );
+      await chmod(join(fakeBin, 'tbd'), 0o755);
+
+      const result = runTbd(['setup', '--auto', '--prefix=test'], tempDir, {
+        PATH: `${fakeBin}${delimiter}${process.env.PATH ?? ''}`,
+        TBD_FOREIGN_MARKER: marker,
+      });
+
+      expect(result.status).toBe(0);
+      await expect(access(marker)).rejects.toThrow();
+      const config = await readFile(join(tempDir, '.tbd', 'config.yml'), 'utf8');
+      expect(config).toContain(`tbd_format: ${CURRENT_FORMAT}`);
     });
 
     it("shows What's Next section after setup", () => {
@@ -373,6 +397,26 @@ describe('setup flows', { timeout: subprocessTestTimeout() }, () => {
       expect(result.status).toBe(0);
       expect(result.stdout).toContain('tbd initialized');
     });
+
+    it('reports a same-format setup version upgrade once with the commit action', async () => {
+      initGitRepo();
+      expect(runTbd(['setup', '--auto', '--prefix=test']).status).toBe(0);
+
+      const configPath = join(tempDir, '.tbd', 'config.yml');
+      const initialConfig = await readFile(configPath, 'utf-8');
+      const runningVersion = /^tbd_version:\s+(.+)$/mu.exec(initialConfig)?.[1];
+      expect(runningVersion).toBeDefined();
+      await writeFile(configPath, initialConfig.split(runningVersion!).join('0.0.0'));
+
+      const upgraded = runTbd(['setup', '--auto']);
+      expect(upgraded.status).toBe(0);
+      expect(upgraded.stdout).toContain(`Recorded tbd setup version 0.0.0 → ${runningVersion}`);
+      expect(upgraded.stdout).toContain('Review and commit the generated repository changes.');
+
+      const repeated = runTbd(['setup', '--auto']);
+      expect(repeated.status).toBe(0);
+      expect(repeated.stdout).not.toContain('Recorded tbd setup version');
+    });
   });
 
   describe('docs summary', () => {
@@ -467,6 +511,32 @@ describe('setup flows', { timeout: subprocessTestTimeout() }, () => {
       const { readConfig } = await import('../src/file/config.js');
       const config = await readConfig(tempDir);
       expect(config.display.id_prefix).toBe('mylegacy');
+    });
+
+    itUnix('keeps import and dashboard commands on the running CLI version', async () => {
+      initGitRepo();
+      const beadsDir = join(tempDir, '.beads');
+      await mkdir(beadsDir, { recursive: true });
+      await writeFile(join(beadsDir, 'config.yaml'), 'display:\n  id_prefix: oldproj\n');
+      await writeFile(join(beadsDir, 'issues.jsonl'), '');
+
+      const fakeBin = join(tempDir, 'foreign-bin');
+      const marker = join(tempDir, 'foreign-tbd-was-run');
+      await mkdir(fakeBin);
+      await writeFile(
+        join(fakeBin, 'tbd'),
+        '#!/bin/bash\nprintf "invoked\\n" > "$TBD_FOREIGN_MARKER"\nexit 99\n',
+      );
+      await chmod(join(fakeBin, 'tbd'), 0o755);
+
+      const result = runTbd(['setup', '--auto'], tempDir, {
+        PATH: `${fakeBin}${delimiter}${process.env.PATH ?? ''}`,
+        TBD_FOREIGN_MARKER: marker,
+      });
+
+      expect(result.status).toBe(0);
+      await expect(access(marker)).rejects.toThrow();
+      await expect(access(join(tempDir, '.beads-disabled'))).resolves.not.toThrow();
     });
   });
 
@@ -670,6 +740,7 @@ describe('setup flows', { timeout: subprocessTestTimeout() }, () => {
       ]) {
         const script = await readFile(join(tempDir, rel), 'utf-8');
         expect(script).toContain('git rev-parse --show-toplevel');
+        expect(script).toContain('tbd_version_at_least');
         expect(script).toMatch(/npx --yes get-tbd@\d+\.\d+\.\d+ closing/);
       }
     });

--- a/packages/tbd/tests/setup-hooks.test.ts
+++ b/packages/tbd/tests/setup-hooks.test.ts
@@ -10,9 +10,19 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, rm, mkdir, writeFile, readFile, access, realpath, stat } from 'node:fs/promises';
+import {
+  mkdtemp,
+  rm,
+  mkdir,
+  writeFile,
+  readFile,
+  access,
+  realpath,
+  stat,
+  chmod,
+} from 'node:fs/promises';
 import { tmpdir, platform } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 import { execSync, spawnSync } from 'node:child_process';
 
 // Shell script hooks are Unix-only; skip entire suite on Windows
@@ -120,10 +130,79 @@ describeUnix('setup hooks (project-local)', { timeout: 15000 }, () => {
       // Verify key parts of the script: local-first, then a pinned npx fallback.
       expect(content).toContain('#!/bin/bash');
       expect(content).toContain('command -v tbd');
+      expect(content).toContain('tbd_version_at_least');
       expect(content).toContain('npx --yes get-tbd@');
       expect(content).toContain('tbd prime');
       // Must not use an unpinned runner.
       expect(content).not.toContain('npx get-tbd prime');
+    });
+
+    it('uses the pinned fallback only when the local CLI is stale or invalid', async () => {
+      const projectDir = join(tempDir, 'project');
+      await mkdir(projectDir, { recursive: true });
+      initGitRepo(projectDir);
+      expect(runTbd(['setup', '--auto', '--prefix=test'], projectDir).status).toBe(0);
+
+      const scriptPath = join(projectDir, '.claude', 'scripts', 'tbd-session.sh');
+      const script = await readFile(scriptPath, 'utf-8');
+      const pinnedVersion = /get-tbd@(\d+\.\d+\.\d+)/u.exec(script)?.[1];
+      expect(pinnedVersion).toBeDefined();
+
+      const fakeBin = join(tempDir, 'fake-bin');
+      const runnerLog = join(tempDir, 'runner.log');
+      await mkdir(fakeBin);
+      await writeFile(
+        join(fakeBin, 'tbd'),
+        '#!/bin/bash\n' +
+          'if [ "$1" = "--version" ]; then printf "%s\\n" "$FAKE_TBD_VERSION"; exit 0; fi\n' +
+          'printf "tbd %s\\n" "$*" >> "$TBD_RUNNER_LOG"\n',
+      );
+      await writeFile(
+        join(fakeBin, 'npx'),
+        '#!/bin/bash\nprintf "npx %s\\n" "$*" >> "$TBD_RUNNER_LOG"\n',
+      );
+      await chmod(join(fakeBin, 'tbd'), 0o755);
+      await chmod(join(fakeBin, 'npx'), 0o755);
+
+      const cases = [
+        {
+          version: '0.0.0',
+          expected: `npx --yes get-tbd@${pinnedVersion} prime --brief`,
+          fallback: true,
+        },
+        { version: pinnedVersion!, expected: 'tbd prime --brief', fallback: false },
+        { version: `${pinnedVersion}-dev.1.local`, expected: 'tbd prime --brief', fallback: false },
+        { version: `${pinnedVersion}+local.1`, expected: 'tbd prime --brief', fallback: false },
+        { version: '999.0.0', expected: 'tbd prime --brief', fallback: false },
+        {
+          version: 'development',
+          expected: `npx --yes get-tbd@${pinnedVersion} prime --brief`,
+          fallback: true,
+        },
+      ];
+
+      for (const testCase of cases) {
+        await writeFile(runnerLog, '');
+        const result = spawnSync('bash', [scriptPath, '--brief'], {
+          cwd: projectDir,
+          encoding: 'utf-8',
+          env: {
+            ...process.env,
+            HOME: fakeHome,
+            PATH: `${fakeBin}${delimiter}${process.env.PATH ?? ''}`,
+            FAKE_TBD_VERSION: testCase.version,
+            TBD_RUNNER_LOG: runnerLog,
+          },
+        });
+
+        expect(result.status).toBe(0);
+        expect((await readFile(runnerLog, 'utf-8')).trim()).toBe(testCase.expected);
+        if (testCase.fallback) {
+          expect(result.stderr).toContain('using pinned fallback');
+        } else {
+          expect(result.stderr).not.toContain('using pinned fallback');
+        }
+      }
     });
   });
 
@@ -368,8 +447,12 @@ describeUnix('setup hooks (project-local)', { timeout: 15000 }, () => {
       initGitRepo(projectDir);
 
       // Run setup twice
-      runTbd(['setup', '--auto', '--prefix=test'], projectDir);
-      runTbd(['setup', '--auto'], projectDir);
+      const first = runTbd(['setup', '--auto', '--prefix=test'], projectDir);
+      const second = runTbd(['setup', '--auto'], projectDir);
+
+      expect(first.status).toBe(0);
+      expect(second.status).toBe(0);
+      expect(second.stdout + second.stderr).not.toContain('Cleaned up legacy');
 
       const settingsPath = join(projectDir, '.claude', 'settings.json');
       const content = await readFile(settingsPath, 'utf-8');

--- a/packages/tbd/tests/setup-hooks.test.ts
+++ b/packages/tbd/tests/setup-hooks.test.ts
@@ -148,9 +148,12 @@ describeUnix('setup hooks (project-local)', { timeout: 15000 }, () => {
       const pinnedVersion = /get-tbd@(\d+\.\d+\.\d+)/u.exec(script)?.[1];
       expect(pinnedVersion).toBeDefined();
 
-      const fakeBin = join(tempDir, 'fake-bin');
+      // The generated hook deliberately prepends common user-local bin directories.
+      // Put the fakes in the first such directory so a runner-level /usr/local/bin/npx
+      // cannot shadow them on Linux.
+      const fakeBin = join(fakeHome, '.local', 'bin');
       const runnerLog = join(tempDir, 'runner.log');
-      await mkdir(fakeBin);
+      await mkdir(fakeBin, { recursive: true });
       await writeFile(
         join(fakeBin, 'tbd'),
         '#!/bin/bash\n' +

--- a/packages/tbd/tests/setup-hooks.test.ts
+++ b/packages/tbd/tests/setup-hooks.test.ts
@@ -170,12 +170,22 @@ describeUnix('setup hooks (project-local)', { timeout: 15000 }, () => {
           expected: `npx --yes get-tbd@${pinnedVersion} prime --brief`,
           fallback: true,
         },
+        {
+          version: '0.6.1',
+          expected: `npx --yes get-tbd@${pinnedVersion} prime --brief`,
+          fallback: true,
+        },
         { version: pinnedVersion!, expected: 'tbd prime --brief', fallback: false },
         { version: `${pinnedVersion}-dev.1.local`, expected: 'tbd prime --brief', fallback: false },
         { version: `${pinnedVersion}+local.1`, expected: 'tbd prime --brief', fallback: false },
         { version: '999.0.0', expected: 'tbd prime --brief', fallback: false },
         {
           version: 'development',
+          expected: `npx --yes get-tbd@${pinnedVersion} prime --brief`,
+          fallback: true,
+        },
+        {
+          version: '01.2.3',
           expected: `npx --yes get-tbd@${pinnedVersion} prime --brief`,
           fallback: true,
         },
@@ -195,7 +205,7 @@ describeUnix('setup hooks (project-local)', { timeout: 15000 }, () => {
           },
         });
 
-        expect(result.status).toBe(0);
+        expect(result.status, `${testCase.version}: ${result.stderr}`).toBe(0);
         expect((await readFile(runnerLog, 'utf-8')).trim()).toBe(testCase.expected);
         if (testCase.fallback) {
           expect(result.stderr).toContain('using pinned fallback');


### PR DESCRIPTION
## Summary

- Make generated session and closing hooks use a Bash-native numeric SemVer-core check and accept a local `tbd` only when it satisfies the repository pin; stale or malformed installations fall through to the exact pinned package.
- Keep setup follow-up import and dashboard work inside the running CLI, make current hook cleanup idempotent, and report repository version-stamp changes with an explicit review-and-commit handoff.
- Add packed-artifact upgrade QA for the common 0.4.2 path, the immediate 0.5.0 f06 boundary, and the same-format 0.6.1 path; enforce it in CI and the release workflow.
- Prepare the patch release as `get-tbd@0.6.2` with user-facing changelog and publishing guidance.

## Senior review

No unresolved findings. The review specifically checked format compatibility, fail-closed old-client behavior, config/issue preservation, idempotence including newly generated files, current-process command dispatch, SemVer suffixes, shell portability, workflow scoping, release metadata, and supply-chain posture.

The exact published 0.6.1 self-upgrade diff is preserved separately on `codex/evidence-v0.6.1-upgrade` at `67490fd6`.

## Validation

- `pnpm run ci` — 136 files / 2,009 tests passed
- `pnpm audit --prod` — no known vulnerabilities
- `pnpm check:package-age` — 31 third-party pins checked, 0 violations
- `TBD_VERSION_OVERRIDE=0.6.2 pnpm release:verify` — build and publint passed
- packed web proof passed for 0.6.2
- packed upgrade proofs passed: 0.6.1/f07 → 0.6.2/f07, 0.4.2/f06 → 0.6.2/f07, 0.5.0/f06 → 0.6.2/f07
- release metadata and changelog extraction passed for v0.6.2
- pre-commit and pre-push hooks passed

## Supply chain

No dependencies or lockfile entries changed. Historical first-party `jlevy/get-tbd` artifacts are exact-version tarballs with lifecycle scripts disabled. The normal 14-day policy remains enforced for all third-party pins.

Refs: tbd-2ezq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect setup, generated hooks, and release gates—critical for format upgrades and agent sessions—but are heavily tested via new upgrade QA and unit/integration tests with no dependency changes.
> 
> **Overview**
> **get-tbd@0.6.2** tightens repository upgrades so stale global CLIs and repeat setup runs stop breaking teams.
> 
> Generated **session and closing hooks** now call a local `tbd` only when its numeric SemVer core is at least the repository pin (`tbd_version_at_least`); otherwise they fall through to `npx --yes get-tbd@<pin>`. **Setup** no longer treats current Claude hook commands as legacy, reports `tbd_version` transitions with a review-and-commit reminder, and runs post-setup **import** / **prime** via `runImport` / `runPrime` in the current process instead of shelling out to PATH.
> 
> A new **`qa:upgrade-package`** script packs the candidate and exercises upgrades from published **0.6.1** (same-format), **0.4.2**, and **0.5.0** baselines (config/issue preservation, idempotent reruns, old-client fail-closed). CI (Ubuntu/Node 24) and **release.yml** run it; docs and publishing call it out. Version bump, CHANGELOG, and specs document version-aware CLI pinning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49b3947f55bf816531f482941baac6a186c55e0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->