### PR TITLE
fix: make a sync with nothing to do actually cost nothing

### DIFF
--- a/packages/tbd/docs/shortcuts/standard/setup-linear.md
+++ b/packages/tbd/docs/shortcuts/standard/setup-linear.md
@@ -85,8 +85,19 @@ integrations:
 
 Leave `policy: default` unless the user asks for something else.
 It selects open epics plus anything whose `spec_path` points into `specs/active/`—the
-right starting point for “track our specs and major work”, and roughly 10% of a typical
-repository’s beads.
+right starting point for “track our specs and major work”.
+
+**Size that selection before the first sync, because it is easy to underestimate.**
+`spec_path` propagates from a parent bead to its descendants, so the spec clause selects
+every descendant of every epic carrying a live spec.
+In a spec-driven repository that can be a large share of open work rather than a small
+one. Two things to check with the user when the preview looks bigger than expected:
+
+- `tbd --dry-run integration sync --push` lists exactly which beads would be mirrored.
+- Beads nested deeper than `max_nesting` (default 2) *within the selected set* are
+  reported as skipped rather than created, so the number of Linear issues is normally
+  smaller than the number of selected beads.
+  Both numbers appear in the dry run.
 
 **Then run `tbd setup --auto` before committing.** Writing the block leaves the
 repository at whatever format it was on; setup stamps `tbd_format: f07`, which is what

--- a/packages/tbd/docs/tbd-docs.md
+++ b/packages/tbd/docs/tbd-docs.md
@@ -1668,9 +1668,10 @@ would ask about in a status meeting, plus whatever carries a live plan spec.
 **Judge that against *open* work, not against every bead you have ever closed.** Status
 gates the selection, so closed beads can never be mirrored and including them in the
 denominator makes any policy look small.
-In this repository the default policy selects 151 beads: about 9% of all 1,726 beads,
-but **52% of the 291 that are still open** — and the second number is the one that
-predicts what lands in the tracker.
+Measured in this repository on 2026-08-14, the default policy selected 151 beads: about
+9% of all 1,726 beads, but **52% of the 291 that were still open**. Both numbers move as
+a repository grows; the second is the one that predicts what lands in the tracker.
+Run `tbd --dry-run integration sync --push` for your own current count.
 
 The default policy is *open epics, or anything whose `spec_path` points into
 `specs/active/`*. Kind and spec are **alternatives**, not requirements, so both “every

--- a/packages/tbd/docs/tbd-docs.md
+++ b/packages/tbd/docs/tbd-docs.md
@@ -1662,10 +1662,15 @@ Both are inert when nothing is enabled.
 
 ### What to sync
 
-**Mirror the shape of the work, not the work itself.** A useful rule of thumb is around
-**10% of your beads**: the epics someone would ask about in a status meeting, plus
-whatever carries a live plan spec.
-In this repository that is 122 of 1,372 beads, or 8%.
+**Mirror the shape of the work, not the work itself.** The target is the epics someone
+would ask about in a status meeting, plus whatever carries a live plan spec.
+
+**Judge that against *open* work, not against every bead you have ever closed.** Status
+gates the selection, so closed beads can never be mirrored and including them in the
+denominator makes any policy look small.
+In this repository the default policy selects 151 beads: about 9% of all 1,726 beads,
+but **52% of the 291 that are still open** — and the second number is the one that
+predicts what lands in the tracker.
 
 The default policy is *open epics, or anything whose `spec_path` points into
 `specs/active/`*. Kind and spec are **alternatives**, not requirements, so both “every

