### PR TITLE
chore: self-upgrade tbd to v0.6.5

### DIFF
--- a/.claude/scripts/ensure-gh-cli.sh
+++ b/.claude/scripts/ensure-gh-cli.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Automated GitHub CLI setup for Claude Code sessions
+# Automated GitHub CLI setup for agent sessions
 # This script runs on SessionStart to ensure gh CLI is available and authenticated
 #
 # Supply-chain policy (see SUPPLY-CHAIN-SECURITY.md): the gh version is PINNED to
@@ -10,6 +10,18 @@
 #   https://github.com/cli/cli/releases/download/v<VERSION>/gh_<VERSION>_checksums.txt
 
 set -euo pipefail
+
+INSTALL_TMP_DIR=""
+INSTALL_STAGING=""
+
+cleanup() {
+    if [ -n "$INSTALL_STAGING" ]; then
+        rm -f -- "$INSTALL_STAGING"
+    fi
+    if [ -n "$INSTALL_TMP_DIR" ]; then
+        rm -rf -- "$INSTALL_TMP_DIR"
+    fi
+}
 
 # Add common binary locations to PATH
 export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
@@ -55,6 +67,9 @@ if command -v gh &> /dev/null; then
 else
     echo "[gh] CLI not found, installing pinned v${GH_VERSION}..."
 
+    INSTALL_TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/tbd-gh.XXXXXX")
+    trap cleanup EXIT
+
     # Detect platform
     OS=$(uname -s | tr '[:upper:]' '[:lower:]')
     ARCH=$(uname -m)
@@ -65,11 +80,11 @@ else
     if [ "$OS" = "darwin" ]; then
         PLATFORM="macOS_${ARCH}.zip"
         ARCHIVE_EXT="zip"
-        EXTRACT_DIR="/tmp/gh_${GH_VERSION}_macOS_${ARCH}"
+        EXTRACT_DIR="${INSTALL_TMP_DIR}/gh_${GH_VERSION}_macOS_${ARCH}"
     else
         PLATFORM="${OS}_${ARCH}.tar.gz"
         ARCHIVE_EXT="tar.gz"
-        EXTRACT_DIR="/tmp/gh_${GH_VERSION}_${OS}_${ARCH}"
+        EXTRACT_DIR="${INSTALL_TMP_DIR}/gh_${GH_VERSION}_${OS}_${ARCH}"
     fi
 
     echo "[gh] Detected platform: ${PLATFORM}"
@@ -82,49 +97,49 @@ else
     fi
 
     ASSET="gh_${GH_VERSION}_${PLATFORM}"
+    ARCHIVE_PATH="${INSTALL_TMP_DIR}/${ASSET}"
     DOWNLOAD_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${ASSET}"
 
     echo "[gh] Downloading from ${DOWNLOAD_URL}..."
-    if ! curl -fsSL -o "/tmp/${ASSET}" "$DOWNLOAD_URL"; then
+    if ! curl -fsSL -o "$ARCHIVE_PATH" "$DOWNLOAD_URL"; then
         # Proxied remote sessions can intercept GitHub downloads with a proxy 403.
         # Retry once bypassing the proxy for GitHub hosts only; this succeeds when
         # the environment's egress policy allows direct GitHub connections.
         echo "[gh] Download failed (a session proxy may intercept GitHub); retrying with NO_PROXY for GitHub hosts..."
         NP="$(github_no_proxy)"
-        NO_PROXY="$NP" no_proxy="$NP" curl -fsSL --connect-timeout 15 -o "/tmp/${ASSET}" "$DOWNLOAD_URL"
+        NO_PROXY="$NP" no_proxy="$NP" curl -fsSL --connect-timeout 15 -o "$ARCHIVE_PATH" "$DOWNLOAD_URL"
     fi
 
     # Verify the download against the pinned checksum before extracting.
     if command -v sha256sum &> /dev/null; then
-        ACTUAL=$(sha256sum "/tmp/${ASSET}" | awk '{print $1}')
+        ACTUAL=$(sha256sum "$ARCHIVE_PATH" | awk '{print $1}')
     else
-        ACTUAL=$(shasum -a 256 "/tmp/${ASSET}" | awk '{print $1}')
+        ACTUAL=$(shasum -a 256 "$ARCHIVE_PATH" | awk '{print $1}')
     fi
     if [ "$ACTUAL" != "$EXPECTED" ]; then
         echo "[gh] ERROR: checksum mismatch for ${ASSET}"
         echo "[gh]   expected ${EXPECTED}"
         echo "[gh]   actual   ${ACTUAL}"
-        rm -f "/tmp/${ASSET}"
         exit 1
     fi
     echo "[gh] Checksum verified for ${ASSET}"
 
     # Extract based on archive type
     if [ "$ARCHIVE_EXT" = "zip" ]; then
-        unzip -q "/tmp/${ASSET}" -d /tmp
+        unzip -q "$ARCHIVE_PATH" -d "$INSTALL_TMP_DIR"
     else
-        tar -xzf "/tmp/${ASSET}" -C /tmp
+        tar -xzf "$ARCHIVE_PATH" -C "$INSTALL_TMP_DIR"
     fi
 
