### PR TITLE
fix: release format-compatible launchers in tbd v0.6.3

### DIFF
--- a/.agents/skills/tbd/SKILL.md
+++ b/.agents/skills/tbd/SKILL.md
@@ -352,7 +352,7 @@ Load the **General engineering** group first, then the language or framework gro
 
 | Name | Description |
 | --- | --- |
-| backward-compatibility-rules | Guidelines for maintaining backward compatibility across code, APIs, file formats, and database schemas |
+| backward-compatibility-rules | Guidelines for maintaining backward compatibility only for real consumers and data from released versions |
 | commit-conventions | Conventional Commits format with extensions for agentic workflows |
 | error-handling-rules | Rules for handling errors, failures, and exceptional conditions |
 | general-coding-rules | Rules for constants, magic numbers, cryptographic hash checks, and general coding practices |

--- a/.claude/hooks/tbd-closing-reminder.sh
+++ b/.claude/hooks/tbd-closing-reminder.sh
@@ -2,21 +2,48 @@
 # Remind about close protocol after git push
 # Installed by: tbd setup --auto
 
+tbd_configured_fallback_version() {
+  local config_path=$1
+  local line configured_fallback_version
+  local version_pattern='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+
+  while IFS= read -r line; do
+    if [[ $line =~ ^tbd_fallback_version:[[:space:]]*([^[:space:]]+)[[:space:]]*$ ]]; then
+      configured_fallback_version=${BASH_REMATCH[1]}
+      if [[ $configured_fallback_version =~ $version_pattern ]]; then
+        printf '%s\n' "$configured_fallback_version"
+        return 0
+      fi
+      return 1
+    fi
+  done < "$config_path"
+  return 1
+}
+
+tbd_local_can_read_repository() {
+  command -v tbd &> /dev/null && tbd config get tbd_format >/dev/null 2>&1
+}
+
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // empty')
 
 # Check if this is a git push command and .tbd exists
 if [[ "$command" == git\ push* ]] || [[ "$command" == *"&& git push"* ]] || [[ "$command" == *"; git push"* ]]; then
   # The hook may start in a subdirectory; check .tbd at the repo root.
-  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) && cd "$repo_root"
+  if ! repo_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+    exit 0
+  fi
+  cd "$repo_root" || exit 0
   if [ -d ".tbd" ]; then
-    # Same local-first, version-pinned fallback as tbd-session.sh, so the
-    # reminder still fires when tbd is not on the hook's PATH.
+    # Same format-compatible local selection and config-pinned fallback as
+    # tbd-session.sh, so compatible patch releases do not rewrite this hook.
     export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
-    if command -v tbd &> /dev/null; then
+    if tbd_local_can_read_repository; then
       tbd closing
-    elif command -v npx &> /dev/null; then
-      npx --yes get-tbd@0.6.1 closing
+    elif configured_fallback_version=$(tbd_configured_fallback_version ".tbd/config.yml"); then
+      if command -v npx &> /dev/null; then
+        npx --yes "get-tbd@$configured_fallback_version" closing
+      fi
     fi
   fi
 fi

--- a/.claude/scripts/tbd-session.sh
+++ b/.claude/scripts/tbd-session.sh
@@ -2,26 +2,70 @@
 # Ensure the tbd CLI is available and run `tbd prime`.
 # Installed by: tbd setup --auto. Runs on SessionStart and PreCompact.
 #
-# Local-first, then a VERSION-PINNED zero-install fallback. Pinning is both a
-# supply-chain control (an unpinned runner re-resolves to latest on every run
-# and bypasses any cool-off) and a consistency control (every teammate and agent
-# runs the same tbd version).
+# Local-first when the installed CLI can read this repository's tbd_format. Otherwise,
+# use the exact version recorded by setup in .tbd/config.yml. Keeping the pin in config
+# avoids rewriting this script for every compatible patch while retaining deterministic
+# zero-install behavior.
 
 # Prefer common local bin locations.
 export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
 
-# Local-first: use tbd if it is already on PATH.
-if command -v tbd &> /dev/null; then
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$repo_root" ] || [ ! -f "$repo_root/.tbd/config.yml" ]; then
+    echo "[tbd] Cannot locate repository .tbd/config.yml." >&2
+    exit 1
+fi
+cd "$repo_root" || exit 1
+
+tbd_configured_fallback_version() {
+  local config_path=$1
+  local line configured_fallback_version
+  local version_pattern='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+
+  while IFS= read -r line; do
+    if [[ $line =~ ^tbd_fallback_version:[[:space:]]*([^[:space:]]+)[[:space:]]*$ ]]; then
+      configured_fallback_version=${BASH_REMATCH[1]}
+      if [[ $configured_fallback_version =~ $version_pattern ]]; then
+        printf '%s\n' "$configured_fallback_version"
+        return 0
+      fi
+      return 1
+    fi
+  done < "$config_path"
+  return 1
+}
+
+tbd_local_can_read_repository() {
+  command -v tbd &> /dev/null && tbd config get tbd_format >/dev/null 2>&1
+}
+
+if tbd_local_can_read_repository; then
     tbd prime "$@"
     exit $?
 fi
 
-# Pinned zero-install fallback. Never use an unpinned runner here.
+# Read and validate the exact fallback before invoking a package runner. This prevents a
+# malformed or hand-edited config value from becoming an executable package spec.
+if ! configured_fallback_version=$(tbd_configured_fallback_version ".tbd/config.yml"); then
+    echo "[tbd] .tbd/config.yml does not contain a valid exact tbd_fallback_version." >&2
+    echo "[tbd] Run a current 'tbd setup --auto' to repair the managed launcher." >&2
+    exit 1
+fi
+
 if command -v npx &> /dev/null; then
-    npx --yes get-tbd@0.6.1 prime "$@"
+    if command -v tbd &> /dev/null; then
+        echo "[tbd] Local tbd cannot read this repository format; using configured fallback get-tbd@$configured_fallback_version." >&2
+    else
+        echo "[tbd] tbd CLI not found; using configured fallback get-tbd@$configured_fallback_version." >&2
+    fi
+    npx --yes "get-tbd@$configured_fallback_version" prime "$@"
     exit $?
 fi
 
-echo "[tbd] tbd CLI not found and npx is unavailable."
-echo "[tbd] Install it with: npm install -g get-tbd@0.6.1"
+if command -v tbd &> /dev/null; then
+    echo "[tbd] Local tbd cannot read this repository format, and npx is unavailable." >&2
+else
+    echo "[tbd] tbd CLI not found and npx is unavailable." >&2
+fi
+echo "[tbd] Install it with: npm install -g get-tbd@$configured_fallback_version" >&2
 exit 1

--- a/.claude/skills/tbd/SKILL.md
+++ b/.claude/skills/tbd/SKILL.md
@@ -352,7 +352,7 @@ Load the **General engineering** group first, then the language or framework gro
 
 | Name | Description |
 | --- | --- |
-| backward-compatibility-rules | Guidelines for maintaining backward compatibility across code, APIs, file formats, and database schemas |
+| backward-compatibility-rules | Guidelines for maintaining backward compatibility only for real consumers and data from released versions |
 | commit-conventions | Conventional Commits format with extensions for agentic workflows |
 | error-handling-rules | Rules for handling errors, failures, and exceptional conditions |
 | general-coding-rules | Rules for constants, magic numbers, cryptographic hash checks, and general coding practices |

--- a/.codex/tbd-closing-reminder.sh
+++ b/.codex/tbd-closing-reminder.sh
@@ -2,21 +2,48 @@
 # Remind about close protocol after git push
 # Installed by: tbd setup --auto
 
+tbd_configured_fallback_version() {
+  local config_path=$1
+  local line configured_fallback_version
+  local version_pattern='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+
+  while IFS= read -r line; do
+    if [[ $line =~ ^tbd_fallback_version:[[:space:]]*([^[:space:]]+)[[:space:]]*$ ]]; then
+      configured_fallback_version=${BASH_REMATCH[1]}
+      if [[ $configured_fallback_version =~ $version_pattern ]]; then
+        printf '%s\n' "$configured_fallback_version"
+        return 0
+      fi
+      return 1
+    fi
+  done < "$config_path"
+  return 1
+}
+
+tbd_local_can_read_repository() {
+  command -v tbd &> /dev/null && tbd config get tbd_format >/dev/null 2>&1
+}
+
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // empty')
 
 # Check if this is a git push command and .tbd exists
 if [[ "$command" == git\ push* ]] || [[ "$command" == *"&& git push"* ]] || [[ "$command" == *"; git push"* ]]; then
   # The hook may start in a subdirectory; check .tbd at the repo root.
-  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) && cd "$repo_root"
+  if ! repo_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+    exit 0
+  fi
+  cd "$repo_root" || exit 0
   if [ -d ".tbd" ]; then
