### PR TITLE
chore: release get-tbd v0.6.5

### DIFF
--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -1,5 +1,27 @@
 # get-tbd
 
+## 0.6.5
+
+### Fixed
+
+- **Hardened generated GitHub CLI installer**: Setup now downloads and extracts the
+  pinned CLI inside a unique temporary directory, removes partial files on exit, and
+  atomically replaces the destination executable.
+  Upgrading no longer downgrades a downstream repository to shared fixed `/tmp` paths or
+  labels the Codex copy as a Claude-specific script.
+
+### Changed
+
+- **Packaged upgrade guard**: Release QA now verifies that the Claude and Codex surfaces
+  receive the same surface-neutral installer, with isolated temporary files and atomic
+  destination staging, across the 0.6.3, 0.4.2, and 0.5.0 upgrade paths.
+
+### Security
+
+- **Dependency posture**: No dependencies or lockfile entries changed.
+  The production audit remains clean, and exact first-party historical `get-tbd`
+  packages continue to run with lifecycle scripts disabled during upgrade QA.
+
 ## 0.6.4
 
 ### Fixed

--- a/packages/tbd/docs/install/ensure-gh-cli.sh
+++ b/packages/tbd/docs/install/ensure-gh-cli.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Automated GitHub CLI setup for Claude Code sessions
+# Automated GitHub CLI setup for agent sessions
 # This script runs on SessionStart to ensure gh CLI is available and authenticated
 #
 # Supply-chain policy (see SUPPLY-CHAIN-SECURITY.md): the gh version is PINNED to
@@ -10,6 +10,18 @@
 #   https://github.com/cli/cli/releases/download/v<VERSION>/gh_<VERSION>_checksums.txt
 
 set -euo pipefail
+
+INSTALL_TMP_DIR=""
+INSTALL_STAGING=""
+
+cleanup() {
+    if [ -n "$INSTALL_STAGING" ]; then
+        rm -f -- "$INSTALL_STAGING"
+    fi
+    if [ -n "$INSTALL_TMP_DIR" ]; then
+        rm -rf -- "$INSTALL_TMP_DIR"
+    fi
+}
 
 # Add common binary locations to PATH
 export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
@@ -55,6 +67,9 @@ if command -v gh &> /dev/null; then
 else
     echo "[gh] CLI not found, installing pinned v${GH_VERSION}..."
 
+    INSTALL_TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/tbd-gh.XXXXXX")
+    trap cleanup EXIT
+
     # Detect platform
     OS=$(uname -s | tr '[:upper:]' '[:lower:]')
     ARCH=$(uname -m)
@@ -65,11 +80,11 @@ else
     if [ "$OS" = "darwin" ]; then
         PLATFORM="macOS_${ARCH}.zip"
         ARCHIVE_EXT="zip"
-        EXTRACT_DIR="/tmp/gh_${GH_VERSION}_macOS_${ARCH}"
+        EXTRACT_DIR="${INSTALL_TMP_DIR}/gh_${GH_VERSION}_macOS_${ARCH}"
     else
         PLATFORM="${OS}_${ARCH}.tar.gz"
         ARCHIVE_EXT="tar.gz"
-        EXTRACT_DIR="/tmp/gh_${GH_VERSION}_${OS}_${ARCH}"
+        EXTRACT_DIR="${INSTALL_TMP_DIR}/gh_${GH_VERSION}_${OS}_${ARCH}"
     fi
 
     echo "[gh] Detected platform: ${PLATFORM}"
@@ -82,49 +97,49 @@ else
     fi
 
     ASSET="gh_${GH_VERSION}_${PLATFORM}"
+    ARCHIVE_PATH="${INSTALL_TMP_DIR}/${ASSET}"
     DOWNLOAD_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${ASSET}"
 
     echo "[gh] Downloading from ${DOWNLOAD_URL}..."
-    if ! curl -fsSL -o "/tmp/${ASSET}" "$DOWNLOAD_URL"; then
+    if ! curl -fsSL -o "$ARCHIVE_PATH" "$DOWNLOAD_URL"; then
         # Proxied remote sessions can intercept GitHub downloads with a proxy 403.
         # Retry once bypassing the proxy for GitHub hosts only; this succeeds when
         # the environment's egress policy allows direct GitHub connections.
         echo "[gh] Download failed (a session proxy may intercept GitHub); retrying with NO_PROXY for GitHub hosts..."
         NP="$(github_no_proxy)"