-    # Install to ~/.local/bin (works in cloud and local)
-    mkdir -p ~/.local/bin
-    cp "${EXTRACT_DIR}/bin/gh" ~/.local/bin/gh
-    chmod +x ~/.local/bin/gh
+    # Stage in the destination directory, then rename atomically into place.
+    mkdir -p "$HOME/.local/bin"
+    INSTALL_STAGING=$(mktemp "$HOME/.local/bin/.gh.XXXXXX")
+    cp "${EXTRACT_DIR}/bin/gh" "$INSTALL_STAGING"
+    chmod +x "$INSTALL_STAGING"
+    mv -f "$INSTALL_STAGING" "$HOME/.local/bin/gh"
+    INSTALL_STAGING=""
 
-    # Clean up
-    rm -rf "${EXTRACT_DIR}" "/tmp/${ASSET}"
-
-    echo "[gh] Installed to ~/.local/bin/gh"
+    echo "[gh] Installed to $HOME/.local/bin/gh"
 fi
 
 # Verify gh is now in PATH

--- a/.codex/ensure-gh-cli.sh
+++ b/.codex/ensure-gh-cli.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Automated GitHub CLI setup for Claude Code sessions
+# Automated GitHub CLI setup for agent sessions
 # This script runs on SessionStart to ensure gh CLI is available and authenticated
 #
 # Supply-chain policy (see SUPPLY-CHAIN-SECURITY.md): the gh version is PINNED to
@@ -10,6 +10,18 @@
 #   https://github.com/cli/cli/releases/download/v<VERSION>/gh_<VERSION>_checksums.txt
 
 set -euo pipefail
+
+INSTALL_TMP_DIR=""
+INSTALL_STAGING=""
+
+cleanup() {
+    if [ -n "$INSTALL_STAGING" ]; then
+        rm -f -- "$INSTALL_STAGING"
+    fi
+    if [ -n "$INSTALL_TMP_DIR" ]; then
+        rm -rf -- "$INSTALL_TMP_DIR"
+    fi
+}
 
 # Add common binary locations to PATH
 export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
@@ -55,6 +67,9 @@ if command -v gh &> /dev/null; then
 else
     echo "[gh] CLI not found, installing pinned v${GH_VERSION}..."
 
+    INSTALL_TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/tbd-gh.XXXXXX")
+    trap cleanup EXIT
+
     # Detect platform
     OS=$(uname -s | tr '[:upper:]' '[:lower:]')
     ARCH=$(uname -m)
@@ -65,11 +80,11 @@ else
     if [ "$OS" = "darwin" ]; then
         PLATFORM="macOS_${ARCH}.zip"
         ARCHIVE_EXT="zip"
-        EXTRACT_DIR="/tmp/gh_${GH_VERSION}_macOS_${ARCH}"
+        EXTRACT_DIR="${INSTALL_TMP_DIR}/gh_${GH_VERSION}_macOS_${ARCH}"
     else
         PLATFORM="${OS}_${ARCH}.tar.gz"
         ARCHIVE_EXT="tar.gz"
-        EXTRACT_DIR="/tmp/gh_${GH_VERSION}_${OS}_${ARCH}"
+        EXTRACT_DIR="${INSTALL_TMP_DIR}/gh_${GH_VERSION}_${OS}_${ARCH}"
     fi
 
     echo "[gh] Detected platform: ${PLATFORM}"
@@ -82,49 +97,49 @@ else
     fi
 
     ASSET="gh_${GH_VERSION}_${PLATFORM}"
+    ARCHIVE_PATH="${INSTALL_TMP_DIR}/${ASSET}"
     DOWNLOAD_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${ASSET}"
 
     echo "[gh] Downloading from ${DOWNLOAD_URL}..."
-    if ! curl -fsSL -o "/tmp/${ASSET}" "$DOWNLOAD_URL"; then
+    if ! curl -fsSL -o "$ARCHIVE_PATH" "$DOWNLOAD_URL"; then
         # Proxied remote sessions can intercept GitHub downloads with a proxy 403.
         # Retry once bypassing the proxy for GitHub hosts only; this succeeds when
         # the environment's egress policy allows direct GitHub connections.
         echo "[gh] Download failed (a session proxy may intercept GitHub); retrying with NO_PROXY for GitHub hosts..."
         NP="$(github_no_proxy)"
-        NO_PROXY="$NP" no_proxy="$NP" curl -fsSL --connect-timeout 15 -o "/tmp/${ASSET}" "$DOWNLOAD_URL"
+        NO_PROXY="$NP" no_proxy="$NP" curl -fsSL --connect-timeout 15 -o "$ARCHIVE_PATH" "$DOWNLOAD_URL"
     fi
 
     # Verify the download against the pinned checksum before extracting.
     if command -v sha256sum &> /dev/null; then
-        ACTUAL=$(sha256sum "/tmp/${ASSET}" | awk '{print $1}')
+        ACTUAL=$(sha256sum "$ARCHIVE_PATH" | awk '{print $1}')
     else