-    # Same local-first, version-pinned fallback as tbd-session.sh, so the
-    # reminder still fires when tbd is not on the hook's PATH.
+    # Same format-compatible local selection and config-pinned fallback as
+    # tbd-session.sh, so compatible patch releases do not rewrite this hook.
     export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
-    if command -v tbd &> /dev/null; then
+    if tbd_local_can_read_repository; then
       tbd closing
-    elif command -v npx &> /dev/null; then
-      npx --yes get-tbd@0.6.1 closing
+    elif configured_fallback_version=$(tbd_configured_fallback_version ".tbd/config.yml"); then
+      if command -v npx &> /dev/null; then
+        npx --yes "get-tbd@$configured_fallback_version" closing
+      fi
     fi
   fi
 fi

--- a/.codex/tbd-session.sh
+++ b/.codex/tbd-session.sh
@@ -2,26 +2,70 @@
 # Ensure the tbd CLI is available and run `tbd prime`.
 # Installed by: tbd setup --auto. Runs on SessionStart and PreCompact.
 #
-# Local-first, then a VERSION-PINNED zero-install fallback. Pinning is both a
-# supply-chain control (an unpinned runner re-resolves to latest on every run
-# and bypasses any cool-off) and a consistency control (every teammate and agent
-# runs the same tbd version).
+# Local-first when the installed CLI can read this repository's tbd_format. Otherwise,
+# use the exact version recorded by setup in .tbd/config.yml. Keeping the pin in config
+# avoids rewriting this script for every compatible patch while retaining deterministic
+# zero-install behavior.
 
 # Prefer common local bin locations.
 export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
 
-# Local-first: use tbd if it is already on PATH.
-if command -v tbd &> /dev/null; then
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$repo_root" ] || [ ! -f "$repo_root/.tbd/config.yml" ]; then
+    echo "[tbd] Cannot locate repository .tbd/config.yml." >&2
+    exit 1
+fi
+cd "$repo_root" || exit 1
+
+tbd_configured_fallback_version() {
+  local config_path=$1
+  local line configured_fallback_version
+  local version_pattern='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+
+  while IFS= read -r line; do
+    if [[ $line =~ ^tbd_fallback_version:[[:space:]]*([^[:space:]]+)[[:space:]]*$ ]]; then
+      configured_fallback_version=${BASH_REMATCH[1]}
+      if [[ $configured_fallback_version =~ $version_pattern ]]; then
+        printf '%s\n' "$configured_fallback_version"
+        return 0
+      fi
+      return 1
+    fi
+  done < "$config_path"
+  return 1
+}
+
+tbd_local_can_read_repository() {
+  command -v tbd &> /dev/null && tbd config get tbd_format >/dev/null 2>&1
+}
+
+if tbd_local_can_read_repository; then
     tbd prime "$@"
     exit $?
 fi
 
-# Pinned zero-install fallback. Never use an unpinned runner here.
+# Read and validate the exact fallback before invoking a package runner. This prevents a
+# malformed or hand-edited config value from becoming an executable package spec.
+if ! configured_fallback_version=$(tbd_configured_fallback_version ".tbd/config.yml"); then
+    echo "[tbd] .tbd/config.yml does not contain a valid exact tbd_fallback_version." >&2
+    echo "[tbd] Run a current 'tbd setup --auto' to repair the managed launcher." >&2
+    exit 1
+fi
+
 if command -v npx &> /dev/null; then
-    npx --yes get-tbd@0.6.1 prime "$@"
+    if command -v tbd &> /dev/null; then
+        echo "[tbd] Local tbd cannot read this repository format; using configured fallback get-tbd@$configured_fallback_version." >&2
+    else
+        echo "[tbd] tbd CLI not found; using configured fallback get-tbd@$configured_fallback_version." >&2
+    fi
+    npx --yes "get-tbd@$configured_fallback_version" prime "$@"
     exit $?
 fi
 
-echo "[tbd] tbd CLI not found and npx is unavailable."
-echo "[tbd] Install it with: npm install -g get-tbd@0.6.1"
+if command -v tbd &> /dev/null; then
+    echo "[tbd] Local tbd cannot read this repository format, and npx is unavailable." >&2
+else
+    echo "[tbd] tbd CLI not found and npx is unavailable." >&2
+fi
+echo "[tbd] Install it with: npm install -g get-tbd@$configured_fallback_version" >&2
 exit 1

--- a/.tbd/config.yml
+++ b/.tbd/config.yml
@@ -1,7 +1,9 @@
 tbd_format: f07
-tbd_version: 0.6.1
+tbd_version: 0.6.3
+tbd_fallback_version: 0.6.3
 # tbd_upgrades: tbd versions that have run `tbd setup` in this repo (oldest first);
 # tbd_version above is the most recent. Informational; updated automatically by setup.
+# tbd_fallback_version is the one exact registry fallback for format-incompatible launchers.
 tbd_upgrades:
   - version: development
   - version: 0.2.4-dev.58.c593430-dirty
@@ -30,6 +32,8 @@ tbd_upgrades:
     at: 2026-08-11T01:21:24.535Z
   - version: 0.6.1
     at: 2026-08-14T07:29:21.939Z
+  - version: 0.6.3
+    at: 2026-08-14T19:58:08.487Z
 display:
   id_prefix: tbd
 sync:

--- a/docs/project/specs/active/plan-2026-05-24-multi-agent-skills-hooks-setup.md
+++ b/docs/project/specs/active/plan-2026-05-24-multi-agent-skills-hooks-setup.md
@@ -590,9 +590,11 @@ Revised through 2026-08-14:
   surface is self-contained and Codex hooks never reference `.claude/`. The guideline
   treats this as a valid alternative to a shared neutral script.
   (`tbd-orup`)
-- **Version-aware local selection** — the session and closing hooks use a local `tbd`
-  only when its numeric SemVer core satisfies `PINNED_NPM_VERSION`; stale or malformed
-  clients fall through to the exact pin.
+- **Format-compatible local selection with one central pin** — the session and closing
+  hooks use a local `tbd` whenever it can read the repository’s `tbd_format`. If it
+  cannot, they use the strictly validated exact `tbd_fallback_version` from
+  `.tbd/config.yml`. Generated Bash files contain no tbd release literal, so compatible
+  package releases update one config value rather than every launcher.
   The remaining `@latest` usages are forward-compatibility upgrade errors or the
   first-install bootstrap, all of which legitimately want the newest release and must
   not be pinned. (`tbd-shsb`, revised 2026-08-14 by `tbd-2ezq`)
@@ -617,8 +619,10 @@ For tbd specifically:
   This makes version pinning safe on teams: an older tbd fails loudly rather than
   clobbering a newer managed block.
   (`tbd-y84j`, surfaced by `tbd-ymts`)
-- Version pinning in generated invocations serves both supply-chain hardening and
-  cross-team/cross-agent behavioral consistency.
+- The one exact config-level fallback pin serves supply-chain hardening and
+  deterministic recovery at format boundaries.
+  Normal local execution is compatibility-gated rather than release-gated, avoiding
+  needless patch-version churn.
   (`tbd-1h2s`)
 
 ## References

--- a/docs/project/specs/active/plan-2026-08-14-github-cli-session-readiness.md
+++ b/docs/project/specs/active/plan-2026-08-14-github-cli-session-readiness.md
@@ -24,10 +24,12 @@ Give remote agents one clear capability verdict, keep healthy local sessions sil
 move proxy internals behind an on-demand troubleshooting reference.
 
 This plan supersedes the GitHub/session proposals in PRs #219 and #221. Merged PR #223
-is the baseline for repository upgrades, and merged PR #220 supplies the compatibility
-decision procedure. Their incident evidence remains useful input, but their broad
-resident documentation, global-install, wrapper, and durable-state proposals are not the
-intended implementation.
+is the baseline for repository upgrades, PR #226 makes its generated launchers
+format-compatible with one centralized fallback pin, and merged PR #220 supplies the
+compatibility decision procedure.
+Their incident evidence remains useful input, but their broad resident documentation,
+global-install, wrapper, and durable-state proposals are not the intended
+implementation.
 
 ## Goals
 
@@ -45,7 +47,7 @@ intended implementation.
 ## Non-Goals
 
 - Checking npm for newer tbd releases or changing repository upgrade behavior.
-  Merged PR #223 already owns the version-aware hook and setup-upgrade path.
+  PR #226 owns the format-aware launcher and setup-upgrade path.
 - Installing tbd globally from a session hook.
 - Installing a user-level `gh` wrapper, editing shell profiles, or maintaining an
   access-plane state file.
@@ -60,8 +62,8 @@ intended implementation.
 | Compare config `tbd_version` with the running CLI | Drop | It cannot discover the reported failure when both the repository pin and running CLI are equally old. Registry-backed release discovery is a separate policy decision. |
 | Check `latest` during every session | Drop | It adds startup network work and conflicts with the reviewed-version cool-off unless update eligibility is defined separately. |
 | Report setup version transitions and avoid stale local CLIs | Landed in PR #223 | The merged upgrade path is now the implementation baseline, not work for this plan. |
