### PR TITLE
chore: release get-tbd v0.6.4

### DIFF
--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -1,5 +1,33 @@
 # get-tbd
 
+## 0.6.4
+
+### Fixed
+
+- **Smooth f06 repository upgrades**: Setup and the first data command now initialize
+  the f07 data scaffold when a pre-existing `tbd-sync` branch never contained one.
+  This repairs the real `get-tbd@0.4.2` repository state found during the downstream
+  upgrade trial while preserving every legacy branch file and remaining idempotent.
+- **Historical data recovery**: If the current branch lost its scaffold but Git history
+  still contains tracker data, the upgrade restores every missing issue and mapping
+  before continuing. Existing files are never overwritten, avoiding both silent data loss
+  and an empty-tracker reset.
+
+### Changed
+
+- **Release upgrade proof**: Packed-package QA now covers the latest 0.6.3 same-format
+  baseline and a fresh clone of the common 0.4.2-era remote-branch layout.
+  The latter proves setup, first issue creation, sync, legacy-file preservation, and a
+  byte-identical repeated setup before release.
+
+### Security
+
+- **Dependency posture**: No dependencies or lockfile entries changed.
+  Exact first-party historical `get-tbd` packages are used for upgrade QA with lifecycle
+  scripts disabled; the existing frozen dependency tree is reused.
+  The production audit is clean; the full audit reports the same 32 dev-only advisories
+  inherited from that unchanged tree.
+
 ## 0.6.3
 
 ### Fixed

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-tbd",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Git-native issue tracking for AI agents and humans",
   "license": "MIT",
   "author": "Joshua Levy <joshua@cal.berkeley.edu> (https://github.com/jlevy)",

--- a/packages/tbd/scripts/validate-upgrade-package.mjs
+++ b/packages/tbd/scripts/validate-upgrade-package.mjs
@@ -5,7 +5,7 @@
  * Prove a packed candidate upgrades real published repositories safely.
  *
  * Three baselines exercise the real-world path and distinct compatibility contracts:
- * - the latest same-format patch (0.6.2 / f07), whose older client must keep working;
+ * - the latest same-format patch (0.6.3 / f07), whose older client must keep working;
  * - the common pre-f07 release (0.4.2 / f06), whose client must fail closed after upgrade;
  * - the last pre-f07 release (0.5.0 / f06), which guards the immediate format boundary.
  */
@@ -32,7 +32,7 @@ const execFileAsync = promisify(execFile);
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const packageDir = join(scriptDir, '..');
 const sourceRepoDir = join(packageDir, '..', '..');