-        NO_PROXY="$NP" no_proxy="$NP" curl -fsSL --connect-timeout 15 -o "/tmp/${ASSET}" "$DOWNLOAD_URL"
+        NO_PROXY="$NP" no_proxy="$NP" curl -fsSL --connect-timeout 15 -o "$ARCHIVE_PATH" "$DOWNLOAD_URL"
     fi
 
     # Verify the download against the pinned checksum before extracting.
     if command -v sha256sum &> /dev/null; then
-        ACTUAL=$(sha256sum "/tmp/${ASSET}" | awk '{print $1}')
+        ACTUAL=$(sha256sum "$ARCHIVE_PATH" | awk '{print $1}')
     else
-        ACTUAL=$(shasum -a 256 "/tmp/${ASSET}" | awk '{print $1}')
+        ACTUAL=$(shasum -a 256 "$ARCHIVE_PATH" | awk '{print $1}')
     fi
     if [ "$ACTUAL" != "$EXPECTED" ]; then
         echo "[gh] ERROR: checksum mismatch for ${ASSET}"
         echo "[gh]   expected ${EXPECTED}"
         echo "[gh]   actual   ${ACTUAL}"
-        rm -f "/tmp/${ASSET}"
         exit 1
     fi
     echo "[gh] Checksum verified for ${ASSET}"
 
     # Extract based on archive type
     if [ "$ARCHIVE_EXT" = "zip" ]; then
-        unzip -q "/tmp/${ASSET}" -d /tmp
+        unzip -q "$ARCHIVE_PATH" -d "$INSTALL_TMP_DIR"
     else
-        tar -xzf "/tmp/${ASSET}" -C /tmp
+        tar -xzf "$ARCHIVE_PATH" -C "$INSTALL_TMP_DIR"
     fi
 
-    # Install to ~/.local/bin (works in cloud and local)
-    mkdir -p ~/.local/bin
-    cp "${EXTRACT_DIR}/bin/gh" ~/.local/bin/gh
-    chmod +x ~/.local/bin/gh
+    # Stage in the destination directory, then rename atomically into place.
+    mkdir -p "$HOME/.local/bin"
+    INSTALL_STAGING=$(mktemp "$HOME/.local/bin/.gh.XXXXXX")
+    cp "${EXTRACT_DIR}/bin/gh" "$INSTALL_STAGING"
+    chmod +x "$INSTALL_STAGING"
+    mv -f "$INSTALL_STAGING" "$HOME/.local/bin/gh"
+    INSTALL_STAGING=""
 
-    # Clean up
-    rm -rf "${EXTRACT_DIR}" "/tmp/${ASSET}"
-
-    echo "[gh] Installed to ~/.local/bin/gh"
+    echo "[gh] Installed to $HOME/.local/bin/gh"
 fi
 
 # Verify gh is now in PATH

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-tbd",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Git-native issue tracking for AI agents and humans",
   "license": "MIT",
   "author": "Joshua Levy <joshua@cal.berkeley.edu> (https://github.com/jlevy)",

--- a/packages/tbd/scripts/validate-upgrade-package.mjs
+++ b/packages/tbd/scripts/validate-upgrade-package.mjs
@@ -220,6 +220,38 @@ async function snapshotIssueData(repository) {
   return snapshot;
 }
 
