### PR TITLE
chore: upgrade repository setup to tbd v0.6.4

### DIFF
--- a/.tbd/config.yml
+++ b/.tbd/config.yml
@@ -1,6 +1,6 @@
 tbd_format: f07
-tbd_version: 0.6.3
-tbd_fallback_version: 0.6.3
+tbd_version: 0.6.4
+tbd_fallback_version: 0.6.4
 # tbd_upgrades: tbd versions that have run `tbd setup` in this repo (oldest first);
 # tbd_version above is the most recent. Informational; updated automatically by setup.
 # tbd_fallback_version is the one exact registry fallback for format-incompatible launchers.
@@ -34,6 +34,8 @@ tbd_upgrades:
     at: 2026-08-14T07:29:21.939Z
   - version: 0.6.3
     at: 2026-08-14T19:58:08.487Z
+  - version: 0.6.4
+    at: 2026-08-14T22:11:51.709Z
 display:
   id_prefix: tbd
 sync:


### PR DESCRIPTION
## Summary

- record the published get-tbd 0.6.4 setup version and fallback in `.tbd/config.yml`
- preserve the f07 format and all generated client launchers unchanged
- record the repository upgrade in setup history

## Validation

- `tbd --version` → `0.6.4`
- repeated `tbd setup --auto` produced the same diff hash
- no generated agent or Bash file contains a `0.6.4` literal
- pre-push quality, build, and all 2,016 tests passed