-const sameFormatBaseline = process.env.TBD_UPGRADE_SAME_FORMAT_FROM ?? '0.6.2';
+const sameFormatBaseline = process.env.TBD_UPGRADE_SAME_FORMAT_FROM ?? '0.6.3';
 const commonUpgradeBaseline = process.env.TBD_UPGRADE_COMMON_FROM ?? '0.4.2';
 const previousFormatBaseline = process.env.TBD_UPGRADE_PREVIOUS_FORMAT_FROM ?? '0.5.0';
 const managedUpgradePaths = new Set([
@@ -224,6 +224,7 @@ async function validateScenario({
   candidate,
   candidateVersion,
   expectedBaselineFormat,
+  expectManagedScriptChange,
   expectOldClientToWork,
   root,
   baseline,
@@ -325,12 +326,20 @@ async function validateScenario({
     unexpectedFiles.length === 0,
     `${name}: upgrade changed non-managed paths: ${unexpectedFiles.join(', ')}`,
   );
-  for (const expected of [
-    '.tbd/config.yml',
-    '.claude/scripts/tbd-session.sh',
-    '.codex/tbd-session.sh',
-  ]) {
+  const expectedChangedFiles = ['.tbd/config.yml'];
+  if (expectManagedScriptChange) {
+    expectedChangedFiles.push('.claude/scripts/tbd-session.sh', '.codex/tbd-session.sh');
+  }
+  for (const expected of expectedChangedFiles) {
     invariant(changedFiles.includes(expected), `${name}: expected ${expected} in the upgrade diff`);
+  }
+  if (!expectManagedScriptChange) {
+    for (const stable of ['.claude/scripts/tbd-session.sh', '.codex/tbd-session.sh']) {
+      invariant(
+        !changedFiles.includes(stable),
+        `${name}: compatible patch upgrade unexpectedly rewrote ${stable}`,
+      );
+    }
   }
   const sessionScript = await readFile(
     join(repository, '.claude', 'scripts', 'tbd-session.sh'),
@@ -409,6 +418,136 @@ async function validateScenario({
   );
   console.log(
     `Packed upgrade proof passed: ${baselineVersion} (${expectedBaselineFormat}) -> ${candidateVersion} (f07)`,
+  );
+}
+
+async function validateLegacyRemoteSyncUpgrade({
+  baseline,
+  baselineVersion,
+  candidate,
+  candidateVersion,
+  root,
+}) {
+  const seedRepository = join(root, 'legacy-remote-seed');
+  const bareRemote = join(root, 'legacy-remote.git');
+  const repository = join(root, 'legacy-remote-clone');
+  const home = join(root, 'legacy-remote-home');
+  await initializeRepository(seedRepository);
+  await mkdir(home, { recursive: true });
+
+  const baselineSetup = await invokeCli(baseline, seedRepository, home, [
+    'setup',
+    '--auto',
+    '--prefix=qa',
+  ]);
+  invariant(
+    baselineSetup.code === 0,
+    `legacy-remote: baseline setup failed\n${baselineSetup.stdout}\n${baselineSetup.stderr}`,
+  );
+  await git(seedRepository, 'add', '--all');
+  await git(seedRepository, 'commit', '--message', `Record ${baselineVersion} baseline`);
+
+  const historicalCreate = await invokeCli(baseline, seedRepository, home, [
+    'create',
+    'Legacy historical seed',
+    '--type=task',
+  ]);
+  invariant(
+    historicalCreate.code === 0,
+    `legacy-remote: baseline create failed\n${historicalCreate.stdout}\n${historicalCreate.stderr}`,
+  );
+
+  // Reproduce the released f06 state found in jlevy/tryscript: a remote tbd-sync
+  // branch once contained valid issues, a legacy sync later removed the entire
+  // scaffold, and unrelated branch files still need to survive recovery.
+  const oldWorktree = join(seedRepository, '.git', 'tbd', 'data-sync-worktree');
+  await git(oldWorktree, 'add', '--force', '.tbd/data-sync');
+  await git(oldWorktree, 'commit', '--message', 'Record historical tracker data');
+  await writeFile(join(oldWorktree, 'legacy-marker.txt'), 'preserve me\n');
+  await git(oldWorktree, 'add', 'legacy-marker.txt');
+  await git(oldWorktree, 'commit', '--message', 'Record legacy branch file');
+  await git(oldWorktree, 'rm', '-r', '.tbd/data-sync');
+  await git(oldWorktree, 'commit', '--message', 'Legacy sync removed data scaffold');
+
+  await mkdir(bareRemote);
+  await git(bareRemote, 'init', '--bare');
+  await git(seedRepository, 'remote', 'add', 'origin', bareRemote);
+  await git(seedRepository, 'push', '--set-upstream', 'origin', 'main');
+  await git(bareRemote, 'symbolic-ref', 'HEAD', 'refs/heads/main');
+  await git(oldWorktree, 'push', 'origin', 'tbd-sync');
+  await run('git', ['clone', bareRemote, repository]);
+  await git(repository, 'config', 'user.name', 'tbd upgrade QA');
+  await git(repository, 'config', 'user.email', 'tbd-upgrade-qa@example.invalid');
+  await git(repository, 'config', 'commit.gpgSign', 'false');
+
+  const upgrade = await invokeCli(candidate, repository, home, ['setup', '--auto']);
+  invariant(
+    upgrade.code === 0,
+    `legacy-remote: candidate setup failed\n${upgrade.stdout}\n${upgrade.stderr}`,
+  );
+  invariant(
+    /Restored \d+ missing tbd-sync data files from Git history/u.test(
+      upgrade.stdout + upgrade.stderr,
+    ),
+    'legacy-remote: candidate did not report historical data recovery',
+  );
+  const configPath = join(repository, '.tbd', 'config.yml');
+  const config = parseYaml(await readFile(configPath, 'utf8'));
+  invariant(config.tbd_format === 'f07', 'legacy-remote: candidate did not produce f07');
+  invariant(
+    config.tbd_version === candidateVersion,
+    `legacy-remote: config reports ${String(config.tbd_version)}, expected ${candidateVersion}`,
+  );
+
+  const commonDirOutput = await git(repository, 'rev-parse', '--git-common-dir');
+  const commonDir = isAbsolute(commonDirOutput)
+    ? commonDirOutput
+    : resolve(repository, commonDirOutput);
+  const worktree = join(commonDir, 'tbd', 'data-sync-worktree');
+  await access(join(worktree, '.tbd', 'data-sync', 'meta.yml'));
+  invariant(
+    (await readFile(join(worktree, 'legacy-marker.txt'), 'utf8')) === 'preserve me\n',
+    'legacy-remote: upgrade discarded a legacy branch file',
+  );
+
+  const create = await invokeCli(candidate, repository, home, [
+    'create',
+    'Legacy remote upgrade probe',
+    '--type=task',
+  ]);
+  invariant(
+    create.code === 0,
+    `legacy-remote: first create failed\n${create.stdout}\n${create.stderr}`,
+  );
+  const list = await invokeCli(candidate, repository, home, ['list', '--json']);
+  invariant(
+    list.code === 0 && list.stdout.includes('Legacy historical seed'),
+    `legacy-remote: historical issue was not recovered\n${list.stdout}\n${list.stderr}`,
+  );
+  invariant(
+    list.stdout.includes('Legacy remote upgrade probe'),
+    'legacy-remote: newly created issue is missing',
+  );
+  const push = await invokeCli(candidate, repository, home, ['sync', '--issues', '--push']);
+  invariant(push.code === 0, `legacy-remote: sync failed\n${push.stdout}\n${push.stderr}`);
+  await git(bareRemote, 'show', 'tbd-sync:.tbd/data-sync/meta.yml');
+  invariant(
+    (await git(bareRemote, 'show', 'tbd-sync:legacy-marker.txt')) === 'preserve me',
+    'legacy-remote: pushed data branch discarded a legacy branch file',
+  );
+
+  const statusBeforeRepeat = await repositoryStatus(repository);
+  const repeated = await invokeCli(candidate, repository, home, ['setup', '--auto']);
+  invariant(
+    repeated.code === 0,
+    `legacy-remote: repeated setup failed\n${repeated.stdout}\n${repeated.stderr}`,
+  );
+  invariant(
+    (await repositoryStatus(repository)) === statusBeforeRepeat,
+    'legacy-remote: repeated setup changed the repository diff',
+  );
+  console.log(
+    `Packed legacy-remote proof passed: ${baselineVersion} (f06) -> ${candidateVersion} (f07)`,
   );
 }
 
@@ -491,6 +630,7 @@ try {
     candidate,
     candidateVersion,
     expectedBaselineFormat: 'f07',
+    expectManagedScriptChange: false,
     expectOldClientToWork: true,
     name: 'same-format',
     root: temporaryDir,
@@ -501,6 +641,7 @@ try {
     candidate,
     candidateVersion,
     expectedBaselineFormat: 'f06',
+    expectManagedScriptChange: true,
     expectOldClientToWork: false,
     name: 'common-upgrade',
     root: temporaryDir,
@@ -511,8 +652,16 @@ try {
     candidate,
     candidateVersion,
     expectedBaselineFormat: 'f06',
+    expectManagedScriptChange: true,
     expectOldClientToWork: false,
     name: 'format-change',
+    root: temporaryDir,
+  });
+  await validateLegacyRemoteSyncUpgrade({
+    baseline: commonUpgradePackage,
+    baselineVersion: commonUpgradeBaseline,
+    candidate,
+    candidateVersion,
     root: temporaryDir,
   });
 

--- a/packages/tbd/src/cli/lib/data-context.ts
+++ b/packages/tbd/src/cli/lib/data-context.ts
@@ -25,7 +25,12 @@ import type { CommandContext } from './context.js';
 import { getCommandContext, quietNoticesActive } from './context.js';
 import { requireInit } from './errors.js';
 import { resolveIssueId } from './id-suggestions.js';
-import { checkWorktreeHealth, repairWorktree } from '../../file/git.js';
+import {
+  checkWorktreeHealth,
+  initWorktree,
+  isDataSyncScaffoldReady,
+  repairWorktree,
+} from '../../file/git.js';
 import type { WorktreeHealth, WorktreeStatus } from '../../file/git.js';
 import {
   ensureCommonDirLayout,
@@ -97,6 +102,7 @@ interface DataSyncProbe {
   sharedPaths: SharedTbdPaths;
   layout: CommonDirLayout | null;
   health: WorktreeHealth;
+  dataSyncReady: boolean;
   ready: boolean;
 }
 
@@ -115,8 +121,10 @@ async function probeDataSyncReadiness(tbdRoot: string): Promise<DataSyncProbe> {
     validateCommonDirLayout(layout, config);
   }
   const health = await checkWorktreeHealth(tbdRoot, config.sync.branch);
-  const ready = !migrated && layout !== null && !layoutNeedsUpgrade && health.valid;
-  return { config, migrated, fromFormat, sharedPaths, layout, health, ready };
+  const dataSyncReady = await isDataSyncScaffoldReady(tbdRoot);
+  const ready =
+    !migrated && layout !== null && !layoutNeedsUpgrade && health.valid && dataSyncReady;
+  return { config, migrated, fromFormat, sharedPaths, layout, health, dataSyncReady, ready };
 }
 
 /**
@@ -140,6 +148,7 @@ async function ensureSharedDataSyncLayout(
       if (!repairResult.success) {
         throw new Error(`Failed to initialize shared data-sync worktree: ${repairResult.error}`);
       }
+      notifyHistoricalDataRestored(repairResult.restoredDataFiles);
       repairedWorktreeStatus = probe.health.status;
     } else {
       throw new Error(
@@ -148,6 +157,17 @@ async function ensureSharedDataSyncLayout(
         }. Run 'tbd doctor --fix' to repair.`,
       );
     }
+  }
+  if (probe.health.valid && !probe.dataSyncReady) {
+    const initResult = await initWorktree(
+      tbdRoot,
+      probe.config.sync.remote,
+      probe.config.sync.branch,
+    );
+    if (!initResult.success) {
+      throw new Error(`Failed to initialize shared data-sync scaffold: ${initResult.error}`);
+    }
+    notifyHistoricalDataRestored(initResult.restoredDataFiles);
   }
   // Re-read inside the lock via ensureCommonDirLayout: if another writer wrote
   // a valid layout between our probe and lock acquisition this returns it
@@ -158,6 +178,15 @@ async function ensureSharedDataSyncLayout(
     notifyConfigMigrated(probe.fromFormat, CURRENT_FORMAT);
   }
   return repairedWorktreeStatus;
+}
+
+function notifyHistoricalDataRestored(restoredDataFiles: number | undefined): void {
+  if (quietNoticesActive() || !restoredDataFiles) {
+    return;
+  }
+  process.stderr.write(
+    `• Restored ${restoredDataFiles} missing tbd-sync data files from Git history.\n`,
+  );
 }
 
 /**

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -1606,6 +1606,175 @@ export async function pushFreshOrphan(
   }
 }
 
+const DATA_SYNC_RELATIVE_PATH = `${TBD_DIR}/${DATA_SYNC_DIR_NAME}`;
+const GIT_PATH_BATCH_SIZE = 128;
+
+async function writeScaffoldFileIfMissing(path: string, contents: string): Promise<boolean> {
+  if (await pathExists(path)) {
+    return false;
+  }
+  await writeFile(path, contents);
+  return true;
+}
+
+/**
+ * Materialize the current data-sync scaffold without disturbing legacy branch files.
+ *
+ * Older tbd releases could create a tbd-sync branch containing a repository snapshot
+ * but no `.tbd/data-sync` directory. That branch is a valid Git worktree, so worktree
+ * health checks alone cannot distinguish it from an initialized data branch. This
+ * additive repair restores missing historical data when available, creates any remaining
+ * scaffold files, and records the repair in one internal commit. Existing worktree files
+ * are never overwritten.
+ *
+ * MUST be called while holding `withSharedDataSyncLock`.
+ */
+async function ensureDataSyncScaffold(baseDir: string): Promise<number> {
+  const { sharedWorktreePath: worktreePath, sharedDataSyncDir: dataSyncPath } =
+    await getSharedPaths(baseDir);
+  const hasHead = await git('-C', worktreePath, 'rev-parse', '--verify', 'HEAD').then(
+    () => true,
+    () => false,
+  );
+  const scaffoldCommitted =
+    hasHead &&
+    (await git(
+      '-C',
+      worktreePath,
+      'cat-file',
+      '-e',
+      `HEAD:${DATA_SYNC_RELATIVE_PATH}/meta.yml`,
+    ).then(
+      () => true,
+      () => false,
+    ));
+  const repairedPaths: string[] = [];
+  let recoveredHistoricalData = false;
+
+  if (!scaffoldCommitted && hasHead) {
+    const scaffoldCommits = await git(
+      '-C',
+      worktreePath,
+      'rev-list',
+      'HEAD',
+      '--',
+      DATA_SYNC_RELATIVE_PATH,
+    );
+    for (const commit of scaffoldCommits.split('\n').filter(Boolean)) {
+      const hasHistoricalScaffold = await git(
+        '-C',
+        worktreePath,
+        'cat-file',
+        '-e',
+        `${commit}:${DATA_SYNC_RELATIVE_PATH}/meta.yml`,
+      ).then(
+        () => true,
+        () => false,
+      );
+      if (!hasHistoricalScaffold) {
+        continue;
+      }
+
+      const historicalPaths = (
+        await git(
+          '-C',
+          worktreePath,
+          'ls-tree',
+          '-r',
+          '--name-only',
+          commit,
+          '--',
+          DATA_SYNC_RELATIVE_PATH,
+        )
+      )
+        .split('\n')
+        .filter(Boolean);
+      const missingPaths: string[] = [];
+      for (const path of historicalPaths) {
+        if (!(await pathExists(join(worktreePath, path)))) {
+          missingPaths.push(path);
+        }
+      }
+      if (missingPaths.length > 0) {
+        for (let index = 0; index < missingPaths.length; index += GIT_PATH_BATCH_SIZE) {
+          await git(
+            '-C',
+            worktreePath,
+            'checkout',
+            commit,
+            '--',
+            ...missingPaths.slice(index, index + GIT_PATH_BATCH_SIZE),
+          );
+        }
+        repairedPaths.push(...missingPaths);
+        recoveredHistoricalData = true;
+      }
+      break;
+    }
+  }
+
+  await mkdir(join(dataSyncPath, 'issues'), { recursive: true });
+  await mkdir(join(dataSyncPath, 'mappings'), { recursive: true });
+  await mkdir(join(dataSyncPath, 'attic', 'conflicts'), { recursive: true });
+
+  const scaffoldFiles = [
+    {
+      relative: `${DATA_SYNC_RELATIVE_PATH}/meta.yml`,
+      contents: `schema_version: ${DATA_SYNC_SCHEMA_VERSION}\n`,
+    },
+    { relative: `${DATA_SYNC_RELATIVE_PATH}/issues/.gitkeep`, contents: '' },
+    { relative: `${DATA_SYNC_RELATIVE_PATH}/mappings/.gitkeep`, contents: '' },
+    {
+      relative: `${DATA_SYNC_RELATIVE_PATH}/mappings/.gitattributes`,
+      contents: 'ids.yml merge=union\n',
+    },
+  ];
+  for (const file of scaffoldFiles) {
+    if (await writeScaffoldFileIfMissing(join(worktreePath, file.relative), file.contents)) {
+      repairedPaths.push(file.relative);
+    }
+  }
+
+  if (repairedPaths.length === 0 && scaffoldCommitted) {
+    return 0;
+  }
+
+  // A legacy repository snapshot on tbd-sync may carry the main branch's rule
+  // that ignores `.tbd/data-sync`. These are tbd's managed data files, so force the
+  // managed directory through that unrelated ignore rule. Staging the directory also
+  // finishes an interrupted recovery whose files reached disk before its commit.
+  await git('-C', worktreePath, 'add', '--force', '--', DATA_SYNC_RELATIVE_PATH);
+  if (hasHead) {
+    await gitCommit(
+      worktreePath,
+      '--no-verify',
+      '--only',
+      '-m',
+      recoveredHistoricalData
+        ? 'Restore missing tbd-sync data layout'
+        : 'Initialize tbd-sync data layout',
+      '--',
+      DATA_SYNC_RELATIVE_PATH,
+    );
+  } else {
+    await gitCommit(worktreePath, '--no-verify', '-m', 'Initialize tbd-sync branch');
+  }
+  return recoveredHistoricalData ? repairedPaths.length : 0;
+}
+
+/** Whether the required scaffold exists both in the worktree and its current commit. */
+export async function isDataSyncScaffoldReady(baseDir: string): Promise<boolean> {
+  const { sharedWorktreePath: worktreePath, sharedDataSyncDir: dataSyncPath } =
+    await getSharedPaths(baseDir);
+  if (!(await pathExists(join(dataSyncPath, 'meta.yml')))) {
+    return false;
+  }
+  return git('-C', worktreePath, 'cat-file', '-e', `HEAD:${DATA_SYNC_RELATIVE_PATH}/meta.yml`).then(
+    () => true,
+    () => false,
+  );
+}
+
 /**
  * Initialize the hidden worktree for the tbd-sync branch.
  * Follows the decision tree from tbd-design.md §2.3.
@@ -1623,13 +1792,27 @@ export async function initWorktree(
   baseDir: string,
   remote = 'origin',
   syncBranch: string = SYNC_BRANCH,
-): Promise<{ success: boolean; path?: string; created?: boolean; error?: string }> {
+): Promise<{
+  success: boolean;
+  path?: string;
+  created?: boolean;
+  restoredDataFiles?: number;
+  error?: string;
+}> {
   const paths = await getSharedPaths(baseDir);
   const worktreePath = paths.sharedWorktreePath;
 
   // Check if worktree already exists and is valid
   if (await worktreeExists(baseDir)) {
-    return { success: true, path: worktreePath, created: false };
+    try {
+      const restoredDataFiles = await ensureDataSyncScaffold(baseDir);
+      return { success: true, path: worktreePath, created: false, restoredDataFiles };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
   }
 
   await mkdir(paths.sharedTbdDir, { recursive: true });
@@ -1655,7 +1838,8 @@ export async function initWorktree(
       // Create worktree on local branch (no --detach, so commits update the branch)
       // Note: Don't use --detach here - we want commits to update tbd-sync branch
       await git('-C', baseDir, 'worktree', 'add', worktreePath, syncBranch);
-      return { success: true, path: worktreePath, created: true };
+      const restoredDataFiles = await ensureDataSyncScaffold(baseDir);
+      return { success: true, path: worktreePath, created: true, restoredDataFiles };
     }
 
     // Probe the remote. A configured-but-unreachable remote must NOT fall
@@ -1690,7 +1874,8 @@ export async function initWorktree(
         worktreePath,
         `${remote}/${syncBranch}`,
       );
-      return { success: true, path: worktreePath, created: true };
+      const restoredDataFiles = await ensureDataSyncScaffold(baseDir);
+      return { success: true, path: worktreePath, created: true, restoredDataFiles };
     }
 
     // No branch exists (probe === 'absent') - create orphan worktree (requires Git 2.42+)
@@ -1698,39 +1883,27 @@ export async function initWorktree(
     await requireGitVersion();
     await git('-C', baseDir, 'worktree', 'add', '--orphan', '-b', syncBranch, worktreePath);
 
-    // Initialize the data-sync directory structure in the worktree
+    // Initialize the data-sync directory structure in the worktree.
     const dataSyncPath = join(worktreePath, TBD_DIR, DATA_SYNC_DIR_NAME);
-    await mkdir(join(dataSyncPath, 'issues'), { recursive: true });
-    await mkdir(join(dataSyncPath, 'mappings'), { recursive: true });
-    await mkdir(join(dataSyncPath, 'attic', 'conflicts'), { recursive: true });
-
-    // Create initial commit in worktree
-    await writeFile(
-      join(dataSyncPath, 'meta.yml'),
-      `schema_version: ${DATA_SYNC_SCHEMA_VERSION}\n`,
-    );
-    await writeFile(join(dataSyncPath, 'issues', '.gitkeep'), '');
-    await writeFile(join(dataSyncPath, 'mappings', '.gitkeep'), '');
-
-    // Add .gitattributes for merge=union on ids.yml so concurrent additions
-    // (both sides add non-overlapping keys) merge cleanly instead of conflicting.
-    // This must be inside the worktree; .gitattributes on the main branch has
-    // no effect on merges happening on the tbd-sync branch.
-    await writeFile(join(dataSyncPath, 'mappings', '.gitattributes'), 'ids.yml merge=union\n');
-
-    // Stage and commit the initial structure
-    // Use --no-verify to bypass parent repo hooks (lefthook, husky, etc.)
-    await git('-C', worktreePath, 'add', '.');
-    await gitCommit(worktreePath, '--no-verify', '-m', 'Initialize tbd-sync branch');
+    let restoredDataFiles = await ensureDataSyncScaffold(baseDir);
 
     // Push the fresh orphan immediately so "first init wins" and the #137 race
     // window closes. Only when a remote is configured; best-effort on transient
     // failure, adopt-or-fail-loud on a detected rejected-race.
     if (hasRemote) {
-      await pushFreshOrphan(baseDir, worktreePath, remote, syncBranch, dataSyncPath);
+      const pushResult = await pushFreshOrphan(
+        baseDir,
+        worktreePath,
+        remote,
+        syncBranch,
+        dataSyncPath,
+      );
+      if (pushResult.adopted) {
+        restoredDataFiles = await ensureDataSyncScaffold(baseDir);
+      }
     }
 
-    return { success: true, path: worktreePath, created: true };
+    return { success: true, path: worktreePath, created: true, restoredDataFiles };
   } catch (error) {
     return {
       success: false,
@@ -2480,7 +2653,13 @@ export async function repairWorktree(
   status: 'missing' | 'prunable' | 'corrupted',
   remote = 'origin',
   syncBranch: string = SYNC_BRANCH,
-): Promise<{ success: boolean; path?: string; backedUp?: string; error?: string }> {
+): Promise<{
+  success: boolean;
+  path?: string;
+  backedUp?: string;
+  restoredDataFiles?: number;
+  error?: string;
+}> {
   const { sharedWorktreePath: worktreePath, sharedBackupsDir } = await getSharedPaths(baseDir);
 
   try {

--- a/packages/tbd/tests/common-dir-layout-doctor.test.ts
+++ b/packages/tbd/tests/common-dir-layout-doctor.test.ts
@@ -327,6 +327,66 @@ describeUnlessWindows('common-dir layout via CLI', { timeout: 30000 }, () => {
     });
   });
 
+  describe('legacy sync branch initialization', () => {
+    it('repairs a registered worktree whose branch predates the data-sync scaffold', async () => {
+      const worktreePath = join(dir, '.git', 'tbd', 'data-sync-worktree');
+      const dataSyncPath = join(worktreePath, '.tbd', 'data-sync');
+
+      // Reproduce an f06-era repository whose tbd-sync branch exists and is
+      // registered, but never contained the f07 data-sync scaffold.
+      await gitIn(dir, 'worktree', 'remove', '--force', worktreePath);
+      await gitIn(dir, 'branch', '-D', 'tbd-sync');
+      await gitIn(dir, 'worktree', 'add', '--orphan', '-b', 'tbd-sync', worktreePath);
+      await writeFile(join(worktreePath, 'legacy-marker.txt'), 'preserve me\n');
+      await gitIn(worktreePath, 'add', '.');
+      await gitIn(worktreePath, 'commit', '-m', 'legacy tbd-sync branch');
+
+      const create = runTbd(dir, ['create', 'Upgrade probe', '--type', 'task']);
+      expect(create.status).toBe(0);
+      expect(await exists(join(dataSyncPath, 'meta.yml'))).toBe(true);
+      expect(await exists(join(dataSyncPath, 'issues'))).toBe(true);
+      expect(await readFile(join(worktreePath, 'legacy-marker.txt'), 'utf-8')).toBe(
+        'preserve me\n',
+      );
+    });
+
+    it('recovers a previously populated scaffold instead of resetting it empty', async () => {
+      const worktreePath = join(dir, '.git', 'tbd', 'data-sync-worktree');
+      const dataSyncPath = join(worktreePath, '.tbd', 'data-sync');
+      await gitIn(worktreePath, 'rm', '-r', '.tbd/data-sync');
+      await gitIn(worktreePath, 'commit', '-m', 'simulate lost tracker data');
+
+      const create = runTbd(dir, ['create', 'Recovery probe', '--type', 'task']);
+      expect(create.status).toBe(0);
+      expect(create.stderr).toMatch(/Restored .* tbd-sync data files from Git history/i);
+      expect(await exists(join(dataSyncPath, 'meta.yml'))).toBe(true);
+      const list = runTbd(dir, ['list', '--json']);
+      expect(list.status).toBe(0);
+      expect(list.stdout).toContain('Seed');
+      expect(list.stdout).toContain('Recovery probe');
+      expect(await gitIn(worktreePath, 'log', '-1', '--format=%s')).toMatch(
+        /Recovery probe|Restore missing tbd-sync data layout/,
+      );
+    });
+
+    it('finishes an interrupted historical recovery on the next command', async () => {
+      const worktreePath = join(dir, '.git', 'tbd', 'data-sync-worktree');
+      await gitIn(worktreePath, 'rm', '-r', '.tbd/data-sync');
+      await gitIn(worktreePath, 'commit', '-m', 'simulate lost tracker data');
+      await gitIn(worktreePath, 'checkout', 'HEAD^', '--', '.tbd/data-sync');
+
+      const create = runTbd(dir, ['create', 'Interrupted recovery probe', '--type', 'task']);
+      expect(create.status).toBe(0);
+      const list = runTbd(dir, ['list', '--json']);
+      expect(list.stdout).toContain('Seed');
+      expect(list.stdout).toContain('Interrupted recovery probe');
+      expect(await gitIn(worktreePath, 'diff', '--cached', '--name-only')).toBe('');
+      expect(await gitIn(worktreePath, 'show', 'HEAD:.tbd/data-sync/meta.yml')).toContain(
+        'schema_version: 1',
+      );
+    });
+  });
+
   describe('sibling-checkout config bump notice (tbd-afjh)', () => {
     it('prints a one-time stderr notice when this checkout migrates .tbd/config.yml to a newer tbd_format', async () => {
       const configPath = join(dir, '.tbd', 'config.yml');

--- a/packages/tbd/tests/git-init-orphan.test.ts
+++ b/packages/tbd/tests/git-init-orphan.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdir, rm, writeFile as fsWriteFile } from 'node:fs/promises';
+import { access, mkdir, rm, writeFile as fsWriteFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir, platform } from 'node:os';
 import { randomBytes } from 'node:crypto';
@@ -120,6 +120,28 @@ describeUnlessWindows('initWorktree orphan hardening', () => {
     const result = await initWorktree(workPath);
     expect(result.success).toBe(true);
     expect(await branchExists(SYNC_BRANCH, workPath)).toBe(true);
+  });
+
+  it('initializes the data scaffold on a pre-existing remote sync branch', async () => {
+    await createBareRepo(barePath);
+    await seedRemoteOrphanSync(testDir, barePath);
+    await initRepoWithRemote(workPath, barePath);
+
+    const result = await initWorktree(workPath);
+    expect(result.success).toBe(true);
+
+    const dataSyncPath = join(result.path!, TBD_DIR, DATA_SYNC_DIR_NAME);
+    await expect(access(join(dataSyncPath, 'meta.yml'))).resolves.toBeUndefined();
+    await expect(access(join(dataSyncPath, 'issues', '.gitkeep'))).resolves.toBeUndefined();
+    await expect(access(join(dataSyncPath, 'mappings', '.gitkeep'))).resolves.toBeUndefined();
+    await expect(access(join(dataSyncPath, 'mappings', '.gitattributes'))).resolves.toBeUndefined();
+    expect(await gitInDir(result.path!, 'status', '--porcelain')).toBe('');
+
+    const initializedHead = await gitInDir(result.path!, 'rev-parse', 'HEAD');
+    const repeated = await initWorktree(workPath);
+    expect(repeated.success).toBe(true);
+    expect(repeated.created).toBe(false);
+    expect(await gitInDir(result.path!, 'rev-parse', 'HEAD')).toBe(initializedHead);
   });
 
   describe('pushFreshOrphan rejected-race handling', () => {


### PR DESCRIPTION
## 0.6.4

### Fixed

- **Smooth f06 repository upgrades**: Setup and the first data command now initialize
  the f07 data scaffold when a pre-existing `tbd-sync` branch never contained one.
  This repairs the real `get-tbd@0.4.2` repository state found during the downstream
  upgrade trial while preserving every legacy branch file and remaining idempotent.
- **Historical data recovery**: If the current branch lost its scaffold but Git history
  still contains tracker data, the upgrade restores every missing issue and mapping
  before continuing. Existing files are never overwritten, avoiding both silent data loss
  and an empty-tracker reset.

### Changed

- **Release upgrade proof**: Packed-package QA now covers the latest 0.6.3 same-format
  baseline and a fresh clone of the common 0.4.2-era remote-branch layout.
  The latter proves setup, first issue creation, sync, legacy-file preservation, and a
  byte-identical repeated setup before release.

### Security

- **Dependency posture**: No dependencies or lockfile entries changed.
  Exact first-party historical `get-tbd` packages are used for upgrade QA with lifecycle
  scripts disabled; the existing frozen dependency tree is reused.
  The production audit is clean; the full audit reports the same 32 dev-only advisories
  inherited from that unchanged tree.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Git worktree initialization, historical recovery commits on `tbd-sync`, and first-command data paths—high impact for upgrade correctness but scoped to legacy scaffold gaps with additive, non-overwriting behavior and broad tests.
> 
> **Overview**
> **get-tbd v0.6.4** fixes upgrades from f06-era repos whose `tbd-sync` branch exists but never had (or later lost) the f07 `.tbd/data-sync` scaffold.
> 
> Setup and the first data command now treat “worktree healthy” as insufficient: they run **`ensureDataSyncScaffold`** to add only missing scaffold files, **`git checkout`** historical tracker paths from branch history when the current tip dropped them, force-add through legacy ignore rules, and commit—without overwriting existing worktree files or unrelated legacy branch files. **`isDataSyncScaffoldReady`** gates the data-context read path; **`data-context`** calls **`initWorktree`** when the worktree is valid but the scaffold is not, and prints a stderr notice when files are restored from history.
> 
> **Release QA** bumps the same-format baseline to **0.6.3**, asserts compatible patch upgrades do **not** rewrite session scripts, and adds a **legacy-remote** packed upgrade scenario (0.4.2 clone with historical data removed on `tbd-sync`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de7cb70dd2879e31a7e000921a2574a4c180a5bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->