+async function assertHardenedGhInstallers(repository, name) {
+  const claudeInstaller = await readFile(
+    join(repository, '.claude', 'scripts', 'ensure-gh-cli.sh'),
+    'utf8',
+  );
+  const codexInstaller = await readFile(join(repository, '.codex', 'ensure-gh-cli.sh'), 'utf8');
+  invariant(
+    claudeInstaller === codexInstaller,
+    `${name}: Claude and Codex received different GitHub CLI installers`,
+  );
+  invariant(
+    claudeInstaller.includes('# Automated GitHub CLI setup for agent sessions'),
+    `${name}: installer carries a surface-specific header`,
+  );
+  invariant(
+    claudeInstaller.includes('INSTALL_TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/tbd-gh.XXXXXX")') &&
+      claudeInstaller.includes('trap cleanup EXIT') &&
+      claudeInstaller.includes('ARCHIVE_PATH="${INSTALL_TMP_DIR}/${ASSET}"'),
+    `${name}: installer does not isolate downloaded and extracted files`,
+  );
+  invariant(
+    claudeInstaller.includes('INSTALL_STAGING=$(mktemp "$HOME/.local/bin/.gh.XXXXXX")') &&
+      claudeInstaller.includes('mv -f "$INSTALL_STAGING" "$HOME/.local/bin/gh"'),
+    `${name}: installer does not replace the destination atomically`,
+  );
+  invariant(
+    !claudeInstaller.includes('EXTRACT_DIR="/tmp/') &&
+      !claudeInstaller.includes('curl -fsSL -o "/tmp/${ASSET}"'),
+    `${name}: installer writes to a shared fixed temporary path`,
+  );
+}
+
 async function validateScenario({
   candidate,
   candidateVersion,
@@ -357,6 +389,7 @@ async function validateScenario({
     !/get-tbd@\d+\.\d+\.\d+/u.test(sessionScript),
     `${name}: session script embeds a release version`,
   );
+  await assertHardenedGhInstallers(repository, name);
 
   const firstDiff = await git(repository, 'diff', '--cached', '--binary');
   const repeatedUpgrade = await invokeCli(candidate, repository, home, ['setup', '--auto']);

--- a/packages/tbd/tests/setup-flows.test.ts
+++ b/packages/tbd/tests/setup-flows.test.ts
@@ -980,6 +980,20 @@ describe('setup flows', { timeout: subprocessTestTimeout() }, () => {
       expect(installed).toBe(bundled);
     });
 
+    it('isolates installer files and replaces the destination atomically', async () => {
+      const bundledPath = join(__dirname, '..', 'docs', 'install', 'ensure-gh-cli.sh');
+      const bundled = await readFile(bundledPath, 'utf-8');
+
+      expect(bundled).toContain('# Automated GitHub CLI setup for agent sessions');
+      expect(bundled).toContain('INSTALL_TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/tbd-gh.XXXXXX")');
+      expect(bundled).toContain('trap cleanup EXIT');
+      expect(bundled).toContain('ARCHIVE_PATH="${INSTALL_TMP_DIR}/${ASSET}"');
+      expect(bundled).toContain('INSTALL_STAGING=$(mktemp "$HOME/.local/bin/.gh.XXXXXX")');
+      expect(bundled).toContain('mv -f "$INSTALL_STAGING" "$HOME/.local/bin/gh"');
+      expect(bundled).not.toContain('EXTRACT_DIR="/tmp/');
+      expect(bundled).not.toContain('curl -fsSL -o "/tmp/${ASSET}"');
+    });
+
     it('refreshes stale ensure-gh-cli.sh copies on re-run (upgrade path)', async () => {
       // A repo that installed the script with an older tbd must get the current
       // bundled script when `tbd setup --auto` runs again after an upgrade.


### PR DESCRIPTION
## 0.6.5

### Fixed

- **Hardened generated GitHub CLI installer**: Setup now downloads and extracts the
  pinned CLI inside a unique temporary directory, removes partial files on exit, and
  atomically replaces the destination executable.
  Upgrading no longer downgrades a downstream repository to shared fixed `/tmp` paths or
  labels the Codex copy as a Claude-specific script.

### Changed

- **Packaged upgrade guard**: Release QA now verifies that the Claude and Codex surfaces
  receive the same surface-neutral installer, with isolated temporary files and atomic
  destination staging, across the 0.6.3, 0.4.2, and 0.5.0 upgrade paths.

### Security

- **Dependency posture**: No dependencies or lockfile entries changed.
  The production audit remains clean, and exact first-party historical `get-tbd`
  packages continue to run with lifecycle scripts disabled during upgrade QA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the optional gh bootstrap shell script, version/changelog, and test/QA guards; pinned checksums and supply-chain policy are unchanged.
> 
> **Overview**
> **get-tbd v0.6.5** tightens the generated **`ensure-gh-cli.sh`** that setup copies to Claude and Codex surfaces.
> 
> The installer now uses a **unique `mktemp` directory** for download and extract (with an **EXIT cleanup trap**), stages `gh` under **`~/.local/bin` via a temp file and `mv`**, and uses an **agent-neutral** header instead of Claude-only wording. Fixed **`/tmp`** paths for archives and extract dirs are removed so concurrent sessions and upgrades are less likely to clash or leave partial binaries.
> 
> **Release QA** (`validate-upgrade-package.mjs`) asserts identical hardened installers on both surfaces and rejects legacy shared-`/tmp` patterns across representative upgrade baselines. **Setup tests** assert the bundled script contains the new isolation and atomic-replace markers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ce81280c7eafeaae877eeffed0d854b8fe52d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->