### PR TITLE
chore: upgrade repository setup to tbd v0.6.2

### DIFF
--- a/.claude/hooks/tbd-closing-reminder.sh
+++ b/.claude/hooks/tbd-closing-reminder.sh
@@ -11,12 +11,46 @@ if [[ "$command" == git\ push* ]] || [[ "$command" == *"&& git push"* ]] || [[ "
   repo_root=$(git rev-parse --show-toplevel 2>/dev/null) && cd "$repo_root"
   if [ -d ".tbd" ]; then
     # Same local-first, version-pinned fallback as tbd-session.sh, so the
-    # reminder still fires when tbd is not on the hook's PATH.
+    # reminder still fires when tbd is missing or too old for this repository.
     export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
+    tbd_version_at_least() {
+  local version_pattern='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+  local installed_major installed_minor installed_patch
+  local required_major required_minor required_patch
+
+  if [[ $1 =~ $version_pattern ]]; then
+    installed_major=${BASH_REMATCH[1]}
+    installed_minor=${BASH_REMATCH[2]}
+    installed_patch=${BASH_REMATCH[3]}
+  else
+    return 1
+  fi
+  if [[ $2 =~ $version_pattern ]]; then
+    required_major=${BASH_REMATCH[1]}
+    required_minor=${BASH_REMATCH[2]}
+    required_patch=${BASH_REMATCH[3]}
+  else
+    return 1
+  fi
+
+  if (( installed_major != required_major )); then
+    (( installed_major > required_major ))
+    return
+  fi
+  if (( installed_minor != required_minor )); then
+    (( installed_minor > required_minor ))
+    return
+  fi
+  (( installed_patch >= required_patch ))
+}
+    installed_tbd_version=""
     if command -v tbd &> /dev/null; then
+      installed_tbd_version=$(tbd --version 2>/dev/null || true)
+    fi
+    if [ -n "$installed_tbd_version" ] && tbd_version_at_least "$installed_tbd_version" "0.6.2"; then
       tbd closing
     elif command -v npx &> /dev/null; then
-      npx --yes get-tbd@0.6.1 closing
+      npx --yes get-tbd@0.6.2 closing
     fi
   fi
 fi

--- a/.claude/scripts/tbd-session.sh
+++ b/.claude/scripts/tbd-session.sh
@@ -10,18 +10,61 @@
 # Prefer common local bin locations.
 export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
 
-# Local-first: use tbd if it is already on PATH.
+tbd_version_at_least() {
+  local version_pattern='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+  local installed_major installed_minor installed_patch
+  local required_major required_minor required_patch
+
+  if [[ $1 =~ $version_pattern ]]; then
+    installed_major=${BASH_REMATCH[1]}
+    installed_minor=${BASH_REMATCH[2]}
+    installed_patch=${BASH_REMATCH[3]}
+  else
+    return 1
+  fi
+  if [[ $2 =~ $version_pattern ]]; then
+    required_major=${BASH_REMATCH[1]}
+    required_minor=${BASH_REMATCH[2]}
+    required_patch=${BASH_REMATCH[3]}
+  else
+    return 1
+  fi
+
+  if (( installed_major != required_major )); then
+    (( installed_major > required_major ))
+    return
+  fi
+  if (( installed_minor != required_minor )); then
+    (( installed_minor > required_minor ))
+    return
+  fi
+  (( installed_patch >= required_patch ))
+}
+
+# Local-first when the installed CLI satisfies this repository's pin. An older CLI may
+# be unable to read a newer tbd_format, so let the exact pinned fallback handle upgrades.
+installed_tbd_version=""
 if command -v tbd &> /dev/null; then
+    installed_tbd_version=$(tbd --version 2>/dev/null || true)
+fi
+if [ -n "$installed_tbd_version" ] && tbd_version_at_least "$installed_tbd_version" "0.6.2"; then
     tbd prime "$@"
     exit $?
 fi
 
 # Pinned zero-install fallback. Never use an unpinned runner here.
 if command -v npx &> /dev/null; then
-    npx --yes get-tbd@0.6.1 prime "$@"
+    if [ -n "$installed_tbd_version" ]; then
+        echo "[tbd] Local tbd $installed_tbd_version does not satisfy repository pin 0.6.2; using pinned fallback." >&2
+    fi
+    npx --yes get-tbd@0.6.2 prime "$@"
     exit $?
 fi
 
-echo "[tbd] tbd CLI not found and npx is unavailable."
-echo "[tbd] Install it with: npm install -g get-tbd@0.6.1"
+if [ -n "$installed_tbd_version" ]; then
+    echo "[tbd] Local tbd $installed_tbd_version does not satisfy repository pin 0.6.2, and npx is unavailable."
+else
+    echo "[tbd] tbd CLI not found and npx is unavailable."
+fi
+echo "[tbd] Install it with: npm install -g get-tbd@0.6.2"
 exit 1

--- a/.codex/tbd-closing-reminder.sh
+++ b/.codex/tbd-closing-reminder.sh
@@ -11,12 +11,46 @@ if [[ "$command" == git\ push* ]] || [[ "$command" == *"&& git push"* ]] || [[ "
   repo_root=$(git rev-parse --show-toplevel 2>/dev/null) && cd "$repo_root"
   if [ -d ".tbd" ]; then
     # Same local-first, version-pinned fallback as tbd-session.sh, so the
-    # reminder still fires when tbd is not on the hook's PATH.
+    # reminder still fires when tbd is missing or too old for this repository.
     export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
+    tbd_version_at_least() {
+  local version_pattern='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+  local installed_major installed_minor installed_patch
+  local required_major required_minor required_patch
+
+  if [[ $1 =~ $version_pattern ]]; then
+    installed_major=${BASH_REMATCH[1]}
+    installed_minor=${BASH_REMATCH[2]}
+    installed_patch=${BASH_REMATCH[3]}
+  else
+    return 1
+  fi
+  if [[ $2 =~ $version_pattern ]]; then
+    required_major=${BASH_REMATCH[1]}
+    required_minor=${BASH_REMATCH[2]}
+    required_patch=${BASH_REMATCH[3]}
+  else
+    return 1
+  fi
+
+  if (( installed_major != required_major )); then
+    (( installed_major > required_major ))
+    return
+  fi
+  if (( installed_minor != required_minor )); then
+    (( installed_minor > required_minor ))
+    return
+  fi
+  (( installed_patch >= required_patch ))
+}
+    installed_tbd_version=""
     if command -v tbd &> /dev/null; then
+      installed_tbd_version=$(tbd --version 2>/dev/null || true)
+    fi
+    if [ -n "$installed_tbd_version" ] && tbd_version_at_least "$installed_tbd_version" "0.6.2"; then
       tbd closing
     elif command -v npx &> /dev/null; then
-      npx --yes get-tbd@0.6.1 closing
+      npx --yes get-tbd@0.6.2 closing
     fi
   fi
 fi

--- a/.codex/tbd-session.sh
+++ b/.codex/tbd-session.sh
@@ -10,18 +10,61 @@
 # Prefer common local bin locations.
 export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
 
-# Local-first: use tbd if it is already on PATH.
+tbd_version_at_least() {
+  local version_pattern='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+  local installed_major installed_minor installed_patch
+  local required_major required_minor required_patch
+
+  if [[ $1 =~ $version_pattern ]]; then
+    installed_major=${BASH_REMATCH[1]}
+    installed_minor=${BASH_REMATCH[2]}
+    installed_patch=${BASH_REMATCH[3]}
+  else
+    return 1
+  fi
+  if [[ $2 =~ $version_pattern ]]; then
+    required_major=${BASH_REMATCH[1]}
+    required_minor=${BASH_REMATCH[2]}
+    required_patch=${BASH_REMATCH[3]}
+  else
+    return 1
+  fi
+
+  if (( installed_major != required_major )); then
+    (( installed_major > required_major ))
+    return
+  fi
+  if (( installed_minor != required_minor )); then
+    (( installed_minor > required_minor ))
+    return
+  fi
+  (( installed_patch >= required_patch ))
+}
+
+# Local-first when the installed CLI satisfies this repository's pin. An older CLI may
+# be unable to read a newer tbd_format, so let the exact pinned fallback handle upgrades.
+installed_tbd_version=""
 if command -v tbd &> /dev/null; then
+    installed_tbd_version=$(tbd --version 2>/dev/null || true)
+fi
+if [ -n "$installed_tbd_version" ] && tbd_version_at_least "$installed_tbd_version" "0.6.2"; then
     tbd prime "$@"
     exit $?
 fi
 
 # Pinned zero-install fallback. Never use an unpinned runner here.
 if command -v npx &> /dev/null; then
-    npx --yes get-tbd@0.6.1 prime "$@"
+    if [ -n "$installed_tbd_version" ]; then
+        echo "[tbd] Local tbd $installed_tbd_version does not satisfy repository pin 0.6.2; using pinned fallback." >&2
+    fi
+    npx --yes get-tbd@0.6.2 prime "$@"
     exit $?
 fi
 
-echo "[tbd] tbd CLI not found and npx is unavailable."
-echo "[tbd] Install it with: npm install -g get-tbd@0.6.1"
+if [ -n "$installed_tbd_version" ]; then
+    echo "[tbd] Local tbd $installed_tbd_version does not satisfy repository pin 0.6.2, and npx is unavailable."
+else
+    echo "[tbd] tbd CLI not found and npx is unavailable."
+fi
+echo "[tbd] Install it with: npm install -g get-tbd@0.6.2"
 exit 1

--- a/.tbd/config.yml
+++ b/.tbd/config.yml
@@ -1,5 +1,5 @@
 tbd_format: f07
-tbd_version: 0.6.1
+tbd_version: 0.6.2
 # tbd_upgrades: tbd versions that have run `tbd setup` in this repo (oldest first);
 # tbd_version above is the most recent. Informational; updated automatically by setup.
 tbd_upgrades:
@@ -30,6 +30,8 @@ tbd_upgrades:
     at: 2026-08-11T01:21:24.535Z
   - version: 0.6.1
     at: 2026-08-14T07:29:21.939Z
+  - version: 0.6.2
+    at: 2026-08-14T19:24:20.988Z
 display:
   id_prefix: tbd
 sync:


### PR DESCRIPTION
## Summary

- dogfood the published `get-tbd@0.6.2` package from a fresh `origin/main` branch
- record the repository setup transition from 0.6.1 to 0.6.2 while retaining `tbd_format: f07`
- refresh the generated Claude and Codex session/closing hooks to require a local CLI satisfying the 0.6.2 repository pin

## Review

The published setup generated exactly five tracked changes: four paired hook scripts and `.tbd/config.yml`. There are no hand-edited or unrelated files. The second setup run left both the tracked diff and untracked-file set byte-for-byte unchanged, and did not report legacy cleanup.

This is the post-release repository stamp for #223 and [v0.6.2](https://github.com/jlevy/tbd/releases/tag/v0.6.2). The pre-release evidence remains on `codex/evidence-v0.6.1-upgrade` at `67490fd6`.

## Validation

- public npm `latest` resolves to 0.6.2 with integrity, shasum, and SLSA provenance metadata
- global exact first-party tarball install used disabled lifecycle scripts and a 14-day cutoff for third-party resolution
- independent 79-node production graph matched the global install; `npm audit --omit=dev` found zero vulnerabilities
- `tbd setup --auto` from published 0.6.2, followed by an identical second run
- `bash -n` on all four generated scripts
- live `.codex/tbd-session.sh` invocation reported tbd 0.6.2
- `tbd doctor`: all managed surfaces current (only the intentionally unavailable Linear credential remains)
- `pnpm run ci`: 136 files, 2,009 tests passed
- full pre-push gate: quality, build, and 2,009 tests passed

## Supply chain

No dependencies or lockfile entries changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generated hook and config-only changes with no app or dependency lockfile updates; main effect is consistent agent CLI version selection.
> 
> **Overview**
> Bumps the repo’s **tbd** pin from **0.6.1** to **0.6.2** in `.tbd/config.yml` (including a new `tbd_upgrades` entry) while keeping **`tbd_format: f07`**.
> 
> The generated Claude and Codex **session** and **push closing** hook scripts now use a **`tbd_version_at_least`** check so a local `tbd` is only used when it meets the **0.6.2** pin; otherwise they fall back to **`npx --yes get-tbd@0.6.2`**. Session scripts also log when the local CLI is too old and update install guidance to **0.6.2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7e22635fc720ec629506f704f83da097fade815. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->