-        ACTUAL=$(shasum -a 256 "/tmp/${ASSET}" | awk '{print $1}')
+        ACTUAL=$(shasum -a 256 "$ARCHIVE_PATH" | awk '{print $1}')
     fi
     if [ "$ACTUAL" != "$EXPECTED" ]; then
         echo "[gh] ERROR: checksum mismatch for ${ASSET}"
         echo "[gh]   expected ${EXPECTED}"
         echo "[gh]   actual   ${ACTUAL}"
-        rm -f "/tmp/${ASSET}"
         exit 1
     fi
     echo "[gh] Checksum verified for ${ASSET}"
 
     # Extract based on archive type
     if [ "$ARCHIVE_EXT" = "zip" ]; then
-        unzip -q "/tmp/${ASSET}" -d /tmp
+        unzip -q "$ARCHIVE_PATH" -d "$INSTALL_TMP_DIR"
     else
-        tar -xzf "/tmp/${ASSET}" -C /tmp
+        tar -xzf "$ARCHIVE_PATH" -C "$INSTALL_TMP_DIR"
     fi
 
-    # Install to ~/.local/bin (works in cloud and local)
-    mkdir -p ~/.local/bin
-    cp "${EXTRACT_DIR}/bin/gh" ~/.local/bin/gh
-    chmod +x ~/.local/bin/gh
+    # Stage in the destination directory, then rename atomically into place.
+    mkdir -p "$HOME/.local/bin"
+    INSTALL_STAGING=$(mktemp "$HOME/.local/bin/.gh.XXXXXX")
+    cp "${EXTRACT_DIR}/bin/gh" "$INSTALL_STAGING"
+    chmod +x "$INSTALL_STAGING"
+    mv -f "$INSTALL_STAGING" "$HOME/.local/bin/gh"
+    INSTALL_STAGING=""
 
-    # Clean up
-    rm -rf "${EXTRACT_DIR}" "/tmp/${ASSET}"
-
-    echo "[gh] Installed to ~/.local/bin/gh"
+    echo "[gh] Installed to $HOME/.local/bin/gh"
 fi
 
 # Verify gh is now in PATH

--- a/.tbd/config.yml
+++ b/.tbd/config.yml
@@ -1,6 +1,6 @@
 tbd_format: f07
-tbd_version: 0.6.3
-tbd_fallback_version: 0.6.3
+tbd_version: 0.6.5
+tbd_fallback_version: 0.6.5
 # tbd_upgrades: tbd versions that have run `tbd setup` in this repo (oldest first);
 # tbd_version above is the most recent. Informational; updated automatically by setup.
 # tbd_fallback_version is the one exact registry fallback for format-incompatible launchers.
@@ -34,6 +34,8 @@ tbd_upgrades:
     at: 2026-08-14T07:29:21.939Z
   - version: 0.6.3
     at: 2026-08-14T19:58:08.487Z
+  - version: 0.6.5
+    at: 2026-08-14T22:57:38.370Z
 display:
   id_prefix: tbd
 sync:


### PR DESCRIPTION
## Summary

- self-upgrade this repository from tbd 0.6.3 to the published 0.6.5 release
- record the 0.6.5 upgrade and matching format-incompatible fallback in `.tbd/config.yml`
- refresh both generated GitHub CLI bootstrap copies from the packaged 0.6.5 template

## Why

This is the repository-side proof that the published upgrade path works on a fresh
branch from current `main`. The generated installer now uses unique temporary
directories, cleanup traps, and an atomic destination rename, while keeping the
installer version policy independent from tbd patch versions.

## Impact

The repository will use tbd 0.6.5 for its normal and fallback launch paths. Both agent
surfaces receive byte-identical generated installer content. No package dependencies or
application source code change.

## Validation

- ran the published global tbd 0.6.5 setup from fresh `origin/main`
- reran setup and confirmed byte-identical output
- confirmed both generated scripts exactly match the packaged template and each other
- `bash -n` passed for both scripts
- confirmed no embedded `get-tbd@x.y.z` or tbd 0.6.5 literal appears in generated bash
- full local quality gate passed after rebasing onto merged PR #227: 137 test files /
  2,032 tests
- source-branch pre-push gate passed
- branch is based on current `main` at `d55790f8`

This is intentionally a draft for review. It does not publish another tbd release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and generated bootstrap scripts only; no application or dependency changes, with supply-chain pinning preserved.
> 
> **Overview**
> Self-upgrades the repo from **tbd 0.6.3** to **0.6.5** by updating `tbd_version`, `tbd_fallback_version`, and appending **0.6.5** to `tbd_upgrades` in `.tbd/config.yml`.
> 
> Regenerates **byte-identical** `ensure-gh-cli.sh` copies under `.claude/scripts/` and `.codex/` from the 0.6.5 packaged template. The installer now uses a **dedicated `mktemp` workspace**, an **EXIT `cleanup` trap** for archives and staging files, and an **atomic `mv` into `~/.local/bin/gh`** instead of writing directly to fixed `/tmp` paths. Header wording shifts from “Claude Code sessions” to **agent sessions**; pinned **gh 2.92.0** and checksum policy are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dee38beaee00e2fb5de6e767e7b1113f83ef89d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->