-| Stamp generated scripts | Drop | Generated hooks already contain an exact package pin, and setup/doctor compare their content with the bundled source. Another stamp adds no new signal. |
-| Globally install tbd from the fallback | Drop | Merged PR #223 deliberately chooses a compatible local CLI or the repository-pinned zero-install fallback. A repository hook should not mutate a user-global install. |
+| Stamp generated scripts | Drop | Generated hooks probe `tbd_format`, share one validated `tbd_fallback_version` in config, and are content-checked by setup/doctor. Another stamp adds no new signal. |
+| Globally install tbd from the fallback | Drop | PR #226 deliberately chooses a format-compatible local CLI or the repository-pinned zero-install fallback. A repository hook should not mutate a user-global install. |
 | Install a `~/.local/bin/gh` proxy wrapper | Replace | A wrapper can shadow the real binary and outlive the session or repository that justified it. Use platform-owned session environment persistence instead. |
 | Persist an access-plane state file | Drop | The result is session-dependent and cheap to re-probe; a durable file creates invalidation and trust problems. |
 | Emit one truthful GitHub verdict | Keep | This directly addresses agent confusion, provided healthy local sessions remain silent. |
@@ -182,6 +184,7 @@ session-environment contract is known.
 - [PR #221: agent session ergonomics](https://github.com/jlevy/tbd/pull/221)
 - [PR #219: proxied-session evidence](https://github.com/jlevy/tbd/pull/219)
 - [PR #223: repository upgrade behavior](https://github.com/jlevy/tbd/pull/223)
+- [PR #226: format-compatible launchers](https://github.com/jlevy/tbd/pull/226)
 - [PR #220: backward-compatibility decision procedure](https://github.com/jlevy/tbd/pull/220)
 - [metabrowser PR #43: downstream application of the compatibility template](https://github.com/jlevy/metabrowser/pull/43)
 - [Claude Code hooks: persistent session environment](https://code.claude.com/docs/en/hooks#persist-environment-variables)

--- a/docs/tbd-format-versioning.md
+++ b/docs/tbd-format-versioning.md
@@ -23,6 +23,25 @@ SINGLE SOURCE OF TRUTH: `CURRENT_FORMAT`, `FORMAT_HISTORY`, the per-step migrati
 `formatUpgradeMessage` all live there.
 When bumping `fNN` → `fNN+1` follow the rules below.
 
+Generated session and closing launchers are content-managed artifacts, not additional
+on-disk format markers.
+They first run the installed CLI only if `tbd config get tbd_format` succeeds.
+If that compatibility probe fails, they read the single exact `tbd_fallback_version`
+from `.tbd/config.yml`, validate it as SemVer, and invoke that package.
+As a result:
+
+- compatible patch and minor releases update one central config pin without rewriting
+  every launcher;
+- launcher files change only when their actual behavior changes;
+- a real format boundary still fails closed and uses the exact reviewed fallback.
+
+`tbd_fallback_version` is an additive f07 top-level key, so f07 clients preserve it and
+its introduction does not itself require a format bump.
+Do not bump `tbd_format` merely for a compatible implementation change to a
+content-managed script.
+Do bump when repository data or a format-stamped managed surface becomes incompatible
+with older clients.
+
 ## When a Config Schema Change Needs a Bump
 
 Adding, removing, or changing the meaning of a config field is a format change.

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -1,5 +1,40 @@
 # get-tbd
 
+## 0.6.3
+
+### Fixed
+
+- **Version-independent repository launchers**: Generated session and closing scripts no
+  longer embed the tbd release that created them.
+  They use any installed CLI that can read the repository’s `tbd_format`, so routine
+  compatible releases do not rewrite every downstream repository’s Bash files.
+- **Deterministic incompatible-format recovery**: If the installed CLI cannot read the
+  repository format, launchers use the single exact `tbd_fallback_version` recorded in
+  `.tbd/config.yml`. The value is strictly validated before it reaches `npx`, retaining
+  the reviewed supply-chain pin without duplicating it across generated files.
+
+### Changed
+
+- **Representative upgrade proof**: Packed release QA now starts with the latest 0.6.2
+  same-format release as well as the common 0.4.2 and final f06 0.5.0 baselines.
+  It verifies compatible local selection, exact fallback behavior, preserved data,
+  fail-closed format boundaries, and byte-identical repeated setup.
+
+### Guidelines and content
+
+- **Centralized generated-runner pins**: CLI integration guidance now recommends one
+  validated repository-level fallback pin when several generated launchers share a
+  package, avoiding release-number churn in each script.
+- **Backward-compatibility decisions**: The bundled guideline now starts from verified
+  released consumers and persisted data, selects the smallest valid response, and calls
+  for obsolete aliases, fallbacks, and shims to be removed when their boundary ends.
+
+### Security
+
+- **Dependency posture**: No dependencies or lockfile entries changed.
+  Exact first-party historical `get-tbd` packages are used for upgrade QA with lifecycle
+  scripts disabled; the existing frozen dependency tree is reused.
+
 ## 0.6.2
 
 ### Fixed

--- a/packages/tbd/docs/guidelines/cli-agent-skill-patterns.md
+++ b/packages/tbd/docs/guidelines/cli-agent-skill-patterns.md
@@ -210,6 +210,15 @@ When generated artifacts need a fallback pin, derive it from a known published r
 not the running development build.
 A local version such as `1.5.0-dev.<sha>` may not be resolvable from the registry.
 
+When several committed launchers share the same package, keep that exact pin once in a
+repository-level config or manifest and have each launcher read it.
+Validate the value against a strict package-version grammar before constructing the
+runner argument. This keeps the fallback deterministic while avoiding a rewrite of every
+script for a routine compatible package release.
+Keep compatibility separate from recency: prefer an installed CLI whenever it can safely
+read the repository’s format, even if its release number is older or newer than the
+recorded fallback.
+
 ### Make Failures Actionable
 
 The CLI should:

--- a/packages/tbd/docs/tbd-design.md
+++ b/packages/tbd/docs/tbd-design.md
@@ -1640,7 +1640,12 @@ Project configuration stored in `.tbd/config.yml`:
 
 ```yaml
 # .tbd/config.yml
+tbd_format: f07
 tbd_version: '3.0.0'
+tbd_fallback_version: '3.0.0'
+tbd_upgrades:
+  - version: '3.0.0'
+    at: '2026-01-01T00:00:00.000Z'
 
 sync:
   branch: tbd-sync # Branch name for synced data
@@ -1658,7 +1663,10 @@ settings:
 
 ```typescript
 const ConfigSchema = z.object({
+  tbd_format: z.string(),
   tbd_version: z.string(),
+  tbd_fallback_version: z.string().optional(),
+  tbd_upgrades: z.array(UpgradeEntrySchema).default([]),
   sync: z
     .object({
       branch: z.string().default('tbd-sync'),
@@ -2596,7 +2604,8 @@ If `.tbd/config.yml` does not exist or is invalid, commands exit with an error:
 **Detection logic:**
 
 1. Check for `.tbd/config.yml` existence
-2. Validate `tbd_version` field is present and compatible
+2. Validate the config and require its `tbd_format` to be compatible (`tbd_version` is
+   informational)
 3. If either check fails → error with initialization instructions
 
 **Commands and their initialization requirements:**
@@ -5435,6 +5444,10 @@ installed globally.
 
 The session script handles tbd CLI installation (if missing) and runs `tbd prime`. It is
 committed to the repo so cloud environments bootstrap automatically.
+It contains no tbd release literal: it uses an installed CLI when that CLI can read the
+repository’s `tbd_format`, otherwise it invokes the strictly validated exact
+`tbd_fallback_version` stored once in `.tbd/config.yml`. Compatible package upgrades
+therefore update the central pin without rewriting the script.
 
 **Setup command:**
 

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-tbd",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Git-native issue tracking for AI agents and humans",
   "license": "MIT",
   "author": "Joshua Levy <joshua@cal.berkeley.edu> (https://github.com/jlevy)",

--- a/packages/tbd/scripts/validate-upgrade-package.mjs
+++ b/packages/tbd/scripts/validate-upgrade-package.mjs
@@ -5,7 +5,7 @@
  * Prove a packed candidate upgrades real published repositories safely.
  *
  * Three baselines exercise the real-world path and distinct compatibility contracts:
- * - the latest same-format patch (0.6.1 / f07), whose older client must keep working;
+ * - the latest same-format patch (0.6.2 / f07), whose older client must keep working;
  * - the common pre-f07 release (0.4.2 / f06), whose client must fail closed after upgrade;
  * - the last pre-f07 release (0.5.0 / f06), which guards the immediate format boundary.
  */
@@ -32,7 +32,7 @@ const execFileAsync = promisify(execFile);
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const packageDir = join(scriptDir, '..');
 const sourceRepoDir = join(packageDir, '..', '..');
-const sameFormatBaseline = process.env.TBD_UPGRADE_SAME_FORMAT_FROM ?? '0.6.1';
+const sameFormatBaseline = process.env.TBD_UPGRADE_SAME_FORMAT_FROM ?? '0.6.2';
 const commonUpgradeBaseline = process.env.TBD_UPGRADE_COMMON_FROM ?? '0.4.2';
 const previousFormatBaseline = process.env.TBD_UPGRADE_PREVIOUS_FORMAT_FROM ?? '0.5.0';
 const managedUpgradePaths = new Set([
@@ -292,6 +292,11 @@ async function validateScenario({
     `${name}: config reports ${String(upgradedConfig.tbd_version)}, expected ${candidateVersion}`,
   );
   invariant(
+    upgradedConfig.tbd_fallback_version === candidateVersion,
+    `${name}: config fallback reports ${String(upgradedConfig.tbd_fallback_version)}, ` +
+      `expected ${candidateVersion}`,
+  );
+  invariant(
     upgradedConfig.upgrade_qa?.preserve === 'top-level-value',
     `${name}: top-level config probe was lost`,
   );
@@ -331,10 +336,17 @@ async function validateScenario({
     join(repository, '.claude', 'scripts', 'tbd-session.sh'),
     'utf8',
   );
-  invariant(sessionScript.includes('tbd_version_at_least'), `${name}: version guard is missing`);
   invariant(
-    sessionScript.includes(`get-tbd@${candidateVersion}`),
-    `${name}: session fallback is not pinned to ${candidateVersion}`,
+    sessionScript.includes('tbd config get tbd_format'),
+    `${name}: format compatibility probe is missing`,
+  );
+  invariant(
+    sessionScript.includes('npx --yes "get-tbd@$configured_fallback_version"'),
+    `${name}: session fallback does not read the exact configured version`,
+  );
+  invariant(
+    !/get-tbd@\d+\.\d+\.\d+/u.test(sessionScript),
+    `${name}: session script embeds a release version`,
   );
 
   const firstDiff = await git(repository, 'diff', '--cached', '--binary');

--- a/packages/tbd/src/cli/commands/init.ts
+++ b/packages/tbd/src/cli/commands/init.ts
@@ -12,7 +12,7 @@ import { BaseCommand } from '../lib/base-command.js';
 import { ensureGitignorePatterns } from '../../utils/gitignore-utils.js';
 import { CLIError, ValidationError } from '../lib/errors.js';
 import { isValidPrefix, isRecommendedPrefix } from '../lib/prefix-detection.js';
-import { VERSION } from '../lib/version.js';
+import { PINNED_NPM_VERSION, VERSION } from '../lib/version.js';
 import { initConfig } from '../../file/config.js';
 import {
   TBD_DIR,
@@ -115,7 +115,7 @@ class InitHandler extends BaseCommand {
     await this.execute(async () => {
       // 1. Create .tbd/ directory with config.yml
       // Note: options.prefix is validated to be non-null above
-      const config = await initConfig(cwd, VERSION, options.prefix!);
+      const config = await initConfig(cwd, VERSION, options.prefix!, PINNED_NPM_VERSION);
       this.output.debug(`Created ${TBD_DIR}/config.yml with prefix '${options.prefix}'`);
 
       // 2. Create .tbd/.gitignore (idempotent)

--- a/packages/tbd/src/cli/commands/setup.ts
+++ b/packages/tbd/src/cli/commands/setup.ts
@@ -254,39 +254,32 @@ interface SetupCodexOptions {
 }
 
 /**
- * Shell helper shared by generated hooks that select between a local tbd and the
- * repository-pinned fallback. Compare numeric SemVer cores so a matching development
- * build is accepted and a genuinely newer local CLI is never downgraded.
+ * Shell helpers shared by generated hooks. Compatibility is defined by the repository
+ * format, not by the release that last ran setup: `tbd config get tbd_format` succeeds
+ * only when the local CLI can safely read the config. The exact network fallback stays
+ * deterministic, but its pin is read from config so patch releases do not rewrite every
+ * generated script.
  */
-const TBD_VERSION_AT_LEAST_FUNCTION = `tbd_version_at_least() {
-  local version_pattern='^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\\+[0-9A-Za-z.-]+)?$'
-  local installed_major installed_minor installed_patch
-  local required_major required_minor required_patch
+const TBD_REPOSITORY_RUNNER_FUNCTIONS = `tbd_configured_fallback_version() {
+  local config_path=$1
+  local line configured_fallback_version
+  local version_pattern='^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$'
 
-  if [[ $1 =~ $version_pattern ]]; then
-    installed_major=\${BASH_REMATCH[1]}
-    installed_minor=\${BASH_REMATCH[2]}
-    installed_patch=\${BASH_REMATCH[3]}
-  else
-    return 1
-  fi
-  if [[ $2 =~ $version_pattern ]]; then
-    required_major=\${BASH_REMATCH[1]}
-    required_minor=\${BASH_REMATCH[2]}
-    required_patch=\${BASH_REMATCH[3]}
-  else
-    return 1
-  fi
+  while IFS= read -r line; do
+    if [[ $line =~ ^tbd_fallback_version:[[:space:]]*([^[:space:]]+)[[:space:]]*$ ]]; then
+      configured_fallback_version=\${BASH_REMATCH[1]}
+      if [[ $configured_fallback_version =~ $version_pattern ]]; then
+        printf '%s\\n' "$configured_fallback_version"
+        return 0
+      fi
+      return 1
+    fi
+  done < "$config_path"
+  return 1
+}
 
-  if (( installed_major != required_major )); then
-    (( installed_major > required_major ))
-    return
-  fi
-  if (( installed_minor != required_minor )); then
-    (( installed_minor > required_minor ))
-    return
-  fi
-  (( installed_patch >= required_patch ))
+tbd_local_can_read_repository() {
+  command -v tbd &> /dev/null && tbd config get tbd_format >/dev/null 2>&1
 }`;
 
 /**
@@ -302,42 +295,52 @@ const TBD_SESSION_SCRIPT = `#!/bin/bash
 # Ensure the tbd CLI is available and run \`tbd prime\`.
 # Installed by: tbd setup --auto. Runs on SessionStart and PreCompact.
 #
-# Local-first, then a VERSION-PINNED zero-install fallback. Pinning is both a
-# supply-chain control (an unpinned runner re-resolves to latest on every run
-# and bypasses any cool-off) and a consistency control (every teammate and agent
-# runs the same tbd version).
+# Local-first when the installed CLI can read this repository's tbd_format. Otherwise,
+# use the exact version recorded by setup in .tbd/config.yml. Keeping the pin in config
+# avoids rewriting this script for every compatible patch while retaining deterministic
+# zero-install behavior.
 
 # Prefer common local bin locations.
 export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
 
-${TBD_VERSION_AT_LEAST_FUNCTION}
-
-# Local-first when the installed CLI satisfies this repository's pin. An older CLI may
-# be unable to read a newer tbd_format, so let the exact pinned fallback handle upgrades.
-installed_tbd_version=""
-if command -v tbd &> /dev/null; then
-    installed_tbd_version=$(tbd --version 2>/dev/null || true)
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$repo_root" ] || [ ! -f "$repo_root/.tbd/config.yml" ]; then
+    echo "[tbd] Cannot locate repository .tbd/config.yml." >&2
+    exit 1
 fi
-if [ -n "$installed_tbd_version" ] && tbd_version_at_least "$installed_tbd_version" "${PINNED_NPM_VERSION}"; then
+cd "$repo_root" || exit 1
+
+${TBD_REPOSITORY_RUNNER_FUNCTIONS}
+
+if tbd_local_can_read_repository; then
     tbd prime "$@"
     exit $?
 fi
 
-# Pinned zero-install fallback. Never use an unpinned runner here.
+# Read and validate the exact fallback before invoking a package runner. This prevents a
+# malformed or hand-edited config value from becoming an executable package spec.
+if ! configured_fallback_version=$(tbd_configured_fallback_version ".tbd/config.yml"); then
+    echo "[tbd] .tbd/config.yml does not contain a valid exact tbd_fallback_version." >&2
+    echo "[tbd] Run a current 'tbd setup --auto' to repair the managed launcher." >&2
+    exit 1
+fi
+
 if command -v npx &> /dev/null; then
-    if [ -n "$installed_tbd_version" ]; then
-        echo "[tbd] Local tbd $installed_tbd_version does not satisfy repository pin ${PINNED_NPM_VERSION}; using pinned fallback." >&2
+    if command -v tbd &> /dev/null; then
+        echo "[tbd] Local tbd cannot read this repository format; using configured fallback get-tbd@$configured_fallback_version." >&2
+    else
+        echo "[tbd] tbd CLI not found; using configured fallback get-tbd@$configured_fallback_version." >&2
     fi
-    npx --yes get-tbd@${PINNED_NPM_VERSION} prime "$@"
+    npx --yes "get-tbd@$configured_fallback_version" prime "$@"
     exit $?
 fi
 
-if [ -n "$installed_tbd_version" ]; then
-    echo "[tbd] Local tbd $installed_tbd_version does not satisfy repository pin ${PINNED_NPM_VERSION}, and npx is unavailable."
+if command -v tbd &> /dev/null; then
+    echo "[tbd] Local tbd cannot read this repository format, and npx is unavailable." >&2
 else
-    echo "[tbd] tbd CLI not found and npx is unavailable."
+    echo "[tbd] tbd CLI not found and npx is unavailable." >&2
 fi
-echo "[tbd] Install it with: npm install -g get-tbd@${PINNED_NPM_VERSION}"
+echo "[tbd] Install it with: npm install -g get-tbd@$configured_fallback_version" >&2
 exit 1
 `;
 
@@ -399,26 +402,28 @@ const TBD_CLOSE_PROTOCOL_SCRIPT = `#!/bin/bash
 # Remind about close protocol after git push
 # Installed by: tbd setup --auto
 
+${TBD_REPOSITORY_RUNNER_FUNCTIONS}
+
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // empty')
 
 # Check if this is a git push command and .tbd exists
 if [[ "$command" == git\\ push* ]] || [[ "$command" == *"&& git push"* ]] || [[ "$command" == *"; git push"* ]]; then
   # The hook may start in a subdirectory; check .tbd at the repo root.
-  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) && cd "$repo_root"
+  if ! repo_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+    exit 0
+  fi
+  cd "$repo_root" || exit 0
   if [ -d ".tbd" ]; then
-    # Same local-first, version-pinned fallback as tbd-session.sh, so the
-    # reminder still fires when tbd is missing or too old for this repository.
+    # Same format-compatible local selection and config-pinned fallback as
+    # tbd-session.sh, so compatible patch releases do not rewrite this hook.
     export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
-    ${TBD_VERSION_AT_LEAST_FUNCTION}
-    installed_tbd_version=""
-    if command -v tbd &> /dev/null; then
-      installed_tbd_version=$(tbd --version 2>/dev/null || true)
-    fi
-    if [ -n "$installed_tbd_version" ] && tbd_version_at_least "$installed_tbd_version" "${PINNED_NPM_VERSION}"; then
+    if tbd_local_can_read_repository; then
       tbd closing
-    elif command -v npx &> /dev/null; then
-      npx --yes get-tbd@${PINNED_NPM_VERSION} closing
+    elif configured_fallback_version=$(tbd_configured_fallback_version ".tbd/config.yml"); then
+      if command -v npx &> /dev/null; then
+        npx --yes "get-tbd@$configured_fallback_version" closing
+      fi
     fi
   fi
 fi
@@ -1515,14 +1520,21 @@ class SetupDefaultHandler extends BaseCommand {
       // Stamp the version that ran this setup: refresh tbd_version and append to the
       // upgrade history when the version changed (dedupe keeps re-runs quiet). Runs on
       // every setup, including same-format upgrades where no migration fires.
-      const stamped = stampSetupVersion(config, VERSION);
-      const versionStamped = stamped !== config;
+      const setupVersionChanged =
+        config.tbd_version !== VERSION || config.tbd_upgrades.at(-1)?.version !== VERSION;
+      const fallbackVersionChanged = config.tbd_fallback_version !== PINNED_NPM_VERSION;
+      const stamped = stampSetupVersion(config, {
+        version: VERSION,
+        fallbackVersion: PINNED_NPM_VERSION,
+      });
+      const configStamped = stamped !== config;
 
       if (this.ctx.dryRun) {
-        if (migrated || versionStamped || ghCliChanged) {
+        if (migrated || configStamped || ghCliChanged) {
           this.output.dryRun('Would update .tbd/config.yml', {
             migrated,
             version: VERSION,
+            fallbackVersion: PINNED_NPM_VERSION,
             ghCliChanged,
           });
         }
@@ -1545,11 +1557,16 @@ class SetupDefaultHandler extends BaseCommand {
       // Persist the version stamp and any flag changes (e.g., --no-gh-cli) as a single
       // explicit write. When migrated, this supersedes the data-context write above with
       // the stamped config (the migration notice has already fired).
-      if (!this.ctx.dryRun && (versionStamped || ghCliChanged)) {
+      if (!this.ctx.dryRun && (configStamped || ghCliChanged)) {
         await writeConfig(projectDir, stamped);
-        if (versionStamped) {
+        if (setupVersionChanged) {
           console.log(
             `  ${colors.success('✓')} Recorded tbd setup version ${previousVersion} → ${VERSION}`,
+          );
+          console.log(colors.dim('      Review and commit the generated repository changes.'));
+        } else if (fallbackVersionChanged) {
+          console.log(
+            `  ${colors.success('✓')} Configured exact tbd fallback ${PINNED_NPM_VERSION}`,
           );
           console.log(colors.dim('      Review and commit the generated repository changes.'));
         }
@@ -1886,7 +1903,7 @@ class SetupDefaultHandler extends BaseCommand {
     const colors = this.output.getColors();
 
     // 1. Create .tbd/ directory with config.yml
-    const config = await initConfig(cwd, VERSION, prefix);
+    const config = await initConfig(cwd, VERSION, prefix, PINNED_NPM_VERSION);
     console.log(`  ${colors.success('✓')} Created .tbd/config.yml`);
 
     // 2. Create/update .tbd/.gitignore (idempotent)

--- a/packages/tbd/src/cli/lib/version.ts
+++ b/packages/tbd/src/cli/lib/version.ts
@@ -14,9 +14,9 @@ import { createRequire } from 'node:module';
 
 import { VERSION as BUILD_VERSION } from '../../index.js';
 
-// Build-time injected clean package.json semver (see tsdown.config.ts). Used for
-// pinned `get-tbd@<version>` fallbacks. Unlike VERSION, this is never a
-// git-describe dev/dirty string.
+// Build-time injected clean package.json semver (see tsdown.config.ts). Recorded once
+// in repository config for pinned `get-tbd@<version>` fallbacks. Unlike VERSION, this
+// is never a git-describe dev/dirty string.
 declare const __TBD_PINNED_VERSION__: string;
 
 /** Read the package.json version (dev fallback, when running from source). */
@@ -45,11 +45,10 @@ function getVersion(): string {
 }
 
 /**
- * Clean published npm version for pinned `get-tbd@<version>` fallbacks (the
- * session script and any other generated install hint). Always the package.json
- * semver, NOT the git-describe display version, which for a local/dirty build
- * is an unpublished string like `0.2.3-dev.2.abc1234-dirty` that npm cannot
- * install and that would churn generated files on every build.
+ * Clean published npm version recorded in config for pinned `get-tbd@<version>`
+ * fallbacks. Always the package.json semver, NOT the git-describe display version,
+ * which for a local/dirty build is an unpublished string like
+ * `0.2.3-dev.2.abc1234-dirty` that npm cannot install.
  */
 function getPinnedNpmVersion(): string {
   // Build-time injected clean semver (production).
@@ -66,8 +65,8 @@ function getPinnedNpmVersion(): string {
 export const VERSION = getVersion();
 
 /**
- * Pinned npm version for `get-tbd@<version>` install fallbacks. Use this (not
- * VERSION) anywhere a version is written into a generated file as an installable
- * pin, so dev/dirty builds do not stamp unpublished, churn-prone strings.
+ * Pinned npm version for `get-tbd@<version>` install fallbacks. Use this (not VERSION)
+ * for the single installable pin in repository config; generated scripts read that
+ * field dynamically and therefore do not churn across compatible releases.
  */
 export const PINNED_NPM_VERSION = getPinnedNpmVersion();

--- a/packages/tbd/src/file/config.ts
+++ b/packages/tbd/src/file/config.ts
@@ -62,10 +62,11 @@ function checkFormatCompatibility(data: RawConfig): void {
  * Create default config for a new project.
  * @param prefix - Required: the project prefix for display IDs (e.g., "proj", "myapp")
  */
-function createDefaultConfig(version: string, prefix: string): Config {
+function createDefaultConfig(version: string, prefix: string, fallbackVersion?: string): Config {
   return ConfigSchema.parse({
     tbd_format: CURRENT_FORMAT,
     tbd_version: version,
+    ...(fallbackVersion ? { tbd_fallback_version: fallbackVersion } : {}),
     // Seed the upgrade history with the version that created this repo.
     tbd_upgrades: [{ version, at: now() }],
     sync: {
@@ -92,18 +93,20 @@ export async function initConfig(
   baseDir: string,
   version: string,
   prefix: string,
+  fallbackVersion?: string,
 ): Promise<Config> {
   const tbdDir = join(baseDir, '.tbd');
   await mkdir(tbdDir, { recursive: true });
 
-  const config = createDefaultConfig(version, prefix);
+  const config = createDefaultConfig(version, prefix, fallbackVersion);
   await writeConfig(baseDir, config);
 
   return config;
 }
 
 /**
- * Stamp the config with the version that is running `tbd setup`.
+ * Stamp the config with the version that is running `tbd setup` and the exact published
+ * package version that generated launchers may use as a fallback.
  *
  * Sets `tbd_version` to the running version and, when that version differs from the most
  * recent `tbd_upgrades` entry, appends a new `{ version, at }` entry. Deduping by the
@@ -112,18 +115,26 @@ export async function initConfig(
  * Pure: returns the SAME object when nothing changed (so callers can skip the write via
  * an identity check), or a new config otherwise. The caller persists the result.
  */
-export function stampSetupVersion(config: Config, version: string, at: string = now()): Config {
+export function stampSetupVersion(
+  config: Config,
+  options: { version: string; fallbackVersion: string; at?: string },
+): Config {
+  const { version, fallbackVersion, at = now() } = options;
   const upgrades = config.tbd_upgrades ?? [];
   const last = upgrades[upgrades.length - 1];
 
   if (last?.version === version) {
-    // This version already heads the history; only ensure tbd_version reflects it.
-    return config.tbd_version === version ? config : { ...config, tbd_version: version };
+    // This version already heads the history; only ensure the current and fallback
+    // metadata reflect it. Existing f07 configs acquire the optional fallback here.
+    return config.tbd_version === version && config.tbd_fallback_version === fallbackVersion
+      ? config
+      : { ...config, tbd_version: version, tbd_fallback_version: fallbackVersion };
   }
 
   return {
     ...config,
     tbd_version: version,
+    tbd_fallback_version: fallbackVersion,
     tbd_upgrades: [...upgrades, { version, at }],
   };
 }
@@ -219,6 +230,7 @@ export async function writeConfig(baseDir: string, config: Config): Promise<void
   if (config.tbd_upgrades && config.tbd_upgrades.length > 0) {
     const upgradesComment = `# tbd_upgrades: tbd versions that have run \`tbd setup\` in this repo (oldest first);
 # tbd_version above is the most recent. Informational; updated automatically by setup.
+# tbd_fallback_version is the one exact registry fallback for format-incompatible launchers.
 `;
     content = content.replace('tbd_upgrades:', upgradesComment + 'tbd_upgrades:');
   }

--- a/packages/tbd/src/lib/schemas.ts
+++ b/packages/tbd/src/lib/schemas.ts
@@ -603,6 +603,16 @@ export const ConfigSchema = z
      */
     tbd_version: z.string(),
     /**
+     * Exact published package version used by generated launchers only when the locally
+     * installed CLI cannot read this repository's `tbd_format`. Kept in one central
+     * config field so compatible patch releases do not rewrite every launcher script.
+     * Optional for repositories created before this field was introduced; `tbd setup`
+     * fills it in before installing or refreshing launchers. Parsing stays lenient so
+     * setup can repair a malformed value; each launcher validates the exact package
+     * grammar before passing it to a runner.
+     */
+    tbd_fallback_version: z.string().optional(),
+    /**
      * Ordered history (oldest first) of tbd versions that have run setup here. Appended
      * on each setup when the version changes; informational. Seeded on the f06 migration
      * from the prior `tbd_version` (without a timestamp). See tbd-format.ts.
@@ -806,6 +816,7 @@ export const ISSUE_FIELD_ORDER = [
 export const CONFIG_FIELD_ORDER = [
   'tbd_format',
   'tbd_version',
+  'tbd_fallback_version',
   'tbd_upgrades',
   'display',
   'sync',

--- a/packages/tbd/src/lib/tbd-format.ts
+++ b/packages/tbd/src/lib/tbd-format.ts
@@ -8,10 +8,12 @@
  * - Bump when changes REQUIRE migration (deleting files, changing formats, moving files)
  * - Bump for config removals, renames, semantic changes, or additions inside a nested
  *   schema that does not preserve unknown keys when an older client could lose data.
- * - **Bump when the shape of a generated agent-integration surface changes** (e.g. the
- *   managed AGENTS.md block). This same format is stamped there via
- *   AGENT_INTEGRATION_FORMAT (integration-paths.ts), so there is ONE format code across
- *   all tbd-managed surfaces.
+ * - Bump when the shape of a format-stamped agent-integration surface changes
+ *   incompatibly (e.g. the managed AGENTS.md block). The same format is stamped there
+ *   via AGENT_INTEGRATION_FORMAT (integration-paths.ts).
+ * - Do NOT bump merely because the implementation of a content-managed launcher script
+ *   changes compatibly. Those scripts are refreshed by content comparison and select a
+ *   CLI by probing this repository format at runtime.
  * - Do NOT bump for a purely additive top-level config block, or a key inside an
  *   explicitly passthrough schema, once the repository is on f07.
  * - Do NOT bump for additive changes that don't affect config.yml (new directories, etc.)
@@ -167,6 +169,8 @@ export type FormatVersion = keyof typeof FORMAT_HISTORY;
 export interface RawConfig {
   tbd_format?: string;
   tbd_version?: string;
+  /** Exact published version for generated launchers' incompatible-format fallback. */
+  tbd_fallback_version?: string;
   /** Upgrade history (f06+). Seeded on migration; appended by setup. */
   tbd_upgrades?: { version: string; at?: string }[];
   sync?: {

--- a/packages/tbd/tests/cli-advanced.tryscript.md
+++ b/packages/tbd/tests/cli-advanced.tryscript.md
@@ -279,6 +279,7 @@ $ tbd config show --json
 {
   "tbd_format": "f07",
   "tbd_version": "[..]",
+  "tbd_fallback_version": "[..]",
   "tbd_upgrades": [
     {
       "version": "[..]",

--- a/packages/tbd/tests/cli-shared-common-dir-worktree.tryscript.md
+++ b/packages/tbd/tests/cli-shared-common-dir-worktree.tryscript.md
@@ -133,6 +133,7 @@ tbd_format: f07
 tbd_version: legacy
 # tbd_upgrades: tbd versions that have run `tbd setup` in this repo (oldest first);
 # tbd_version above is the most recent. Informational; updated automatically by setup.
+# tbd_fallback_version is the one exact registry fallback for format-incompatible launchers.
 tbd_upgrades:
   - version: legacy
 display:

--- a/packages/tbd/tests/config.test.ts
+++ b/packages/tbd/tests/config.test.ts
@@ -36,12 +36,13 @@ describe('config operations', () => {
 
   describe('initConfig', () => {
     it('creates config file with defaults', async () => {
-      await initConfig(tempDir, '3.0.0', 'test');
+      await initConfig(tempDir, '3.0.0', 'test', '3.0.0');
 
       const configPath = join(tempDir, CONFIG_FILE);
       const content = await readFile(configPath, 'utf-8');
 
       expect(content).toContain('tbd_version: 3.0.0');
+      expect(content).toContain('tbd_fallback_version: 3.0.0');
       expect(content).toContain('branch: tbd-sync');
       expect(content).toContain('storage: git-common-dir-v1');
       expect(content).toContain('id_prefix: test');
@@ -70,6 +71,7 @@ describe('config operations', () => {
     const base: Config = {
       tbd_format: CURRENT_FORMAT,
       tbd_version: '0.3.0',
+      tbd_fallback_version: '0.3.0',
       tbd_upgrades: [{ version: '0.3.0', at: '2026-06-12T00:00:00.000Z' }],
       sync: { branch: 'tbd-sync', remote: 'origin', storage: 'git-common-dir-v1' },
       display: { id_prefix: 'test' },
@@ -77,26 +79,52 @@ describe('config operations', () => {
     };
 
     it('appends a new entry and updates tbd_version when the version changed', () => {
-      const stamped = stampSetupVersion(base, '0.3.1', '2026-06-13T00:00:00.000Z');
+      const stamped = stampSetupVersion(base, {
+        version: '0.3.1-dev.1.abc1234',
+        fallbackVersion: '0.3.1',
+        at: '2026-06-13T00:00:00.000Z',
+      });
 
       expect(stamped).not.toBe(base);
-      expect(stamped.tbd_version).toBe('0.3.1');
+      expect(stamped.tbd_version).toBe('0.3.1-dev.1.abc1234');
+      expect(stamped.tbd_fallback_version).toBe('0.3.1');
       expect(stamped.tbd_upgrades).toEqual([
         { version: '0.3.0', at: '2026-06-12T00:00:00.000Z' },
-        { version: '0.3.1', at: '2026-06-13T00:00:00.000Z' },
+        { version: '0.3.1-dev.1.abc1234', at: '2026-06-13T00:00:00.000Z' },
       ]);
     });
 
     it('is a no-op (same reference) when the version already heads the history', () => {
-      const stamped = stampSetupVersion(base, '0.3.0', '2026-06-13T00:00:00.000Z');
+      const stamped = stampSetupVersion(base, {
+        version: '0.3.0',
+        fallbackVersion: '0.3.0',
+        at: '2026-06-13T00:00:00.000Z',
+      });
 
       expect(stamped).toBe(base);
       expect(stamped.tbd_upgrades).toHaveLength(1);
     });
 
+    it('adds or refreshes the central fallback without duplicating upgrade history', () => {
+      const configWithoutFallback: Config = { ...base, tbd_fallback_version: undefined };
+      const stamped = stampSetupVersion(configWithoutFallback, {
+        version: '0.3.0',
+        fallbackVersion: '0.3.1',
+        at: '2026-06-13T00:00:00.000Z',
+      });
+
+      expect(stamped).not.toBe(configWithoutFallback);
+      expect(stamped.tbd_fallback_version).toBe('0.3.1');
+      expect(stamped.tbd_upgrades).toEqual(base.tbd_upgrades);
+    });
+
     it('seeds the first entry for a config with no history', () => {
       const noHistory: Config = { ...base, tbd_upgrades: [] };
-      const stamped = stampSetupVersion(noHistory, '0.3.0', '2026-06-13T00:00:00.000Z');
+      const stamped = stampSetupVersion(noHistory, {
+        version: '0.3.0',
+        fallbackVersion: '0.3.0',
+        at: '2026-06-13T00:00:00.000Z',
+      });
 
       expect(stamped.tbd_version).toBe('0.3.0');
       expect(stamped.tbd_upgrades).toEqual([{ version: '0.3.0', at: '2026-06-13T00:00:00.000Z' }]);
@@ -105,11 +133,12 @@ describe('config operations', () => {
 
   describe('readConfig', () => {
     it('reads existing config', async () => {
-      await initConfig(tempDir, '3.0.0', 'test');
+      await initConfig(tempDir, '3.0.0', 'test', '3.0.0');
 
       const config = await readConfig(tempDir);
 
       expect(config.tbd_version).toBe('3.0.0');
+      expect(config.tbd_fallback_version).toBe('3.0.0');
       expect(config.sync.branch).toBe('tbd-sync');
       expect(config.sync.remote).toBe('origin');
       expect(config.display.id_prefix).toBe('test');

--- a/packages/tbd/tests/schemas.test.ts
+++ b/packages/tbd/tests/schemas.test.ts
@@ -274,6 +274,20 @@ describe('ConfigSchema', () => {
     expect(result.success).toBe(false);
   });
 
+  it('preserves the optional launcher fallback for setup and boundary validation', () => {
+    const base = {
+      tbd_version: '3.0.1-dev.2.abc1234',
+      display: { id_prefix: 'proj' },
+    };
+
+    const result = ConfigSchema.safeParse({ ...base, tbd_fallback_version: '3.1.0-beta.2' });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.tbd_fallback_version).toBe('3.1.0-beta.2');
+    }
+  });
+
   describe('docs_cache', () => {
     it('parses config with docs_cache.files', () => {
       const config = {

--- a/packages/tbd/tests/setup-flows.test.ts
+++ b/packages/tbd/tests/setup-flows.test.ts
@@ -731,17 +731,18 @@ describe('setup flows', { timeout: subprocessTestTimeout() }, () => {
         'bash "$CLAUDE_PROJECT_DIR"/.claude/hooks/tbd-closing-reminder.sh',
       );
 
-      // Both generated scripts resolve the repo root before checking .tbd
-      // (the hook may start in a subdirectory) and fall back to a pinned npx
-      // runner when tbd is not on the hook's PATH.
+      // Both generated scripts resolve the repo root before checking .tbd,
+      // probe the local CLI's format compatibility, and read an exact fallback
+      // from config without embedding a release number.
       for (const rel of [
         '.claude/hooks/tbd-closing-reminder.sh',
         '.codex/tbd-closing-reminder.sh',
       ]) {
         const script = await readFile(join(tempDir, rel), 'utf-8');
         expect(script).toContain('git rev-parse --show-toplevel');
-        expect(script).toContain('tbd_version_at_least');
-        expect(script).toMatch(/npx --yes get-tbd@\d+\.\d+\.\d+ closing/);
+        expect(script).toContain('tbd config get tbd_format');
+        expect(script).toContain('npx --yes "get-tbd@$configured_fallback_version" closing');
+        expect(script).not.toMatch(/get-tbd@\d+\.\d+\.\d+/u);
       }
     });
 

--- a/packages/tbd/tests/setup-hooks.test.ts
+++ b/packages/tbd/tests/setup-hooks.test.ts
@@ -127,26 +127,37 @@ describeUnix('setup hooks (project-local)', { timeout: 15000 }, () => {
       const scriptPath = join(projectDir, '.claude', 'scripts', 'tbd-session.sh');
       const content = await readFile(scriptPath, 'utf-8');
 
-      // Verify key parts of the script: local-first, then a pinned npx fallback.
+      // Verify key parts of the script: format-compatible local-first, then an exact
+      // npx fallback read from repository config. Release numbers must not be copied
+      // into every generated script on routine patch upgrades.
       expect(content).toContain('#!/bin/bash');
       expect(content).toContain('command -v tbd');
-      expect(content).toContain('tbd_version_at_least');
-      expect(content).toContain('npx --yes get-tbd@');
+      expect(content).toContain('tbd config get tbd_format');
+      expect(content).toContain('tbd_configured_fallback_version');
+      expect(content).toContain('npx --yes "get-tbd@$configured_fallback_version"');
       expect(content).toContain('tbd prime');
+      expect(content).not.toMatch(/get-tbd@\d+\.\d+\.\d+/u);
       // Must not use an unpinned runner.
       expect(content).not.toContain('npx get-tbd prime');
     });
 
-    it('uses the pinned fallback only when the local CLI is stale or invalid', async () => {
+    it('uses the configured fallback only when the local CLI cannot read the format', async () => {
       const projectDir = join(tempDir, 'project');
       await mkdir(projectDir, { recursive: true });
       initGitRepo(projectDir);
       expect(runTbd(['setup', '--auto', '--prefix=test'], projectDir).status).toBe(0);
 
       const scriptPath = join(projectDir, '.claude', 'scripts', 'tbd-session.sh');
-      const script = await readFile(scriptPath, 'utf-8');
-      const pinnedVersion = /get-tbd@(\d+\.\d+\.\d+)/u.exec(script)?.[1];
-      expect(pinnedVersion).toBeDefined();
+      const scriptBeforePinChange = await readFile(scriptPath, 'utf-8');
+      const configPath = join(projectDir, '.tbd', 'config.yml');
+      const config = (await readFile(configPath, 'utf-8')).replace(
+        /^tbd_fallback_version:.*$/mu,
+        'tbd_fallback_version: 9.8.7-beta.2',
+      );
+      await writeFile(configPath, config);
+      expect(await readFile(scriptPath, 'utf-8')).toBe(scriptBeforePinChange);
+      const configuredVersion = /^tbd_fallback_version:\s*(\S+)$/mu.exec(config)?.[1];
+      expect(configuredVersion).toBeDefined();
 
       // The generated hook deliberately prepends common user-local bin directories.
       // Put the fakes in the first such directory so a runner-level /usr/local/bin/npx
@@ -157,7 +168,10 @@ describeUnix('setup hooks (project-local)', { timeout: 15000 }, () => {
       await writeFile(
         join(fakeBin, 'tbd'),
         '#!/bin/bash\n' +
-          'if [ "$1" = "--version" ]; then printf "%s\\n" "$FAKE_TBD_VERSION"; exit 0; fi\n' +
+          'if [ "$1 $2 $3" = "config get tbd_format" ]; then\n' +
+          '  if [ "$FAKE_TBD_CAN_READ" = "true" ]; then printf "f07\\n"; exit 0; fi\n' +
+          '  exit 1\n' +
+          'fi\n' +
           'printf "tbd %s\\n" "$*" >> "$TBD_RUNNER_LOG"\n',
       );
       await writeFile(
@@ -169,27 +183,15 @@ describeUnix('setup hooks (project-local)', { timeout: 15000 }, () => {
 
       const cases = [
         {
-          version: '0.0.0',
-          expected: `npx --yes get-tbd@${pinnedVersion} prime --brief`,
-          fallback: true,
+          name: 'format-compatible local CLI',
+          canRead: true,
+          expected: 'tbd prime --brief',
+          fallback: false,
         },
         {
-          version: '0.6.1',
-          expected: `npx --yes get-tbd@${pinnedVersion} prime --brief`,
-          fallback: true,
-        },
-        { version: pinnedVersion!, expected: 'tbd prime --brief', fallback: false },
-        { version: `${pinnedVersion}-dev.1.local`, expected: 'tbd prime --brief', fallback: false },
-        { version: `${pinnedVersion}+local.1`, expected: 'tbd prime --brief', fallback: false },
-        { version: '999.0.0', expected: 'tbd prime --brief', fallback: false },
-        {
-          version: 'development',
-          expected: `npx --yes get-tbd@${pinnedVersion} prime --brief`,
-          fallback: true,
-        },
-        {
-          version: '01.2.3',
-          expected: `npx --yes get-tbd@${pinnedVersion} prime --brief`,
+          name: 'format-incompatible local CLI',
+          canRead: false,
+          expected: `npx --yes get-tbd@${configuredVersion} prime --brief`,
           fallback: true,
         },
       ];
@@ -203,19 +205,74 @@ describeUnix('setup hooks (project-local)', { timeout: 15000 }, () => {
             ...process.env,
             HOME: fakeHome,
             PATH: `${fakeBin}${delimiter}${process.env.PATH ?? ''}`,
-            FAKE_TBD_VERSION: testCase.version,
+            FAKE_TBD_CAN_READ: String(testCase.canRead),
             TBD_RUNNER_LOG: runnerLog,
           },
         });
 
-        expect(result.status, `${testCase.version}: ${result.stderr}`).toBe(0);
+        expect(result.status, `${testCase.name}: ${result.stderr}`).toBe(0);
         expect((await readFile(runnerLog, 'utf-8')).trim()).toBe(testCase.expected);
         if (testCase.fallback) {
-          expect(result.stderr).toContain('using pinned fallback');
+          expect(result.stderr).toContain('cannot read this repository format');
         } else {
-          expect(result.stderr).not.toContain('using pinned fallback');
+          expect(result.stderr).not.toContain('cannot read this repository format');
         }
       }
+    });
+
+    it('rejects an invalid configured fallback without invoking npx', async () => {
+      const projectDir = join(tempDir, 'project');
+      await mkdir(projectDir, { recursive: true });
+      initGitRepo(projectDir);
+      expect(runTbd(['setup', '--auto', '--prefix=test'], projectDir).status).toBe(0);
+
+      const configPath = join(projectDir, '.tbd', 'config.yml');
+      await writeFile(
+        configPath,
+        (await readFile(configPath, 'utf-8')).replace(
+          /^tbd_fallback_version:.*$/mu,
+          'tbd_fallback_version: 0.6.3; touch SHOULD_NOT_RUN',
+        ),
+      );
+
+      const fakeBin = join(fakeHome, '.local', 'bin');
+      const runnerLog = join(tempDir, 'invalid-pin-runner.log');
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(
+        join(fakeBin, 'tbd'),
+        '#!/bin/bash\nif [ "$1 $2 $3" = "config get tbd_format" ]; then exit 1; fi\n',
+      );
+      await writeFile(
+        join(fakeBin, 'npx'),
+        '#!/bin/bash\nprintf "npx %s\\n" "$*" >> "$TBD_RUNNER_LOG"\n',
+      );
+      await chmod(join(fakeBin, 'tbd'), 0o755);
+      await chmod(join(fakeBin, 'npx'), 0o755);
+
+      const result = spawnSync('bash', [join(projectDir, '.claude', 'scripts', 'tbd-session.sh')], {
+        cwd: projectDir,
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          HOME: fakeHome,
+          PATH: `${fakeBin}${delimiter}${process.env.PATH ?? ''}`,
+          TBD_RUNNER_LOG: runnerLog,
+        },
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('valid exact tbd_fallback_version');
+      await expect(access(runnerLog)).rejects.toThrow();
+      await expect(access(join(projectDir, 'SHOULD_NOT_RUN'))).rejects.toThrow();
+
+      // The recovery instruction must be truthful: setup reads the inert string,
+      // replaces it with its own package pin, and never evaluates the payload.
+      const repair = runTbd(['setup', '--auto'], projectDir);
+      expect(repair.status, repair.stderr).toBe(0);
+      expect(await readFile(configPath, 'utf-8')).toMatch(
+        /^tbd_fallback_version:\s*\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/mu,
+      );
+      await expect(access(join(projectDir, 'SHOULD_NOT_RUN'))).rejects.toThrow();
     });
   });
 
@@ -581,11 +638,11 @@ echo "This is outdated"
       const refreshedContent = await readFile(scriptPath, 'utf-8');
       expect(refreshedContent).not.toContain('This is outdated');
       expect(refreshedContent).toContain('command -v tbd');
-      expect(refreshedContent).toContain('npx --yes get-tbd@');
+      expect(refreshedContent).toContain('npx --yes "get-tbd@$configured_fallback_version"');
       expect(refreshedContent).toContain('tbd prime');
     });
 
-    it('pins the get-tbd version in the npx fallback', async () => {
+    it('reads the exact npx fallback from config without embedding a release', async () => {
       const projectDir = join(tempDir, 'project');
       await mkdir(projectDir, { recursive: true });
       initGitRepo(projectDir);
@@ -595,8 +652,9 @@ echo "This is outdated"
       const scriptPath = join(projectDir, '.claude', 'scripts', 'tbd-session.sh');
       const content = await readFile(scriptPath, 'utf-8');
 
-      // The fallback must reference a pinned version (get-tbd@<semver>), never bare.
-      expect(content).toMatch(/npx --yes get-tbd@\d+\.\d+\.\d+/);
+      expect(content).toContain('tbd_configured_fallback_version');
+      expect(content).toContain('npx --yes "get-tbd@$configured_fallback_version"');
+      expect(content).not.toMatch(/get-tbd@\d+\.\d+\.\d+/u);
     });
 
     it('refreshed script preserves executable permissions', async () => {

--- a/packages/tbd/tsdown.config.ts
+++ b/packages/tbd/tsdown.config.ts
@@ -8,10 +8,9 @@ import { getGitVersion } from './scripts/git-version.mjs';
 // Full git-describe version, used for display/diagnostics (e.g. `tbd --version`).
 const version = getGitVersion();
 
-// Clean published semver from package.json, used for pinned `get-tbd@<version>`
-// fallbacks (e.g. the session script). Unlike `version`, this is never a
-// dev/dirty git-describe string — that would not be installable from npm and
-// would churn generated files on every local build.
+// Clean published semver from package.json, recorded once in repository config for
+// pinned `get-tbd@<version>` fallbacks. Unlike `version`, this is never a dev/dirty
+// git-describe string, and generated scripts do not embed it.
 const pinnedVersion = (
   JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as {
     version: string;


### PR DESCRIPTION
## 0.6.3

### Fixed

- **Version-independent repository launchers**: Generated session and closing scripts no
  longer embed the tbd release that created them.
  They use any installed CLI that can read the repository’s `tbd_format`, so routine
  compatible releases do not rewrite every downstream repository’s Bash files.
- **Deterministic incompatible-format recovery**: If the installed CLI cannot read the
  repository format, launchers use the single exact `tbd_fallback_version` recorded in
  `.tbd/config.yml`. The value is strictly validated before it reaches `npx`, retaining
  the reviewed supply-chain pin without duplicating it across generated files.

### Changed

- **Representative upgrade proof**: Packed release QA now starts with the latest 0.6.2
  same-format release as well as the common 0.4.2 and final f06 0.5.0 baselines.
  It verifies compatible local selection, exact fallback behavior, preserved data,
  fail-closed format boundaries, and byte-identical repeated setup.

### Guidelines and content

- **Centralized generated-runner pins**: CLI integration guidance now recommends one
  validated repository-level fallback pin when several generated launchers share a
  package, avoiding release-number churn in each script.
- **Backward-compatibility decisions**: The bundled guideline now starts from verified
  released consumers and persisted data, selects the smallest valid response, and calls
  for obsolete aliases, fallbacks, and shims to be removed when their boundary ends.

### Security

- **Dependency posture**: No dependencies or lockfile entries changed.
  Exact first-party historical `get-tbd` packages are used for upgrade QA with lifecycle
  scripts disabled; the existing frozen dependency tree is reused.

## Validation

- Full local CI: 2,012 tests, formatting, lint, typecheck, and build
- Packed upgrades: 0.6.2/f07, 0.4.2/f06, and 0.5.0/f06
- Packed web proof, watch release smoke, publint, and release metadata
- Runtime audit: zero known vulnerabilities
- Package-age policy: 31 pins checked, zero violations
- Fresh origin/main self-upgrade: seven managed files; identical second-run diff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent session bootstrap and git-push closing hooks across Claude/Codex; mis-selection or bad fallback validation could break `tbd prime`/`closing`, though tests and strict SemVer parsing mitigate that.
> 
> **Overview**
> **v0.6.3** stops embedding release numbers in generated session and closing hooks. Launchers now prefer any local `tbd` that can read the repo (`tbd config get tbd_format`); otherwise they use a single **SemVer-validated** `tbd_fallback_version` from `.tbd/config.yml` for `npx get-tbd@…`, so compatible patch upgrades update config instead of rewriting every downstream Bash file.
> 
> `init`/`setup` stamp `tbd_fallback_version` alongside `tbd_version`, upgrade QA asserts the new contract (no literal pins in scripts, 0.6.2 same-format baseline), and docs/specs clarify that launcher behavior is content-managed and does not require a format bump when only the selection logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59872ba44abd12f1d6c2c405d22c797528b53808. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->