--- a/packages/tbd/src/cli/commands/sync.ts
+++ b/packages/tbd/src/cli/commands/sync.ts
@@ -148,18 +148,18 @@ class SyncHandler extends BaseCommand {
     //
     // This must survive the default invocation: `info()` is verbose-only, so
     // reporting it there would leave the ordinary run exactly as silent as
-    // before. `data()` gives the structured form under --json and the
-    // default-visible `notice()` otherwise. Dry runs report it too — "what
-    // would this do?" has to include "not the tracker".
+    // before. `notice()` gives the default-visible text form and writes its
+    // structured diagnostic to stderr under --json, preserving stdout's
+    // single-result-document contract. Dry runs report it too — "what would
+    // this do?" has to include "not the tracker".
     if (!syncIntegrations && !options.status) {
       const config = await readConfig(tbdRoot);
       if (!integrationsInert(config) && config.integrations?.sync_on_tbd_sync !== false) {
-        this.output.data({ skippedSurfaces: ['integrations'] }, () => {
-          this.output.notice(
-            'Skipping external trackers for this run (surface flag given). ' +
-              'Run `tbd sync` or `tbd sync --integrations` to reconcile them.',
-          );
-        });
+        this.output.notice(
+          'Skipping external trackers for this run (surface flag given). ' +
+            'Run `tbd sync` or `tbd sync --integrations` to reconcile them.',
+          { skippedSurfaces: ['integrations'] },
+        );
       }
     }
 

--- a/packages/tbd/src/cli/commands/sync.ts
+++ b/packages/tbd/src/cli/commands/sync.ts
@@ -145,13 +145,21 @@ class SyncHandler extends BaseCommand {
     // Narrowing to a surface excludes the tracker, which is easy to do by
     // accident (`--issues` reads like "the issue surface", and the tracker IS
     // issues). Say so rather than letting the mirror go quietly stale.
-    if (!syncIntegrations && !options.status && !this.ctx.dryRun) {
+    //
+    // This must survive the default invocation: `info()` is verbose-only, so
+    // reporting it there would leave the ordinary run exactly as silent as
+    // before. `data()` gives the structured form under --json and the
+    // default-visible `notice()` otherwise. Dry runs report it too — "what
+    // would this do?" has to include "not the tracker".
+    if (!syncIntegrations && !options.status) {
       const config = await readConfig(tbdRoot);
       if (!integrationsInert(config) && config.integrations?.sync_on_tbd_sync !== false) {
-        this.output.info(
-          'Skipping external trackers for this run (surface flag given). ' +
-            'Run `tbd sync` or `tbd sync --integrations` to reconcile them.',
-        );
+        this.output.data({ skippedSurfaces: ['integrations'] }, () => {
+          this.output.notice(
+            'Skipping external trackers for this run (surface flag given). ' +
+              'Run `tbd sync` or `tbd sync --integrations` to reconcile them.',
+          );
+        });
       }
     }
 

--- a/packages/tbd/src/cli/commands/sync.ts
+++ b/packages/tbd/src/cli/commands/sync.ts
@@ -142,6 +142,19 @@ class SyncHandler extends BaseCommand {
     const syncIssues = Boolean(options.issues) || hasDirectionFlag || !hasSurfaceFlag;
     const syncIntegrations = Boolean(options.integrations) || (!hasSurfaceFlag && !options.status);
 
+    // Narrowing to a surface excludes the tracker, which is easy to do by
+    // accident (`--issues` reads like "the issue surface", and the tracker IS
+    // issues). Say so rather than letting the mirror go quietly stale.
+    if (!syncIntegrations && !options.status && !this.ctx.dryRun) {
+      const config = await readConfig(tbdRoot);
+      if (!integrationsInert(config) && config.integrations?.sync_on_tbd_sync !== false) {
+        this.output.info(
+          'Skipping external trackers for this run (surface flag given). ' +
+            'Run `tbd sync` or `tbd sync --integrations` to reconcile them.',
+        );
+      }
+    }
+
     // Every surface runs independently and its failure is collected rather
     // than thrown: one surface failing (an expired tracker credential, say)
     // must never stop another from completing, and must never cost data that
@@ -1152,7 +1165,8 @@ class SyncHandler extends BaseCommand {
       this.output.debug(`Fetch failed (may be first sync): ${(error as Error).message}`);
     }
 
-    // Integration fold, off by default. This is the one correct moment for
+    // Integration fold, on by default (`sync_on_tbd_sync` defaults to true;
+    // enabling a provider IS the opt-in). This is the one correct moment for
     // it: AFTER pull/merge (so reconciliation sees other machines' bead
     // changes instead of pushing stale state to the tracker) and BEFORE the
     // push (so the beads and bridge records it writes ride this very push).

--- a/packages/tbd/src/cli/lib/output.ts
+++ b/packages/tbd/src/cli/lib/output.ts
@@ -398,10 +398,16 @@ export class OutputManager {
 
   /**
    * Output notice message - noteworthy events during normal operation.
-   * Blue bullet, shown at default level. Suppressed by --quiet and --json.
+   * Blue bullet, shown at default level. Suppressed by --quiet. In JSON mode,
+   * optional structured data is emitted to stderr so stdout remains one
+   * machine-readable result document.
    */
-  notice(message: string): void {
-    if (!this.ctx.json && !this.ctx.quiet) {
+  notice(message: string, jsonData?: unknown): void {
+    if (this.ctx.json) {
+      if (jsonData !== undefined) {
+        console.error(JSON.stringify(jsonData));
+      }
+    } else if (!this.ctx.quiet) {
       console.log(this.colors.info(`${ICONS.NOTICE} ${message}`));
     }
   }

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -1014,6 +1014,12 @@ export async function pushWithRetry(
 ): Promise<PushResult> {
   // Use explicit refspec to avoid ambiguity with tags or other refs
   const refspec = `refs/heads/${syncBranch}:refs/heads/${syncBranch}`;
+  // `--no-verify` for the same reason the sync-branch COMMITS use it: the
+  // branch carries bead bookkeeping, never source code, so a parent repo's
+  // pre-push gate (lefthook, husky) has nothing to say about it. Without this
+  // every sync pays for that gate — a full test suite in this repository — and
+  // the retry loop below pays for it again on each non-fast-forward.
+  const pushArgs = ['push', '--no-verify', remote, refspec];
   // Build -C prefix args when baseDir is provided
   const dirArgs = baseDir ? ['-C', baseDir] : [];
 
@@ -1026,7 +1032,7 @@ export async function pushWithRetry(
   for (let attempt = 1; attempt <= MAX_PUSH_RETRIES; attempt++) {
     try {
       // Try to push
-      await git(...dirArgs, 'push', remote, refspec);
+      await git(...dirArgs, ...pushArgs);
       return {
         success: true,
         attempt,
@@ -1579,7 +1585,16 @@ export async function pushFreshOrphan(
   dataSyncPath: string,
 ): Promise<{ pushed: boolean; adopted: boolean }> {
   try {
-    await gitNoPrompt('-C', worktreePath, 'push', remote, `HEAD:refs/heads/${syncBranch}`);
+    // `--no-verify` for the same reason as pushWithRetry: the sync branch is
+    // bead bookkeeping, not source, so parent-repo pre-push gates do not apply.
+    await gitNoPrompt(
+      '-C',
+      worktreePath,
+      'push',
+      '--no-verify',
+      remote,
+      `HEAD:refs/heads/${syncBranch}`,
+    );
     return { pushed: true, adopted: false };
   } catch (err) {
     if (!isNonFastForward(err)) {

--- a/packages/tbd/src/integrations/core/bridge-state.ts
+++ b/packages/tbd/src/integrations/core/bridge-state.ts
@@ -16,6 +16,7 @@
 import { createHash } from 'node:crypto';
 import { mkdir, readdir, readFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
 
 import { writeFile } from 'atomically';
 
@@ -131,25 +132,31 @@ export async function writeLinkRecord(
 }
 
 /**
- * True when two records differ in anything that matters.
+ * Every field whose change makes a record worth rewriting.
  *
- * `synced_at` is deliberately excluded: it advances on every run, so comparing
- * it would make every record differ from itself and defeat the caller. It is
- * not merely cosmetic — `pickNewestLinkRecord` uses it as a merge tiebreaker —
- * which is why it is skipped here rather than removed from the record.
+ * Exhaustive over `LinkRecord` minus `synced_at`, so adding a field to
+ * `LinkRecordSchema` fails to compile here until someone decides whether it is
+ * substantive. A hand-listed comparator would instead treat the new field as
+ * cosmetic and silently stop persisting it.
+ *
+ * `synced_at` is the one deliberate omission: it advances on every run, so
+ * including it would make every record differ from itself and defeat the
+ * caller. It is not merely cosmetic — `pickNewestLinkRecord` uses it as a merge
+ * tiebreaker — which is why it stays in the record and is skipped only here.
  */
+const SUBSTANTIVE_FIELDS: Readonly<Record<Exclude<keyof LinkRecord, 'synced_at'>, true>> = {
+  type: true,
+  bead_id: true,
+  external_id: true,
+  base: true,
+  remote_updated_at: true,
+  state: true,
+};
+
+/** True when two records differ in anything that matters. */
 function recordSubstantivelyDiffers(a: LinkRecord, b: LinkRecord): boolean {
-  return (
-    a.external_id !== b.external_id ||
-    a.remote_updated_at !== b.remote_updated_at ||
-    a.state !== b.state ||
-    a.base.title !== b.base.title ||
-    a.base.status !== b.base.status ||
-    a.base.priority !== b.base.priority ||
-    a.base.assignee !== b.base.assignee ||
-    a.base.description_hash !== b.base.description_hash ||
-    a.base.labels.length !== b.base.labels.length ||
-    a.base.labels.some((label, index) => label !== b.base.labels[index])
+  return (Object.keys(SUBSTANTIVE_FIELDS) as Exclude<keyof LinkRecord, 'synced_at'>[]).some(
+    (key) => !isDeepStrictEqual(a[key], b[key]),
   );
 }
 

--- a/packages/tbd/src/integrations/core/bridge-state.ts
+++ b/packages/tbd/src/integrations/core/bridge-state.ts
@@ -130,6 +130,52 @@ export async function writeLinkRecord(
   await writeFile(join(dir, `${record.bead_id}.yml`), stringifyYaml(record));
 }
 
+/**
+ * True when two records differ in anything that matters.
+ *
+ * `synced_at` is deliberately excluded: it advances on every run, so comparing
+ * it would make every record differ from itself and defeat the caller. It is
+ * not merely cosmetic — `pickNewestLinkRecord` uses it as a merge tiebreaker —
+ * which is why it is skipped here rather than removed from the record.
+ */
+function recordSubstantivelyDiffers(a: LinkRecord, b: LinkRecord): boolean {
+  return (
+    a.external_id !== b.external_id ||
+    a.remote_updated_at !== b.remote_updated_at ||
+    a.state !== b.state ||
+    a.base.title !== b.base.title ||
+    a.base.status !== b.base.status ||
+    a.base.priority !== b.base.priority ||
+    a.base.assignee !== b.base.assignee ||
+    a.base.description_hash !== b.base.description_hash ||
+    a.base.labels.length !== b.base.labels.length ||
+    a.base.labels.some((label, index) => label !== b.base.labels[index])
+  );
+}
+
+/**
+ * Write a link record only when it actually changed.
+ *
+ * A settled mirror re-reconciles every linked pair on every sync and arrives at
+ * the same answer. Writing unconditionally would therefore rewrite one file per
+ * linked bead on every run — differing only by `synced_at` — which turns a sync
+ * with nothing to do into a commit, a push, and (in repositories whose
+ * `pre-push` hook runs a test suite) a very expensive no-op. Returns whether a
+ * write happened, so callers can report honestly.
+ */
+export async function writeLinkRecordIfChanged(
+  dataSyncDir: string,
+  provider: ProviderNameType,
+  record: LinkRecord,
+  previous: LinkRecord | undefined,
+): Promise<boolean> {
+  if (previous && !recordSubstantivelyDiffers(record, previous)) {
+    return false;
+  }
+  await writeLinkRecord(dataSyncDir, provider, record);
+  return true;
+}
+
 /** Remove one link's record (unlink). Missing is fine — the goal is absence. */
 export async function deleteLinkRecord(
   dataSyncDir: string,

--- a/packages/tbd/src/integrations/core/policy.ts
+++ b/packages/tbd/src/integrations/core/policy.ts
@@ -28,8 +28,15 @@ export interface PolicyConfigSlice {
  * Named presets, expanded through the schema so every preset is complete.
  *
  * `default` names the recommended practice: mirror major epics and beads with
- * active specs (typically ~10% of open work), report importable items rather
- * than auto-importing, and let linked pairs converge on every mapped field.
+ * active specs, report importable items rather than auto-importing, and let
+ * linked pairs converge on every mapped field.
+ *
+ * Size the selection before enabling it. `spec_path` propagates from a parent
+ * to its descendants, so the `specs: active` clause selects every descendant
+ * of every epic carrying a live spec — in a spec-driven repository that is a
+ * large fraction of open work, not a small one. Preview with
+ * `tbd --dry-run integration sync --push` and narrow `policy.outbound` if the
+ * count is higher than intended.
  */
 const PRESETS: Record<PolicyNameType, PolicyDefinition> = {
   default: PolicyDefinitionSchema.parse({

--- a/packages/tbd/src/integrations/core/sync-engine.ts
+++ b/packages/tbd/src/integrations/core/sync-engine.ts
@@ -40,6 +40,7 @@ import {
   listLinkRecords,
   pullWatermark,
   writeLinkRecord,
+  writeLinkRecordIfChanged,
 } from './bridge-state.js';
 import {
   mergeExternalComments,
@@ -1213,22 +1214,31 @@ export async function runSync(options: SyncEngineOptions): Promise<SyncRunReport
       if (inboundOnly && Object.keys(pair.result.externalPatch).length > 0) {
         continue;
       }
-      await writeLinkRecord(dataSyncDir, provider, {
-        type: 'lk',
-        bead_id: pair.bead.id,
-        external_id: link.id,
-        base: {
-          title: pair.result.merged.title,
-          status: pair.result.merged.status,
-          priority: pair.result.merged.priority,
-          labels: pair.result.merged.labels,
-          assignee: pair.result.merged.assignee,
-          description_hash: pair.result.merged.description_hash,
+      // Only when something actually changed: a settled pair reconciles to the
+      // same answer every run, and rewriting it would differ solely by
+      // `synced_at` — turning a sync with nothing to do into a commit and a
+      // push. See writeLinkRecordIfChanged.
+      await writeLinkRecordIfChanged(
+        dataSyncDir,
+        provider,
+        {
+          type: 'lk',
+          bead_id: pair.bead.id,
+          external_id: link.id,
+          base: {
+            title: pair.result.merged.title,
+            status: pair.result.merged.status,
+            priority: pair.result.merged.priority,
+            labels: pair.result.merged.labels,
+            assignee: pair.result.merged.assignee,
+            description_hash: pair.result.merged.description_hash,
+          },
+          remote_updated_at: postWriteUpdatedAt,
+          synced_at: options.now(),
+          state: 'linked',
         },
-        remote_updated_at: postWriteUpdatedAt,
-        synced_at: options.now(),
-        state: 'linked',
-      });
+        recordByBead.get(pair.bead.id),
+      );
     } catch (error) {
       if (journaledExternalIds.has(link.id) || journaledCommentBeads.has(pair.bead.id)) {
         journalDirty = true;

--- a/packages/tbd/tests/cli-sync-surface-honesty.tryscript.md
+++ b/packages/tbd/tests/cli-sync-surface-honesty.tryscript.md
@@ -74,11 +74,26 @@ $ tbd sync --issues --dry-run 2>&1 | grep -c "Skipping external trackers"
 ? 0
 ```
 
-# Test: JSON mode carries the omission as data
+# Test: capture JSON result and diagnostics on their separate channels
 
 ```console
-$ tbd sync --issues --json 2>&1 | grep -c "skippedSurfaces"
-1
+$ tbd sync --issues --json > sync-output.json 2> sync-diagnostics.jsonl || true
+? 0
+```
+
+# Test: JSON mode keeps stdout as one valid result document
+
+```console
+$ node -e "const fs=require('node:fs'); JSON.parse(fs.readFileSync('sync-output.json','utf8')); console.log('valid JSON result')"
+valid JSON result
+? 0
+```
+
+# Test: JSON mode carries the omission as a structured diagnostic
+
+```console
+$ node -e "const fs=require('node:fs'); const rows=fs.readFileSync('sync-diagnostics.jsonl','utf8').trim().split('\\n').map(JSON.parse); console.log(rows.find((row)=>row.skippedSurfaces)?.skippedSurfaces.join(','))"
+integrations
 ? 0
 ```
 

--- a/packages/tbd/tests/cli-sync-surface-honesty.tryscript.md
+++ b/packages/tbd/tests/cli-sync-surface-honesty.tryscript.md
@@ -1,0 +1,134 @@
+---
+sandbox: true
+env:
+  NO_COLOR: '1'
+  FORCE_COLOR: '0'
+path:
+  - ../dist
+timeout: 30000
+before: |
+  git init --initial-branch=main
+  git config user.email "test@example.com"
+  git config user.name "Test User"
+  git config commit.gpgsign false
+  echo "# Test repo" > README.md
+  git add README.md
+  git commit -m "Initial commit"
+  tbd init --prefix=test
+---
+# tbd CLI: Sync Surface Honesty
+
+Narrowing `tbd sync` to a surface excludes external trackers.
+That is easy to do by accident — `--issues` reads like “the issue surface”, and the
+tracker *is* issues — so the run has to say it skipped them rather than letting the
+mirror go quietly stale.
+
+The notice must survive the **default** invocation.
+An earlier attempt routed it through `info()`, which only emits under `--verbose`, so
+the ordinary command stayed exactly as silent as before.
+
+* * *
+
+## No integration configured: stay silent
+
+A repository with no tracker has nothing to skip, so a scoped sync must not mention one.
+
+# Test: --issues says nothing when no tracker is configured
+
+```console
+$ tbd sync --issues 2>&1 | grep -c "external tracker" || true
+0
+? 0
+```
+
+* * *
+
+## An enabled integration: say so, by default
+
+```console
+$ printf 'integrations:\n  linear:\n    enabled: true\n    team_key: TEST\n' >> .tbd/config.yml
+? 0
+```
+
+# Test: --issues reports the skipped tracker in a default run
+
+```console
+$ tbd sync --issues 2>&1 | grep -c "Skipping external trackers"
+1
+? 0
+```
+
+# Test: --docs reports it too
+
+```console
+$ tbd sync --docs 2>&1 | grep -c "Skipping external trackers"
+1
+? 0
+```
+
+# Test: a dry run still reports it
+
+```console
+$ tbd sync --issues --dry-run 2>&1 | grep -c "Skipping external trackers"
+1
+? 0
+```
+
+# Test: JSON mode carries the omission as data
+
+```console
+$ tbd sync --issues --json 2>&1 | grep -c "skippedSurfaces"
+1
+? 0
+```
+
+* * *
+
+## Not skipped: stay silent
+
+A run that actually includes the tracker, or that only reports status, must not claim to
+have skipped anything.
+
+# Test: a full sync does not claim to skip trackers
+
+```console
+$ tbd sync 2>&1 | grep -c "Skipping external trackers" || true
+0
+? 0
+```
+
+# Test: --integrations does not claim to skip trackers
+
+```console
+$ tbd sync --integrations 2>&1 | grep -c "Skipping external trackers" || true
+0
+? 0
+```
+
+# Test: --status does not claim to skip trackers
+
+```console
+$ tbd sync --status 2>&1 | grep -c "Skipping external trackers" || true
+0
+? 0
+```
+
+* * *
+
+## Deliberately excluded from `tbd sync`
+
+A team that sets `sync_on_tbd_sync: false` has already decided the tracker is manual, so
+a scoped run has nothing to warn about.
+
+```console
+$ node -e "const f=require('fs'),p='.tbd/config.yml';f.writeFileSync(p,f.readFileSync(p,'utf8').replace('integrations:','integrations:\n  sync_on_tbd_sync: false'))"
+? 0
+```
+
+# Test: an explicitly manual tracker is not reported as skipped
+
+```console
+$ tbd sync --issues 2>&1 | grep -c "Skipping external trackers" || true
+0
+? 0
+```

--- a/packages/tbd/tests/integrations-bridge-state.test.ts
+++ b/packages/tbd/tests/integrations-bridge-state.test.ts
@@ -8,7 +8,7 @@
  * changes.
  */
 
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -24,6 +24,7 @@ import {
   pullWatermark,
   readLinkRecord,
   writeLinkRecord,
+  writeLinkRecordIfChanged,
 } from '../src/integrations/core/bridge-state.js';
 import { MANAGED_BLOCK_MARKERS } from '../src/integrations/core/managed-block.js';
 import type { LinkRecord } from '../src/lib/types.js';
@@ -200,5 +201,62 @@ describe('description normalization and hashing', () => {
     expect(normalizeDescription('  keep leading\ninternal  spacing')).toBe(
       'keep leading\ninternal  spacing',
     );
+  });
+});
+
+describe('writeLinkRecordIfChanged', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'tbd-bridge-guard-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('does not write when only synced_at advanced', async () => {
+    const previous = record();
+    await writeLinkRecord(dir, 'linear', previous);
+    const before = await readFile(join(bridgeLinksDir(dir, 'linear'), `${BEAD_ID}.yml`), 'utf8');
+
+    const wrote = await writeLinkRecordIfChanged(
+      dir,
+      'linear',
+      record({ synced_at: '2099-01-01T00:00:00.000Z' }),
+      previous,
+    );
+
+    expect(wrote).toBe(false);
+    const after = await readFile(join(bridgeLinksDir(dir, 'linear'), `${BEAD_ID}.yml`), 'utf8');
+    expect(after).toBe(before);
+  });
+
+  it.each([
+    ['remote_updated_at', record({ remote_updated_at: '2099-01-01T00:00:00.000Z' })],
+    ['state', record({ state: 'orphaned' as const })],
+    ['external_id', record({ external_id: 'other' })],
+    ['base.title', record({ base: { ...record().base, title: 'Renamed' } })],
+    ['base.status', record({ base: { ...record().base, status: 'closed' as const } })],
+    ['base.priority', record({ base: { ...record().base, priority: 0 as const } })],
+    ['base.assignee', record({ base: { ...record().base, assignee: 'agent' } })],
+    ['base.labels', record({ base: { ...record().base, labels: ['added'] } })],
+    [
+      'base.description_hash',
+      record({ base: { ...record().base, description_hash: descriptionHash('Changed') } }),
+    ],
+  ])('writes when %s changed', async (_field, next) => {
+    const previous = record();
+    await writeLinkRecord(dir, 'linear', previous);
+
+    const wrote = await writeLinkRecordIfChanged(dir, 'linear', next, previous);
+
+    expect(wrote).toBe(true);
+    expect(await readLinkRecord(dir, 'linear', BEAD_ID)).toEqual(next);
+  });
+
+  it('writes when there is no previous record', async () => {
+    expect(await writeLinkRecordIfChanged(dir, 'linear', record(), undefined)).toBe(true);
+    expect(await readLinkRecord(dir, 'linear', BEAD_ID)).toEqual(record());
   });
 });

--- a/packages/tbd/tests/integrations-sync-engine.test.ts
+++ b/packages/tbd/tests/integrations-sync-engine.test.ts
@@ -4,7 +4,7 @@
  * exactly-once reports, and inbound report/import.
  */
 
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -164,6 +164,38 @@ describe('the sync engine', () => {
     expect(second.pulled).toEqual([]);
     expect(second.conflicts).toEqual([]);
     expect(second.createdOutbound).toEqual([]);
+  });
+
+  it('a settled mirror writes nothing on a further quiet sync', async () => {
+    // The property that makes frequent syncing affordable. Rewriting bridge
+    // records that only differ by `synced_at` turns a sync with nothing to do
+    // into a commit, a push, and whatever the repo's pre-push hook costs.
+    const ids = [
+      'is-01hx5zzkbkactav9wevgemma01',
+      'is-01hx5zzkbkactav9wevgemma02',
+      'is-01hx5zzkbkactav9wevgemma03',
+    ];
+    for (const id of ids) {
+      store.set(id, bead(id));
+    }
+    await run([...store.values()]);
+    await run([...store.values()]); // settle
+
+    const linksDir = join(dir, 'bridge', 'linear', 'links');
+    const before = new Map<string, string>();
+    for (const file of await readdir(linksDir)) {
+      before.set(file, await readFile(join(linksDir, file), 'utf8'));
+    }
+    expect(before.size).toBe(ids.length);
+
+    const quiet = await run([...store.values()]);
+    expect(quiet.nothingToDo).toBe(true);
+
+    const after = new Map<string, string>();
+    for (const file of await readdir(linksDir)) {
+      after.set(file, await readFile(join(linksDir, file), 'utf8'));
+    }
+    expect(after).toEqual(before);
   });
 
   it('backfills and preserves the managed block on a pre-existing linked item', async () => {

--- a/packages/tbd/tests/output.test.ts
+++ b/packages/tbd/tests/output.test.ts
@@ -138,6 +138,14 @@ describe('OutputManager', () => {
       const output = new OutputManager(createMockContext({ json: true }));
       output.notice('Noteworthy event');
       expect(consoleLog).not.toHaveBeenCalled();
+      expect(consoleError).not.toHaveBeenCalled();
+    });
+
+    it('emits optional structured data to stderr in json mode', () => {
+      const output = new OutputManager(createMockContext({ json: true }));
+      output.notice('Noteworthy event', { skippedSurfaces: ['integrations'] });
+      expect(consoleLog).not.toHaveBeenCalled();
+      expect(consoleError).toHaveBeenCalledWith('{"skippedSurfaces":["integrations"]}');
     });
   });
 

--- a/packages/tbd/tests/sync-push-no-verify.test.ts
+++ b/packages/tbd/tests/sync-push-no-verify.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The sync-branch push must not run the parent repository's `pre-push` hook.
+ *
+ * tbd already passes `--no-verify` on its sync-branch COMMITS, deliberately, so
+ * bead bookkeeping never triggers lefthook/husky. The push has to make the same
+ * promise: the branch carries no source code, so a repository whose `pre-push`
+ * runs a test suite would otherwise pay for it on every sync — and again on
+ * each non-fast-forward retry.
+ *
+ * The hook here exits non-zero unconditionally, so a push that runs hooks
+ * fails and a push that skips them succeeds. That makes the assertion about
+ * behavior rather than about argument strings.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { chmod, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir, platform } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { pushWithRetry } from '../src/file/git.js';
+
+const execFileAsync = promisify(execFile);
+const describeUnlessWindows = platform() === 'win32' ? describe.skip : describe;
+
+const SYNC_BRANCH = 'tbd-sync';
+
+async function git(dir: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, {
+    cwd: dir,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+  });
+  return stdout.trim();
+}
+
+describeUnlessWindows('sync-branch push and parent-repo hooks', () => {
+  let root: string;
+  let repo: string;
+  let remote: string;
+
+  beforeEach(async () => {
+    root = join(tmpdir(), `tbd-push-hooks-${randomBytes(6).toString('hex')}`);
+    repo = join(root, 'repo');
+    remote = join(root, 'remote.git');
+
+    await mkdir(remote, { recursive: true });
+    await git(remote, 'init', '--bare');
+
+    await mkdir(repo, { recursive: true });
+    await git(repo, 'init', '-b', SYNC_BRANCH);
+    await git(repo, 'config', 'user.email', 'test@test.com');
+    await git(repo, 'config', 'user.name', 'Test User');
+    await git(repo, 'config', 'commit.gpgsign', 'false');
+    await git(repo, 'remote', 'add', 'origin', remote);
+    await writeFile(join(repo, 'issue.md'), '# a bead\n');
+    await git(repo, 'add', '-A');
+    await git(repo, 'commit', '--no-verify', '-m', 'seed');
+
+    // A parent-repo pre-push gate that always refuses, standing in for a
+    // lefthook/husky hook that runs a test suite.
+    const hook = join(repo, '.git', 'hooks', 'pre-push');
+    await writeFile(hook, '#!/bin/sh\necho "pre-push gate ran" >&2\nexit 1\n');
+    await chmod(hook, 0o755);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('pushes the sync branch even when pre-push would reject it', async () => {
+    const result = await pushWithRetry(SYNC_BRANCH, 'origin', () => Promise.resolve([]), repo);
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+    // The remote really received it, so this is not a false positive from a
+    // push that silently did nothing.
+    expect(await git(remote, 'rev-parse', SYNC_BRANCH)).toBe(
+      await git(repo, 'rev-parse', SYNC_BRANCH),
+    );
+  });
+
+  it('the same push fails when hooks are honored, proving the hook is live', async () => {
+    // Guards the guard: if this repository's hook were inert, the test above
+    // would pass no matter what pushWithRetry did.
+    await expect(
+      git(repo, 'push', 'origin', `refs/heads/${SYNC_BRANCH}:refs/heads/${SYNC_BRANCH}`),
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
First implementation PR from the [external sync and traceability plan](https://github.com/jlevy/tbd/pull/222) — the Phase 1 items that are unambiguously safe and need no product decision.

Beads: `tbd-774m`, `tbd-7okw`, `tbd-8ot8`, `tbd-1uep`, `tbd-czhw`.

## Why

Two defects compounded to make frequent syncing unaffordable, and each made the other worse. Measured before this change, a *settled* mirror re-synced with nothing changed anywhere:

```
3 beads,  comments=two_way:  5 requests, 3 of 3 bridge records rewritten
10 beads, comments=two_way: 12 requests, 10 of 10 rewritten
```

Every one of those rewrites differed only in `synced_at`.

## What changed

**A quiet sync now writes nothing.** The apply loop reconciles every linked pair on every run and arrives at the same answer for a settled pair, then wrote the bridge record unconditionally with a fresh `synced_at`. So a sync that changed nothing produced one file write per linked bead → a commit → a push, all while reporting `nothingToDo: true`. Records now write only when something other than `synced_at` differs.

`synced_at` is **kept**, not dropped — the plan originally preferred dropping it, but `pickNewestLinkRecord` uses it as a merge tiebreaker when two machines observe the same item. It is load-bearing; only its role as a write trigger was wrong.

**The sync-branch push no longer runs the parent repo's `pre-push` hook.** tbd already passes `--no-verify` on sync-branch *commits*, deliberately, so bead bookkeeping never triggers lefthook/husky (`git.ts` says so). The push made no such promise, so in this repository every sync paid for the full test suite — and the retry loop paid again on each non-fast-forward. Both sync-branch push sites now pass `--no-verify`. This does not affect pushes of your own branches.

**`tbd sync --issues` no longer excludes the tracker silently.** Easy to hit by accident, since the tracker *is* issues. It now says it skipped, and how to reconcile.

**Docs.** The "~10% of a repository" figure for the default policy was measured against every bead *including closed ones*. Status gates the selection, so closed beads can never be mirrored, and that denominator understates what actually lands in the tracker: here the same policy is ~9% of all 1,726 beads but **52% of the 291 still open**. Reframed against open work, with a pointer to the dry run and a note that `max_nesting` skips make the issue count smaller than the selection count. Also fixed a comment claiming the integration fold is off by default — it is on.

## Tests

Both properties are pinned by behavior, not by asserting on argument strings:

- A settled mirror re-synced with no changes must leave `bridge/<provider>/links/` **byte-identical**. Verified to fail before the fix.
- A sync-branch push must succeed against a repo whose `pre-push` hook always rejects — with a companion test proving that hook is live, so the first cannot pass vacuously.

Full suite: 2,026 tests across 137 files, all passing.

## Deliberately not in this PR

- **Comment delta-gating** (`tbd-iqgm`) — the biggest remaining win (`2 + N` → flat 2 requests), but it assumes Linear bumps `updatedAt` on comment creation. The plan makes proving that in live QA a precondition, and I have no key here.
- **Hook PATH order** (`tbd-fnwc`) — #226 just rewrote these launchers and added a test asserting the current PATH order, so changing it is now a conversation rather than a fix.
- **`tbd sync --push` semantics** (`tbd-71am`) — needs a decision: guard it, or make it a full reconcile.
- **`tbd start` / agent identity** (`tbd-mnci`, `tbd-f39i`) — additive and safe, but a bigger surface with an open question (sync by default?). Better as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core sync, integration bridge persistence, and git push behavior for the sync branch; well-tested but affects every frequent `tbd sync` with Linear enabled.
> 
> **Overview**
> Makes **settled integration syncs** stop rewriting bridge link YAML when only `synced_at` would change, so a quiet reconcile no longer forces a sync-branch commit and push (including through heavy parent `pre-push` hooks).
> 
> **Sync-branch git pushes** now pass **`--no-verify`** in `pushWithRetry` and `pushFreshOrphan`, matching sync-branch commits: bead bookkeeping is not gated by the main repo’s hooks.
> 
> **`tbd sync --issues` / `--docs`** (and dry runs) emit a default-visible **notice** when an enabled tracker would normally run but surface flags excluded it, with optional structured `{ skippedSurfaces: ['integrations'] }` on **stderr** under `--json` so stdout stays a single result document.
> 
> **Docs** reframe default Linear policy sizing against **open** beads (not all history), add dry-run / `max_nesting` guidance, and correct the comment that the integration fold is **on** by default when a provider is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fea4ce966042549e29856d3683f6bff9422cee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->