### PR TITLE
fix: Resolve duplicate short IDs in ids.yml to prevent bead data loss

### DIFF
--- a/packages/tbd/docs/tbd-design.md
+++ b/packages/tbd/docs/tbd-design.md
@@ -674,7 +674,11 @@ serialization:
 > file” as the correct state.
 > The `merge=union` strategy keeps all lines from both sides, which is safe for
 > `ids.yml` since it’s an append-only mapping.
-> Duplicate keys (if any) are tolerated by the YAML parser and auto-fixed on next save.
+> Contested duplicate keys (same short ID mapped to different ULIDs) are resolved
+> deterministically at load time: the lexicographically smallest ULID keeps the
+> contested short ID, and each displaced ULID receives a replacement derived from its
+> own characters (no randomness).
+> The corrected mapping is written on next save.
 > This file is placed inside `.tbd/` so all tbd settings are self-contained in one
 > directory. Git supports `.gitattributes` in subdirectories with paths relative to that
 > directory.

--- a/packages/tbd/src/file/id-mapping.ts
+++ b/packages/tbd/src/file/id-mapping.ts
@@ -12,8 +12,7 @@ import { join, dirname } from 'node:path';
 import { writeFile } from 'atomically';
 
 import {
-  parseYamlToleratingDuplicateKeys,
-  detectDuplicateYamlKeys,
+  parseYamlDocumentEntries,
   MergeConflictError,
   stringifyYaml,
   hasMergeConflictMarkers,
@@ -30,7 +29,7 @@ import {
   type InternalIssueId,
 } from '../lib/ids.js';
 import { naturalSort } from '../lib/sort.js';
-import { IdMappingYamlSchema } from '../lib/schemas.js';
+import { ShortId, Ulid } from '../lib/schemas.js';
 
 /**
  * ID mapping from short ID to ULID.
@@ -60,25 +59,50 @@ function serializeIdMapping(mapping: IdMapping): string {
 }
 
 /**
- * Parse all key-value entries from raw ids.yml content, preserving every
- * occurrence of duplicate keys. The YAML parser's `uniqueKeys: false` mode
- * silently drops all but the last value for each key; this line-level parser
- * captures every entry so that duplicate-key repair can see all competing ULIDs.
+ * Extract validated ID mapping entries from raw YAML content, preserving every
+ * occurrence of duplicate keys.
  *
- * Only matches top-level `shortId: ulid` lines; comments and blank lines are
- * skipped. This is safe because ids.yml is a flat key-value map.
+ * Uses the `yaml` library's AST (via `parseYamlDocumentEntries`) to handle
+ * quoted keys, trailing comments, and all other YAML formatting correctly —
+ * unlike a line-level regex, which cannot match keys that `stringifyYaml`
+ * quotes (e.g., all-digit short IDs like `"1234"`, `"0000"`, or YAML
+ * special scalars like `"true"`, `"null"`).
+ *
+ * Each extracted entry is validated against `ShortId` and `Ulid` schemas.
+ * Entries that fail validation cause a loud error rather than being silently
+ * skipped, preserving the same failure behavior as the Zod-validated parse path.
+ *
+ * @param content - Raw ids.yml YAML content
+ * @param filePath - Optional file path for error messages
+ * @returns Every (shortId, ulid) pair in document order, plus duplicate keys
  */
-export function parseAllIdEntries(content: string): { shortId: string; ulid: string }[] {
-  const entries: { shortId: string; ulid: string }[] = [];
-  for (const line of content.split('\n')) {
-    // Match lines like "a7k2: 01hx5zzkbkactav9wevgemmvrz"
-    // ShortId allows [0-9a-z._-]+, Ulid is exactly 26 [0-9a-z] chars
-    const match = /^([0-9a-z._-]+):\s+([0-9a-z]{26})\s*$/.exec(line);
-    if (match) {
-      entries.push({ shortId: match[1]!, ulid: match[2]! });
+function extractValidatedIdEntries(
+  content: string,
+  filePath?: string,
+): {
+  allEntries: { shortId: string; ulid: string }[];
+  duplicateKeys: string[];
+} {
+  const { entries, duplicateKeys } = parseYamlDocumentEntries(content, filePath);
+
+  const allEntries: { shortId: string; ulid: string }[] = [];
+  for (const { key, value } of entries) {
+    const shortIdResult = ShortId.safeParse(key);
+    if (!shortIdResult.success) {
+      const location = filePath ? ` in ${filePath}` : '';
+      throw new Error(`Invalid short ID "${key}"${location}: ${shortIdResult.error.message}`);
     }
+    const ulidResult = Ulid.safeParse(value);
+    if (!ulidResult.success) {
+      const location = filePath ? ` in ${filePath}` : '';
+      throw new Error(
+        `Invalid ULID "${value}" for key "${key}"${location}: ${ulidResult.error.message}`,
+      );
+    }
+    allEntries.push({ shortId: key, ulid: value });
   }
-  return entries;
+
+  return { allEntries, duplicateKeys };
 }
 
 /**
@@ -185,7 +209,14 @@ export function resolveDuplicateShortIds(
   for (const shortId of sortedDuplicateKeys) {
     const ulids = duplicateUlids.get(shortId)!;
 
-    if (ulids.size <= 1) {
+    // Guard: a reported duplicate key with no matching parsed entries is a no-op.
+    // This should not happen when detection and extraction use the same parser,
+    // but the guard prevents writing undefined into the Map if it ever does.
+    if (ulids.size === 0) {
+      continue;
+    }
+
+    if (ulids.size === 1) {
       // Same ULID repeated (harmless duplicate); just keep one copy
       const ulid = ulids.values().next().value!;
       shortToUlid.set(shortId, ulid);
@@ -212,7 +243,11 @@ export function resolveDuplicateShortIds(
   displacedUlids.sort((a, b) => (a.ulid < b.ulid ? -1 : a.ulid > b.ulid ? 1 : 0));
 
   for (const { ulid } of displacedUlids) {
-    const newShortId = deriveShortIdFromUlid(ulid, usedShortIds);
+    const newShortId = deriveShortIdFromUlid(
+      ulid,
+      usedShortIds,
+      calculateOptimalLength(usedShortIds.size),
+    );
     shortToUlid.set(newShortId, ulid);
     ulidToShort.set(ulid, newShortId);
     usedShortIds.add(newShortId);
@@ -250,8 +285,8 @@ export async function loadIdMapping(baseDir: string): Promise<IdMapping> {
   }
 
   // Check for unresolved merge conflict markers before any other parsing.
-  // This must run before the duplicate-key branch, because parseAllIdEntries
-  // silently skips conflict marker lines and would treat both sides of an
+  // Conflict markers must be caught before the duplicate-key branch, because
+  // the YAML AST parser skips marker lines and would treat both sides of an
   // unresolved conflict as live data.
   if (hasMergeConflictMarkers(content)) {
     throw new MergeConflictError(
@@ -262,13 +297,13 @@ export async function loadIdMapping(baseDir: string): Promise<IdMapping> {
     );
   }
 
-  // Detect duplicate keys from the raw content before YAML parsing.
-  const duplicateKeys = detectDuplicateYamlKeys(content);
+  // Single AST parse: extracts every (key, value) pair in document order,
+  // handles quoted keys and trailing comments, and detects duplicates — all
+  // from one parseDocument call rather than separate regex + YAML passes.
+  const { allEntries, duplicateKeys } = extractValidatedIdEntries(content, filePath);
 
   if (duplicateKeys.length > 0) {
-    // Parse all entries from raw content (preserving every duplicate) and
-    // resolve deterministically so no ULID loses its mapping.
-    const allEntries = parseAllIdEntries(content);
+    // Resolve deterministically so no ULID loses its mapping.
     const mapping = resolveDuplicateShortIds(allEntries, duplicateKeys);
 
     console.warn(
@@ -281,21 +316,11 @@ export async function loadIdMapping(baseDir: string): Promise<IdMapping> {
     return mapping;
   }
 
-  // No duplicates: standard YAML parse path
-  const { data: rawData } = parseYamlToleratingDuplicateKeys(content, filePath);
-  const data = rawData ?? {};
-
-  // Validate with Zod schema - ensures all keys are valid short IDs and values are ULIDs
-  const parseResult = IdMappingYamlSchema.safeParse(data);
-  if (!parseResult.success) {
-    throw new Error(`Invalid ID mapping format in ${filePath}: ${parseResult.error.message}`);
-  }
-  const validData = parseResult.data;
-
+  // No duplicates: build mapping directly from validated entries.
   const shortToUlid = new Map<string, string>();
   const ulidToShort = new Map<string, string>();
 
-  for (const [shortId, ulid] of Object.entries(validData)) {
+  for (const { shortId, ulid } of allEntries) {
     shortToUlid.set(shortId, ulid);
     ulidToShort.set(ulid, shortId);
   }
@@ -375,23 +400,35 @@ export async function replaceRecoveredIdMapping(
 /**
  * Load an ID mapping directly from a file path (internal helper for save merging).
  * Separated from loadIdMapping to avoid coupling the save path to baseDir resolution.
+ *
+ * Uses the same AST-based parser as `loadIdMapping` so that quoted keys,
+ * trailing comments, and duplicate entries are all handled consistently
+ * across every read path.
  */
 async function loadIdMappingRaw(filePath: string): Promise<IdMapping> {
   const content = await readFile(filePath, 'utf-8');
 
-  const { data: rawData } = parseYamlToleratingDuplicateKeys(content, filePath);
-  const data = rawData ?? {};
-
-  const parseResult = IdMappingYamlSchema.safeParse(data);
-  if (!parseResult.success) {
-    throw new Error(`Invalid ID mapping format in ${filePath}: ${parseResult.error.message}`);
+  // Conflict markers inside the lock would be a serious consistency problem;
+  // let the caller surface it rather than silently dropping entries.
+  if (hasMergeConflictMarkers(content)) {
+    throw new MergeConflictError(
+      `File in ${filePath} contains unresolved git merge conflict markers.\n` +
+        `This usually happens when 'tbd sync' encountered conflicts that weren't properly resolved.\n` +
+        `To fix: manually edit the file to resolve conflicts, or run 'tbd doctor --fix'.`,
+      filePath,
+    );
   }
-  const validData = parseResult.data;
+
+  const { allEntries, duplicateKeys } = extractValidatedIdEntries(content, filePath);
+
+  if (duplicateKeys.length > 0) {
+    return resolveDuplicateShortIds(allEntries, duplicateKeys);
+  }
 
   const shortToUlid = new Map<string, string>();
   const ulidToShort = new Map<string, string>();
 
-  for (const [shortId, ulid] of Object.entries(validData)) {
+  for (const { shortId, ulid } of allEntries) {
     shortToUlid.set(shortId, ulid);
     ulidToShort.set(ulid, shortId);
   }
@@ -559,8 +596,8 @@ export function resolveToInternalId(input: string, mapping: IdMapping): Internal
  */
 export function parseIdMappingFromYaml(content: string): IdMapping {
   // Check for unresolved merge conflict markers before any other parsing.
-  // This must run before the duplicate-key branch, because parseAllIdEntries
-  // silently skips conflict marker lines and would treat both sides of an
+  // Conflict markers must be caught before the duplicate-key branch, because
+  // the YAML AST parser skips marker lines and would treat both sides of an
   // unresolved conflict as live data.
   if (hasMergeConflictMarkers(content)) {
     throw new MergeConflictError(
@@ -570,8 +607,9 @@ export function parseIdMappingFromYaml(content: string): IdMapping {
     );
   }
 
-  // Detect duplicates from raw content
-  const duplicateKeys = detectDuplicateYamlKeys(content);
+  // Single AST parse: extracts every (key, value) pair in document order,
+  // handles quoted keys and trailing comments, and detects duplicates.
+  const { allEntries, duplicateKeys } = extractValidatedIdEntries(content);
 
   if (duplicateKeys.length > 0) {
     console.warn(
@@ -579,26 +617,14 @@ export function parseIdMappingFromYaml(content: string): IdMapping {
         `Duplicates will be auto-resolved.`,
     );
 
-    // Parse all entries preserving duplicates, then resolve deterministically
-    const allEntries = parseAllIdEntries(content);
     return resolveDuplicateShortIds(allEntries, duplicateKeys);
   }
 
-  // No duplicates: standard parse path
-  const { data: rawData } = parseYamlToleratingDuplicateKeys(content);
-  const data = rawData ?? {};
-
-  // Validate with Zod schema
-  const parseResult = IdMappingYamlSchema.safeParse(data);
-  if (!parseResult.success) {
-    throw new Error(`Invalid ID mapping format: ${parseResult.error.message}`);
-  }
-  const validData = parseResult.data;
-
+  // No duplicates: build mapping directly from validated entries.
   const shortToUlid = new Map<string, string>();
   const ulidToShort = new Map<string, string>();
 
-  for (const [shortId, ulid] of Object.entries(validData)) {
+  for (const { shortId, ulid } of allEntries) {
     shortToUlid.set(shortId, ulid);
     ulidToShort.set(ulid, shortId);
   }

--- a/packages/tbd/src/file/id-mapping.ts
+++ b/packages/tbd/src/file/id-mapping.ts
@@ -13,6 +13,7 @@ import { writeFile } from 'atomically';
 
 import {
   parseYamlToleratingDuplicateKeys,
+  detectDuplicateYamlKeys,
   stringifyYaml,
   hasMergeConflictMarkers,
 } from '../utils/yaml-utils.js';
@@ -58,8 +59,175 @@ function serializeIdMapping(mapping: IdMapping): string {
 }
 
 /**
+ * Parse all key-value entries from raw ids.yml content, preserving every
+ * occurrence of duplicate keys. The YAML parser's `uniqueKeys: false` mode
+ * silently drops all but the last value for each key; this line-level parser
+ * captures every entry so that duplicate-key repair can see all competing ULIDs.
+ *
+ * Only matches top-level `shortId: ulid` lines; comments and blank lines are
+ * skipped. This is safe because ids.yml is a flat key-value map.
+ */
+export function parseAllIdEntries(content: string): { shortId: string; ulid: string }[] {
+  const entries: { shortId: string; ulid: string }[] = [];
+  for (const line of content.split('\n')) {
+    // Match lines like "a7k2: 01hx5zzkbkactav9wevgemmvrz"
+    // ShortId allows [0-9a-z._-]+, Ulid is exactly 26 [0-9a-z] chars
+    const match = /^([0-9a-z._-]+):\s+([0-9a-z]{26})\s*$/.exec(line);
+    if (match) {
+      entries.push({ shortId: match[1]!, ulid: match[2]! });
+    }
+  }
+  return entries;
+}
+
+/**
+ * Derive a deterministic short ID from a ULID by extracting character windows.
+ *
+ * Tries successive non-overlapping 4-char windows from the end of the ULID,
+ * then overlapping single-offset windows, then 5-char windows as a last resort.
+ * The derivation is a pure function of the ULID and the set of already-used
+ * short IDs, so two clones repairing the same file independently will compute
+ * the same replacement — no randomness involved.
+ */
+export function deriveShortIdFromUlid(ulid: string, usedShortIds: Set<string>, length = 4): string {
+  // Try non-overlapping windows from the end: [22:26], [18:22], [14:18], ...
+  for (let offset = ulid.length - length; offset >= 0; offset -= length) {
+    const candidate = ulid.slice(offset, offset + length);
+    if (!usedShortIds.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Try every single-offset window from the end
+  for (let offset = ulid.length - length; offset >= 0; offset--) {
+    const candidate = ulid.slice(offset, offset + length);
+    if (!usedShortIds.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Last resort: try 5-char windows (longer ID)
+  const longerLength = length + 1;
+  for (let offset = ulid.length - longerLength; offset >= 0; offset--) {
+    const candidate = ulid.slice(offset, offset + longerLength);
+    if (!usedShortIds.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    `Cannot derive a unique short ID from ULID ${ulid}. ` +
+      `This should be extremely rare — please report this error.`,
+  );
+}
+
+/**
+ * Resolve duplicate short IDs that map to different ULIDs.
+ *
+ * When `merge=union` combines two clones' ids.yml files that independently
+ * allocated the same short ID for different beads, the merged file contains
+ * the same key twice with different values. This function deterministically
+ * resolves the conflict:
+ *
+ * 1. For each contested short ID, the lexicographically smallest ULID keeps it
+ *    (ULIDs are time-ordered, so the earlier-created bead wins).
+ * 2. Each displaced ULID receives a new short ID derived from its own characters
+ *    via `deriveShortIdFromUlid` — no randomness, so every clone that sees the
+ *    same merged file computes the same repair.
+ * 3. Duplicate keys are processed in sorted order for full determinism.
+ *
+ * @param allEntries - Every key-value pair from the raw file, in file order
+ * @param duplicateKeys - The set of short IDs that appear more than once
+ * @returns A resolved IdMapping where every ULID is addressable
+ */
+export function resolveDuplicateShortIds(
+  allEntries: { shortId: string; ulid: string }[],
+  duplicateKeys: string[],
+): IdMapping {
+  // Collect all ULIDs for each duplicate short ID
+  const duplicateUlids = new Map<string, Set<string>>();
+  for (const key of duplicateKeys) {
+    duplicateUlids.set(key, new Set());
+  }
+  for (const { shortId, ulid } of allEntries) {
+    const set = duplicateUlids.get(shortId);
+    if (set) {
+      set.add(ulid);
+    }
+  }
+
+  // Build the base mapping from all unique entries (non-duplicated keys).
+  // For duplicated keys, only the winner (smallest ULID) gets the original short ID.
+  const shortToUlid = new Map<string, string>();
+  const ulidToShort = new Map<string, string>();
+  const usedShortIds = new Set<string>();
+
+  // First pass: add all non-duplicate entries
+  const seenShortIds = new Set<string>();
+  for (const { shortId, ulid } of allEntries) {
+    if (duplicateUlids.has(shortId)) {
+      continue; // Handle duplicates separately below
+    }
+    if (!seenShortIds.has(shortId)) {
+      shortToUlid.set(shortId, ulid);
+      ulidToShort.set(ulid, shortId);
+      usedShortIds.add(shortId);
+      seenShortIds.add(shortId);
+    }
+  }
+
+  // Second pass: resolve each duplicate key deterministically.
+  // Process duplicate keys in sorted order for cross-clone determinism.
+  const sortedDuplicateKeys = [...duplicateKeys].sort();
+  const displacedUlids: { ulid: string; originalShortId: string }[] = [];
+
+  for (const shortId of sortedDuplicateKeys) {
+    const ulids = duplicateUlids.get(shortId)!;
+
+    if (ulids.size <= 1) {
+      // Same ULID repeated (harmless duplicate); just keep one copy
+      const ulid = ulids.values().next().value!;
+      shortToUlid.set(shortId, ulid);
+      ulidToShort.set(ulid, shortId);
+      usedShortIds.add(shortId);
+      continue;
+    }
+
+    // Multiple different ULIDs: smallest ULID keeps the short ID
+    const sorted = [...ulids].sort();
+    const winner = sorted[0]!;
+    shortToUlid.set(shortId, winner);
+    ulidToShort.set(winner, shortId);
+    usedShortIds.add(shortId);
+
+    // Collect displaced ULIDs for re-allocation
+    for (let i = 1; i < sorted.length; i++) {
+      displacedUlids.push({ ulid: sorted[i]!, originalShortId: shortId });
+    }
+  }
+
+  // Third pass: assign deterministic replacement short IDs to displaced ULIDs.
+  // Process in sorted order by ULID for determinism.
+  displacedUlids.sort((a, b) => (a.ulid < b.ulid ? -1 : a.ulid > b.ulid ? 1 : 0));
+
+  for (const { ulid } of displacedUlids) {
+    const newShortId = deriveShortIdFromUlid(ulid, usedShortIds);
+    shortToUlid.set(newShortId, ulid);
+    ulidToShort.set(ulid, newShortId);
+    usedShortIds.add(newShortId);
+  }
+
+  return { shortToUlid, ulidToShort };
+}
+
+/**
  * Load the ID mapping from disk.
  * Returns empty mapping if file doesn't exist.
+ *
+ * When the file contains duplicate short IDs (from a `merge=union` merge where
+ * two clones independently allocated the same short ID for different beads),
+ * the duplicates are resolved deterministically at load time so that every ULID
+ * remains addressable. The file is corrected on the next save.
  */
 export async function loadIdMapping(baseDir: string): Promise<IdMapping> {
   const filePath = getMappingPath(baseDir);
@@ -80,19 +248,28 @@ export async function loadIdMapping(baseDir: string): Promise<IdMapping> {
     };
   }
 
-  // Parse tolerating duplicate keys; this handles the case where a git merge
-  // conflict resolution kept entries from both sides, creating duplicate YAML keys.
-  // Without this, the yaml parser throws "Map keys must be unique".
-  const { data: rawData, duplicateKeys } = parseYamlToleratingDuplicateKeys(content, filePath);
-  const data = rawData ?? {};
+  // Detect duplicate keys from the raw content before YAML parsing.
+  const duplicateKeys = detectDuplicateYamlKeys(content);
 
   if (duplicateKeys.length > 0) {
+    // Parse all entries from raw content (preserving every duplicate) and
+    // resolve deterministically so no ULID loses its mapping.
+    const allEntries = parseAllIdEntries(content);
+    const mapping = resolveDuplicateShortIds(allEntries, duplicateKeys);
+
     console.warn(
       `Warning: ${filePath} contains ${duplicateKeys.length} duplicate key(s): ${duplicateKeys.join(', ')}. ` +
-        `This usually happens after a git merge conflict resolution. ` +
+        `This usually happens after a union merge of two clones. ` +
+        `Displaced entries have been assigned deterministic replacement short IDs. ` +
         `The file will be auto-fixed on next save.`,
     );
+
+    return mapping;
   }
+
+  // No duplicates: standard YAML parse path
+  const { data: rawData } = parseYamlToleratingDuplicateKeys(content, filePath);
+  const data = rawData ?? {};
 
   // Validate with Zod schema - ensures all keys are valid short IDs and values are ULIDs
   const parseResult = IdMappingYamlSchema.safeParse(data);
@@ -361,19 +538,29 @@ export function resolveToInternalId(input: string, mapping: IdMapping): Internal
  * Parse an ID mapping from raw YAML content.
  * Used for loading mappings from git show output during conflict resolution.
  *
+ * When duplicate keys map to different ULIDs (from a union merge), resolves
+ * them deterministically so no ULID loses its mapping.
+ *
  * @throws MergeConflictError if content contains merge conflict markers
  */
 export function parseIdMappingFromYaml(content: string): IdMapping {
-  // Parse tolerating duplicate keys; handles post-merge-conflict duplicates
-  const { data: rawData, duplicateKeys } = parseYamlToleratingDuplicateKeys(content);
-  const data = rawData ?? {};
+  // Detect duplicates from raw content first
+  const duplicateKeys = detectDuplicateYamlKeys(content);
 
   if (duplicateKeys.length > 0) {
     console.warn(
       `Warning: ID mapping YAML contains ${duplicateKeys.length} duplicate key(s): ${duplicateKeys.join(', ')}. ` +
         `Duplicates will be auto-resolved.`,
     );
+
+    // Parse all entries preserving duplicates, then resolve deterministically
+    const allEntries = parseAllIdEntries(content);
+    return resolveDuplicateShortIds(allEntries, duplicateKeys);
   }
+
+  // No duplicates: standard parse path
+  const { data: rawData } = parseYamlToleratingDuplicateKeys(content);
+  const data = rawData ?? {};
 
   // Validate with Zod schema
   const parseResult = IdMappingYamlSchema.safeParse(data);

--- a/packages/tbd/src/file/id-mapping.ts
+++ b/packages/tbd/src/file/id-mapping.ts
@@ -14,6 +14,7 @@ import { writeFile } from 'atomically';
 import {
   parseYamlToleratingDuplicateKeys,
   detectDuplicateYamlKeys,
+  MergeConflictError,
   stringifyYaml,
   hasMergeConflictMarkers,
 } from '../utils/yaml-utils.js';
@@ -246,6 +247,19 @@ export async function loadIdMapping(baseDir: string): Promise<IdMapping> {
       shortToUlid: new Map(),
       ulidToShort: new Map(),
     };
+  }
+
+  // Check for unresolved merge conflict markers before any other parsing.
+  // This must run before the duplicate-key branch, because parseAllIdEntries
+  // silently skips conflict marker lines and would treat both sides of an
+  // unresolved conflict as live data.
+  if (hasMergeConflictMarkers(content)) {
+    throw new MergeConflictError(
+      `File in ${filePath} contains unresolved git merge conflict markers.\n` +
+        `This usually happens when 'tbd sync' encountered conflicts that weren't properly resolved.\n` +
+        `To fix: manually edit the file to resolve conflicts, or run 'tbd doctor --fix'.`,
+      filePath,
+    );
   }
 
   // Detect duplicate keys from the raw content before YAML parsing.
@@ -544,7 +558,19 @@ export function resolveToInternalId(input: string, mapping: IdMapping): Internal
  * @throws MergeConflictError if content contains merge conflict markers
  */
 export function parseIdMappingFromYaml(content: string): IdMapping {
-  // Detect duplicates from raw content first
+  // Check for unresolved merge conflict markers before any other parsing.
+  // This must run before the duplicate-key branch, because parseAllIdEntries
+  // silently skips conflict marker lines and would treat both sides of an
+  // unresolved conflict as live data.
+  if (hasMergeConflictMarkers(content)) {
+    throw new MergeConflictError(
+      `File contains unresolved git merge conflict markers.\n` +
+        `This usually happens when 'tbd sync' encountered conflicts that weren't properly resolved.\n` +
+        `To fix: manually edit the file to resolve conflicts, or run 'tbd doctor --fix'.`,
+    );
+  }
+
+  // Detect duplicates from raw content
   const duplicateKeys = detectDuplicateYamlKeys(content);
 
   if (duplicateKeys.length > 0) {

--- a/packages/tbd/src/utils/yaml-utils.ts
+++ b/packages/tbd/src/utils/yaml-utils.ts
@@ -10,7 +10,7 @@
  * This ensures consistent formatting and proper error handling across the codebase.
  */
 
-import { parse as parseYaml, stringify, parseDocument } from 'yaml';
+import { parse as parseYaml, stringify, parseDocument, isMap, isPair, isScalar } from 'yaml';
 
 import {
   YAML_LINE_WIDTH,
@@ -164,6 +164,69 @@ export function detectDuplicateYamlKeys(content: string): string[] {
   }
 
   return Array.from(duplicates);
+}
+
+/**
+ * Result from extracting all key-value pairs from a YAML document via AST.
+ */
+export interface YamlDocumentEntries {
+  /** Every (key, value) pair in document order, including duplicates. */
+  entries: { key: string; value: string }[];
+  /** Keys that appeared more than once (empty if no duplicates). */
+  duplicateKeys: string[];
+}
+
+/**
+ * Parse a flat YAML map via the `yaml` library's AST, retaining every duplicate
+ * key-value pair in document order.
+ *
+ * Unlike `parseYaml()` or `doc.toJSON()`, which silently drop all but the last
+ * occurrence of a duplicate key, this walks `parseDocument(…, { uniqueKeys: false })`
+ * to return every pair the parser saw. Quoted keys (`"1234"`, `"true"`),
+ * trailing comments, and all other YAML formatting are handled by the real parser
+ * rather than a regex, so the result always agrees with what YAML semantics say
+ * the keys and values are.
+ *
+ * Intended for flat key-value files like ids.yml. Nested maps or sequences are
+ * not supported and will cause their pairs to be skipped.
+ *
+ * @param content - Raw YAML content (may contain duplicate keys)
+ * @param filePath - Optional file path for error messages
+ * @returns All entries in document order, plus the set of duplicated keys
+ * @throws On YAML parse errors (other than duplicate keys)
+ */
+export function parseYamlDocumentEntries(content: string, filePath?: string): YamlDocumentEntries {
+  const doc = parseDocument(content, { uniqueKeys: false });
+
+  // Check for parse errors (other than duplicate keys, which uniqueKeys: false suppresses)
+  if (doc.errors.length > 0) {
+    const location = filePath ? ` in ${filePath}` : '';
+    throw new Error(`YAML parse error${location}: ${doc.errors.map((e) => e.message).join('; ')}`);
+  }
+
+  const entries: { key: string; value: string }[] = [];
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+
+  if (isMap(doc.contents)) {
+    for (const item of doc.contents.items) {
+      if (isPair(item) && isScalar(item.key) && isScalar(item.value)) {
+        const key = String(item.key.value);
+        const value = String(item.value.value);
+        entries.push({ key, value });
+
+        if (seen.has(key)) {
+          duplicates.add(key);
+        }
+        seen.add(key);
+      }
+    }
+  }
+
+  return {
+    entries,
+    duplicateKeys: Array.from(duplicates),
+  };
 }
 
 /**

--- a/packages/tbd/tests/id-mapping-duplicate-short-ids.test.ts
+++ b/packages/tbd/tests/id-mapping-duplicate-short-ids.test.ts
@@ -128,6 +128,15 @@ v2.0: 01bbbbbbbbbbbbbbbbbbbbbbbb`;
     expect(entries[0]!.key).toBe('stat-in_progress');
     expect(entries[1]!.key).toBe('v2.0');
   });
+
+  it('throws on malformed YAML', () => {
+    // Unclosed quote is a parse error that parseDocument reports in doc.errors.
+    // parseYamlDocumentEntries must surface it, not silently return empty entries.
+    const malformed = `"unclosed: 01aaaaaaaaaaaaaaaaaaaaaaaa
+a1b2: 01bbbbbbbbbbbbbbbbbbbbbbbb`;
+
+    expect(() => parseYamlDocumentEntries(malformed)).toThrow(/YAML parse error/);
+  });
 });
 
 // =============================================================================
@@ -820,6 +829,25 @@ UPPER: 01cccccccccccccccccccccccc
     await writeFile(join(baseDir, 'mappings', 'ids.yml'), content);
 
     await expect(loadIdMapping(baseDir)).rejects.toThrow(/Invalid short ID/);
+  });
+
+  it('throws on invalid ULID in file with duplicates', async () => {
+    // A file with a duplicate AND an entry whose value is not a valid ULID
+    // (uppercase, which Ulid rejects). The repair path must throw, not skip.
+    const baseDir = join(
+      tmpdir(),
+      `tbd-test-ulid-validation-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(join(baseDir, 'mappings'), { recursive: true });
+
+    // "01CCCCCCCCCCCCCCCCCCCCCCCC" is 26 chars but uppercase — Ulid rejects it
+    const content = `a1b2: 01aaaaaaaaaaaaaaaaaaaaaaaa
+a1b2: 01bbbbbbbbbbbbbbbbbbbbbbbb
+c3d4: 01CCCCCCCCCCCCCCCCCCCCCCCC
+`;
+    await writeFile(join(baseDir, 'mappings', 'ids.yml'), content);
+
+    await expect(loadIdMapping(baseDir)).rejects.toThrow(/Invalid ULID.*c3d4/);
   });
 });
 

--- a/packages/tbd/tests/id-mapping-duplicate-short-ids.test.ts
+++ b/packages/tbd/tests/id-mapping-duplicate-short-ids.test.ts
@@ -1,0 +1,489 @@
+/**
+ * Tests for duplicate short ID resolution in ids.yml.
+ *
+ * When `merge=union` combines two clones' ids.yml files and both clones
+ * independently allocated the same short ID for different beads, the merged
+ * file contains the same key twice with different ULID values. These tests
+ * verify that the repair is deterministic, convergent, and preserves all ULIDs.
+ *
+ * See: tbd-ysz0 (tracking bead)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  loadIdMapping,
+  saveIdMapping,
+  parseAllIdEntries,
+  deriveShortIdFromUlid,
+  resolveDuplicateShortIds,
+  parseIdMappingFromYaml,
+} from '../src/file/id-mapping.js';
+import { formatDisplayId } from '../src/lib/ids.js';
+
+// =============================================================================
+// parseAllIdEntries
+// =============================================================================
+
+describe('parseAllIdEntries', () => {
+  it('parses all entries including duplicates', () => {
+    const content = `00wl: 01aaaaaaaaaaaaaaaaaaaaaaaa
+00wl: 01bbbbbbbbbbbbbbbbbbbbbbbb
+zzzz: 01cccccccccccccccccccccccc`;
+
+    const entries = parseAllIdEntries(content);
+    expect(entries).toHaveLength(3);
+    expect(entries[0]).toEqual({ shortId: '00wl', ulid: '01aaaaaaaaaaaaaaaaaaaaaaaa' });
+    expect(entries[1]).toEqual({ shortId: '00wl', ulid: '01bbbbbbbbbbbbbbbbbbbbbbbb' });
+    expect(entries[2]).toEqual({ shortId: 'zzzz', ulid: '01cccccccccccccccccccccccc' });
+  });
+
+  it('skips comments and blank lines', () => {
+    const content = `# comment
+a1b2: 01aaaaaaaaaaaaaaaaaaaaaaaa
+
+c3d4: 01bbbbbbbbbbbbbbbbbbbbbbbb`;
+
+    const entries = parseAllIdEntries(content);
+    expect(entries).toHaveLength(2);
+  });
+
+  it('handles empty content', () => {
+    expect(parseAllIdEntries('')).toEqual([]);
+  });
+
+  it('handles short IDs with dots, dashes, and underscores', () => {
+    const content = `stat-in_progress: 01aaaaaaaaaaaaaaaaaaaaaaaa
+v2.0: 01bbbbbbbbbbbbbbbbbbbbbbbb`;
+
+    const entries = parseAllIdEntries(content);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]!.shortId).toBe('stat-in_progress');
+    expect(entries[1]!.shortId).toBe('v2.0');
+  });
+});
+
+// =============================================================================
+// deriveShortIdFromUlid
+// =============================================================================
+
+describe('deriveShortIdFromUlid', () => {
+  it('derives short ID from last 4 chars of ULID', () => {
+    const ulid = '01aabbccddeeffffgghhjjkkll';
+    const used = new Set<string>();
+    const result = deriveShortIdFromUlid(ulid, used);
+    expect(result).toBe('kkll'); // last 4 chars
+  });
+
+  it('tries earlier windows when last 4 chars collide', () => {
+    const ulid = '01aabbccddeeffffgghhjjkkll';
+    const used = new Set<string>(['kkll']); // last 4 chars taken
+    const result = deriveShortIdFromUlid(ulid, used);
+    // Next non-overlapping window: chars 18-21 = "hhjj"
+    expect(result).toBe('hhjj');
+  });
+
+  it('is deterministic - same input produces same output', () => {
+    const ulid = '01aabbccddeeffffgghhjjkkll';
+    const used = new Set<string>(['kkll']);
+    const result1 = deriveShortIdFromUlid(ulid, used);
+    const result2 = deriveShortIdFromUlid(ulid, used);
+    expect(result1).toBe(result2);
+  });
+
+  it('falls back to overlapping windows', () => {
+    const ulid = '01aabbccddeeffffgghhjjkkll';
+    // Block all non-overlapping 4-char windows
+    const used = new Set<string>(['kkll', 'gghh', 'ccdd', 'ffff', 'aabb', 'jjkk', '01aa']);
+    const result = deriveShortIdFromUlid(ulid, used);
+    expect(result.length).toBe(4);
+    expect(used.has(result)).toBe(false);
+  });
+
+  it('produces valid base36 short IDs from ULID characters', () => {
+    const ulid = '01hx5zzkbkactav9wevgemmvrz';
+    const result = deriveShortIdFromUlid(ulid, new Set());
+    expect(result).toMatch(/^[0-9a-z]+$/);
+    expect(result.length).toBe(4);
+  });
+});
+
+// =============================================================================
+// resolveDuplicateShortIds
+// =============================================================================
+
+describe('resolveDuplicateShortIds', () => {
+  it('resolves the exact bug report scenario', () => {
+    const entries = [
+      { shortId: '00wl', ulid: '01aaaaaaaaaaaaaaaaaaaaaaaa' },
+      { shortId: '00wl', ulid: '01bbbbbbbbbbbbbbbbbbbbbbbb' },
+      { shortId: 'zzzz', ulid: '01cccccccccccccccccccccccc' },
+    ];
+    const duplicateKeys = ['00wl'];
+
+    const mapping = resolveDuplicateShortIds(entries, duplicateKeys);
+
+    // Both ULIDs must be addressable
+    expect(mapping.shortToUlid.size).toBe(3);
+    expect(mapping.ulidToShort.size).toBe(3);
+
+    // Smallest ULID keeps the original short ID
+    expect(mapping.shortToUlid.get('00wl')).toBe('01aaaaaaaaaaaaaaaaaaaaaaaa');
+    expect(mapping.ulidToShort.get('01aaaaaaaaaaaaaaaaaaaaaaaa')).toBe('00wl');
+
+    // Larger ULID gets a deterministic replacement
+    expect(mapping.ulidToShort.has('01bbbbbbbbbbbbbbbbbbbbbbbb')).toBe(true);
+    const replacementShortId = mapping.ulidToShort.get('01bbbbbbbbbbbbbbbbbbbbbbbb')!;
+    expect(replacementShortId).not.toBe('00wl');
+    expect(replacementShortId.length).toBeGreaterThanOrEqual(4);
+
+    // Non-duplicate entry unchanged
+    expect(mapping.shortToUlid.get('zzzz')).toBe('01cccccccccccccccccccccccc');
+  });
+
+  it('handles harmless duplicates (same ULID repeated)', () => {
+    const entries = [
+      { shortId: 'a1b2', ulid: '01aaaaaaaaaaaaaaaaaaaaaaaa' },
+      { shortId: 'a1b2', ulid: '01aaaaaaaaaaaaaaaaaaaaaaaa' },
+      { shortId: 'c3d4', ulid: '01bbbbbbbbbbbbbbbbbbbbbbbb' },
+    ];
+    const duplicateKeys = ['a1b2'];
+
+    const mapping = resolveDuplicateShortIds(entries, duplicateKeys);
+
+    // Only 2 unique entries
+    expect(mapping.shortToUlid.size).toBe(2);
+    expect(mapping.ulidToShort.size).toBe(2);
+    expect(mapping.shortToUlid.get('a1b2')).toBe('01aaaaaaaaaaaaaaaaaaaaaaaa');
+  });
+
+  it('handles multiple duplicate keys', () => {
+    const entries = [
+      { shortId: 'a1b2', ulid: '01aaaaaaaaaaaaaaaaaaaaaaaa' },
+      { shortId: 'a1b2', ulid: '01bbbbbbbbbbbbbbbbbbbbbbbb' },
+      { shortId: 'c3d4', ulid: '01cccccccccccccccccccccccc' },
+      { shortId: 'c3d4', ulid: '01dddddddddddddddddddddddd' },
+    ];
+    const duplicateKeys = ['a1b2', 'c3d4'];
+
+    const mapping = resolveDuplicateShortIds(entries, duplicateKeys);
+
+    // All 4 ULIDs must be addressable
+    expect(mapping.ulidToShort.size).toBe(4);
+    expect(mapping.shortToUlid.size).toBe(4);
+
+    // Smallest ULIDs keep their original short IDs
+    expect(mapping.shortToUlid.get('a1b2')).toBe('01aaaaaaaaaaaaaaaaaaaaaaaa');
+    expect(mapping.shortToUlid.get('c3d4')).toBe('01cccccccccccccccccccccccc');
+
+    // Displaced ULIDs have replacement short IDs
+    expect(mapping.ulidToShort.has('01bbbbbbbbbbbbbbbbbbbbbbbb')).toBe(true);
+    expect(mapping.ulidToShort.has('01dddddddddddddddddddddddd')).toBe(true);
+  });
+
+  it('tiebreak: lexicographically smallest ULID keeps the short ID', () => {
+    // Deliberately put the larger ULID first in file order
+    const entries = [
+      { shortId: 'x9m3', ulid: '01zzzzzzzzzzzzzzzzzzzzzzzzz' },
+      { shortId: 'x9m3', ulid: '01aaaaaaaaaaaaaaaaaaaaaaaa' },
+    ];
+    const duplicateKeys = ['x9m3'];
+
+    const mapping = resolveDuplicateShortIds(entries, duplicateKeys);
+
+    // Smaller ULID wins regardless of file order
+    expect(mapping.shortToUlid.get('x9m3')).toBe('01aaaaaaaaaaaaaaaaaaaaaaaa');
+    expect(mapping.ulidToShort.get('01aaaaaaaaaaaaaaaaaaaaaaaa')).toBe('x9m3');
+  });
+});
+
+// =============================================================================
+// Convergence: two independent repairs produce identical output
+// =============================================================================
+
+describe('convergence', () => {
+  it('two independent repairs of the same input produce identical mappings', () => {
+    const content = `00wl: 01aaaaaaaaaaaaaaaaaaaaaaaa
+00wl: 01bbbbbbbbbbbbbbbbbbbbbbbb
+zzzz: 01cccccccccccccccccccccccc`;
+
+    // Simulate two clones independently repairing the same file
+    const entries1 = parseAllIdEntries(content);
+    const mapping1 = resolveDuplicateShortIds(entries1, ['00wl']);
+
+    const entries2 = parseAllIdEntries(content);
+    const mapping2 = resolveDuplicateShortIds(entries2, ['00wl']);
+
+    // Both must produce identical results
+    expect([...mapping1.shortToUlid.entries()].sort()).toEqual(
+      [...mapping2.shortToUlid.entries()].sort(),
+    );
+    expect([...mapping1.ulidToShort.entries()].sort()).toEqual(
+      [...mapping2.ulidToShort.entries()].sort(),
+    );
+  });
+
+  it('convergence holds with multiple duplicate keys', () => {
+    const content = `a1b2: 01aaaaaaaaaaaaaaaaaaaaaaaa
+a1b2: 01bbbbbbbbbbbbbbbbbbbbbbbb
+c3d4: 01cccccccccccccccccccccccc
+c3d4: 01dddddddddddddddddddddddd
+e5f6: 01eeeeeeeeeeeeeeeeeeeeeeee`;
+
+    const entries1 = parseAllIdEntries(content);
+    const mapping1 = resolveDuplicateShortIds(entries1, ['a1b2', 'c3d4']);
+
+    const entries2 = parseAllIdEntries(content);
+    const mapping2 = resolveDuplicateShortIds(entries2, ['a1b2', 'c3d4']);
+
+    expect([...mapping1.shortToUlid.entries()].sort()).toEqual(
+      [...mapping2.shortToUlid.entries()].sort(),
+    );
+    expect([...mapping1.ulidToShort.entries()].sort()).toEqual(
+      [...mapping2.ulidToShort.entries()].sort(),
+    );
+  });
+
+  it('convergence holds when entries are in different file order', () => {
+    // Clone 1 sees entries in one order
+    const content1 = `00wl: 01bbbbbbbbbbbbbbbbbbbbbbbb
+00wl: 01aaaaaaaaaaaaaaaaaaaaaaaa
+zzzz: 01cccccccccccccccccccccccc`;
+
+    // Clone 2 sees entries in reverse order
+    const content2 = `00wl: 01aaaaaaaaaaaaaaaaaaaaaaaa
+00wl: 01bbbbbbbbbbbbbbbbbbbbbbbb
+zzzz: 01cccccccccccccccccccccccc`;
+
+    const mapping1 = resolveDuplicateShortIds(parseAllIdEntries(content1), ['00wl']);
+    const mapping2 = resolveDuplicateShortIds(parseAllIdEntries(content2), ['00wl']);
+
+    // Same result regardless of file order
+    expect([...mapping1.shortToUlid.entries()].sort()).toEqual(
+      [...mapping2.shortToUlid.entries()].sort(),
+    );
+  });
+});
+
+// =============================================================================
+// loadIdMapping integration: the full scenario from the bug report
+// =============================================================================
+
+describe('loadIdMapping with duplicate short IDs', () => {
+  async function createTempDir(): Promise<string> {
+    const baseDir = join(
+      tmpdir(),
+      `tbd-test-dup-ids-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(join(baseDir, 'mappings'), { recursive: true });
+    return baseDir;
+  }
+
+  it('exact bug report scenario: both ULIDs stay addressable, neither formatDisplayId throws', async () => {
+    const baseDir = await createTempDir();
+    const idsYml = `00wl: 01aaaaaaaaaaaaaaaaaaaaaaaa
+00wl: 01bbbbbbbbbbbbbbbbbbbbbbbb
+zzzz: 01cccccccccccccccccccccccc
+`;
+    await writeFile(join(baseDir, 'mappings', 'ids.yml'), idsYml);
+
+    const mapping = await loadIdMapping(baseDir);
+
+    // Both ULIDs must be in the mapping
+    expect(mapping.ulidToShort.has('01aaaaaaaaaaaaaaaaaaaaaaaa')).toBe(true);
+    expect(mapping.ulidToShort.has('01bbbbbbbbbbbbbbbbbbbbbbbb')).toBe(true);
+    expect(mapping.ulidToShort.has('01cccccccccccccccccccccccc')).toBe(true);
+
+    // Neither formatDisplayId call should throw
+    expect(() => formatDisplayId('is-01aaaaaaaaaaaaaaaaaaaaaaaa', mapping)).not.toThrow();
+    expect(() => formatDisplayId('is-01bbbbbbbbbbbbbbbbbbbbbbbb', mapping)).not.toThrow();
+    expect(() => formatDisplayId('is-01cccccccccccccccccccccccc', mapping)).not.toThrow();
+
+    // shortToUlid has 3 entries (two for the formerly-duplicate short ID + zzzz)
+    expect(mapping.shortToUlid.size).toBe(3);
+  });
+
+  it('smallest ULID keeps the contested short ID', async () => {
+    const baseDir = await createTempDir();
+    const idsYml = `00wl: 01aaaaaaaaaaaaaaaaaaaaaaaa
+00wl: 01bbbbbbbbbbbbbbbbbbbbbbbb
+`;
+    await writeFile(join(baseDir, 'mappings', 'ids.yml'), idsYml);
+
+    const mapping = await loadIdMapping(baseDir);
+
+    // ULID A (smaller) keeps "00wl"
+    expect(mapping.ulidToShort.get('01aaaaaaaaaaaaaaaaaaaaaaaa')).toBe('00wl');
+    expect(mapping.shortToUlid.get('00wl')).toBe('01aaaaaaaaaaaaaaaaaaaaaaaa');
+  });
+
+  it('displaced ULID gets a deterministic replacement derived from its value', async () => {
+    const baseDir = await createTempDir();
+    const idsYml = `00wl: 01aaaaaaaaaaaaaaaaaaaaaaaa
+00wl: 01bbbbbbbbbbbbbbbbbbbbbbbb
+`;
+    await writeFile(join(baseDir, 'mappings', 'ids.yml'), idsYml);
+
+    const mapping = await loadIdMapping(baseDir);
+
+    const replacementShortId = mapping.ulidToShort.get('01bbbbbbbbbbbbbbbbbbbbbbbb')!;
+    expect(replacementShortId).not.toBe('00wl');
+    // Derived from the ULID's last 4 chars
+    expect(replacementShortId).toBe('bbbb');
+  });
+
+  it('emits a warning about duplicate keys', async () => {
+    const baseDir = await createTempDir();
+    const idsYml = `00wl: 01aaaaaaaaaaaaaaaaaaaaaaaa
+00wl: 01bbbbbbbbbbbbbbbbbbbbbbbb
+`;
+    await writeFile(join(baseDir, 'mappings', 'ids.yml'), idsYml);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      await loadIdMapping(baseDir);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('duplicate key(s): 00wl'));
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('deterministic replacement short IDs'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
+// =============================================================================
+// Simulated two-clone union-merge end-to-end scenario
+// =============================================================================
+
+describe('two-clone union merge end-to-end', () => {
+  async function createTempDir(): Promise<string> {
+    const baseDir = join(
+      tmpdir(),
+      `tbd-test-merge-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(join(baseDir, 'mappings'), { recursive: true });
+    return baseDir;
+  }
+
+  it('simulates union merge, loads, repairs, saves, and verifies', async () => {
+    // Scenario: Two clones both allocate short ID "x5k9" for different beads.
+    // After union merge, ids.yml has both lines.
+
+    // Clone A's ids.yml (before merge):
+    //   x5k9: 01hx5zzkbkactav9wevgemmvrz
+    //   a1b2: 01hx5zzkbkbctav9wevgemmvrw
+
+    // Clone B's ids.yml (before merge):
+    //   x5k9: 01hx5zzkbkcctav9wevgemmvrx
+    //   c3d4: 01hx5zzkbkdctav9wevgemmvry
+
+    // After union merge, the file contains:
+    const mergedContent = `a1b2: 01hx5zzkbkbctav9wevgemmvrw
+c3d4: 01hx5zzkbkdctav9wevgemmvry
+x5k9: 01hx5zzkbkactav9wevgemmvrz
+x5k9: 01hx5zzkbkcctav9wevgemmvrx
+`;
+
+    const baseDir = await createTempDir();
+    await writeFile(join(baseDir, 'mappings', 'ids.yml'), mergedContent);
+
+    // Load the mapping (repair happens here)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const mapping = await loadIdMapping(baseDir);
+    warnSpy.mockRestore();
+
+    // All 4 ULIDs must be addressable
+    expect(mapping.ulidToShort.size).toBe(4);
+    expect(mapping.shortToUlid.size).toBe(4);
+
+    // The smallest ULID keeps "x5k9"
+    expect(mapping.shortToUlid.get('x5k9')).toBe('01hx5zzkbkactav9wevgemmvrz');
+
+    // The displaced ULID has a different short ID
+    const displacedShortId = mapping.ulidToShort.get('01hx5zzkbkcctav9wevgemmvrx');
+    expect(displacedShortId).toBeDefined();
+    expect(displacedShortId).not.toBe('x5k9');
+
+    // All formatDisplayId calls succeed
+    for (const ulid of mapping.ulidToShort.keys()) {
+      expect(() => formatDisplayId(`is-${ulid}`, mapping)).not.toThrow();
+    }
+
+    // Save the repaired mapping
+    await saveIdMapping(baseDir, mapping);
+
+    // Reload and verify the file is now clean
+    const warnSpy2 = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const reloaded = await loadIdMapping(baseDir);
+    // No warning should be emitted on reload (duplicates are gone)
+    expect(warnSpy2).not.toHaveBeenCalled();
+    warnSpy2.mockRestore();
+
+    // Same content after save-and-reload
+    expect(reloaded.shortToUlid.size).toBe(mapping.shortToUlid.size);
+    for (const [shortId, ulid] of mapping.shortToUlid) {
+      expect(reloaded.shortToUlid.get(shortId)).toBe(ulid);
+    }
+  });
+
+  it('two clones repairing the same merged file produce identical results', async () => {
+    const mergedContent = `a1b2: 01hx5zzkbkbctav9wevgemmvrw
+c3d4: 01hx5zzkbkdctav9wevgemmvry
+x5k9: 01hx5zzkbkactav9wevgemmvrz
+x5k9: 01hx5zzkbkcctav9wevgemmvrx
+`;
+
+    // Clone 1 repairs
+    const baseDir1 = await createTempDir();
+    await writeFile(join(baseDir1, 'mappings', 'ids.yml'), mergedContent);
+    const warnSpy1 = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const mapping1 = await loadIdMapping(baseDir1);
+    warnSpy1.mockRestore();
+
+    // Clone 2 repairs (same file)
+    const baseDir2 = await createTempDir();
+    await writeFile(join(baseDir2, 'mappings', 'ids.yml'), mergedContent);
+    const warnSpy2 = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const mapping2 = await loadIdMapping(baseDir2);
+    warnSpy2.mockRestore();
+
+    // Both must produce identical results
+    expect([...mapping1.shortToUlid.entries()].sort()).toEqual(
+      [...mapping2.shortToUlid.entries()].sort(),
+    );
+    expect([...mapping1.ulidToShort.entries()].sort()).toEqual(
+      [...mapping2.ulidToShort.entries()].sort(),
+    );
+  });
+});
+
+// =============================================================================
+// parseIdMappingFromYaml with duplicate keys (same fix path)
+// =============================================================================
+
+describe('parseIdMappingFromYaml with conflicting duplicate keys', () => {
+  it('resolves duplicate keys mapping to different ULIDs', () => {
+    const yaml = `a1b2: 01hx5zzkbkactav9wevgemmvrz
+c3d4: 01hx5zzkbkbctav9wevgemmvrw
+a1b2: 01hx5zzkbkxctav9wevgemmabc`;
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const mapping = parseIdMappingFromYaml(yaml);
+    warnSpy.mockRestore();
+
+    // All 3 ULIDs must be addressable
+    expect(mapping.ulidToShort.size).toBe(3);
+    expect(mapping.shortToUlid.size).toBe(3);
+
+    // Smallest ULID keeps "a1b2"
+    expect(mapping.shortToUlid.get('a1b2')).toBe('01hx5zzkbkactav9wevgemmvrz');
+
+    // Displaced ULID has a replacement
+    expect(mapping.ulidToShort.has('01hx5zzkbkxctav9wevgemmabc')).toBe(true);
+    expect(mapping.ulidToShort.get('01hx5zzkbkxctav9wevgemmabc')).not.toBe('a1b2');
+  });
+});

--- a/packages/tbd/tests/id-mapping-duplicate-short-ids.test.ts
+++ b/packages/tbd/tests/id-mapping-duplicate-short-ids.test.ts
@@ -113,6 +113,132 @@ describe('deriveShortIdFromUlid', () => {
 });
 
 // =============================================================================
+// deriveShortIdFromUlid — escalation tiers under collision pressure
+// =============================================================================
+
+describe('deriveShortIdFromUlid escalation tiers', () => {
+  // This ULID has all-distinct characters so every 4-char and 5-char window is unique,
+  // making it possible to saturate each tier precisely without accidental collisions.
+  // Characters are valid Crockford base32 (a strict subset of the base36 ShortId allows).
+  const ulid = '0123456789abcdefghjkmnpqrs';
+
+  // Tier 1: non-overlapping windows (offsets 22, 18, 14, 10, 6, 2)
+  const tier1Windows = ['pqrs', 'jkmn', 'efgh', 'abcd', '6789', '2345'];
+
+  // Tier 2: all 23 single-offset 4-char windows (offsets 22 down to 0)
+  const allFourCharWindows = [
+    'pqrs',
+    'npqr',
+    'mnpq',
+    'kmnp',
+    'jkmn',
+    'hjkm',
+    'ghjk',
+    'fghj',
+    'efgh',
+    'defg',
+    'cdef',
+    'bcde',
+    'abcd',
+    '9abc',
+    '89ab',
+    '789a',
+    '6789',
+    '5678',
+    '4567',
+    '3456',
+    '2345',
+    '1234',
+    '0123',
+  ];
+
+  // Tier 3: all 22 five-char windows (offsets 21 down to 0)
+  const allFiveCharWindows = [
+    'npqrs',
+    'mnpqr',
+    'kmnpq',
+    'jkmnp',
+    'hjkmn',
+    'ghjkm',
+    'fghjk',
+    'efghj',
+    'defgh',
+    'cdefg',
+    'bcdef',
+    'abcde',
+    '9abcd',
+    '89abc',
+    '789ab',
+    '6789a',
+    '56789',
+    '45678',
+    '34567',
+    '23456',
+    '12345',
+    '01234',
+  ];
+
+  it('tier 2: falls through to single-offset window when all non-overlapping windows are taken', () => {
+    const used = new Set<string>(tier1Windows);
+    const result = deriveShortIdFromUlid(ulid, used);
+
+    // The single-offset loop starts at offset 22 and works down.
+    // Offsets 22, 18, 14, 10, 6, 2 are blocked (same as tier 1).
+    // First new offset tried is 21 → 'npqr'.
+    expect(result).toBe('npqr');
+    expect(result.length).toBe(4);
+    expect(result).toMatch(/^[0-9a-z._-]+$/);
+  });
+
+  it('tier 3: falls through to 5-char window when all 23 four-char windows are taken', () => {
+    const used = new Set<string>(allFourCharWindows);
+    const result = deriveShortIdFromUlid(ulid, used);
+
+    // All 4-char windows exhausted, so the function tries 5-char windows
+    // starting at offset 21 → 'npqrs'.
+    expect(result).toBe('npqrs');
+    expect(result.length).toBe(5);
+    expect(result).toMatch(/^[0-9a-z._-]+$/);
+  });
+
+  it('throws when every 4-char and 5-char window is taken', () => {
+    const used = new Set<string>([...allFourCharWindows, ...allFiveCharWindows]);
+
+    expect(() => deriveShortIdFromUlid(ulid, used)).toThrow(
+      `Cannot derive a unique short ID from ULID ${ulid}. ` +
+        `This should be extremely rare — please report this error.`,
+    );
+  });
+
+  it('determinism: identical inputs produce identical output at every tier', () => {
+    // Tier 1 (happy path — covered elsewhere but included for completeness)
+    const usedTier1 = new Set<string>();
+    expect(deriveShortIdFromUlid(ulid, usedTier1)).toBe(deriveShortIdFromUlid(ulid, usedTier1));
+
+    // Tier 2
+    const usedTier2 = new Set<string>(tier1Windows);
+    expect(deriveShortIdFromUlid(ulid, usedTier2)).toBe(deriveShortIdFromUlid(ulid, usedTier2));
+
+    // Tier 3
+    const usedTier3 = new Set<string>(allFourCharWindows);
+    expect(deriveShortIdFromUlid(ulid, usedTier3)).toBe(deriveShortIdFromUlid(ulid, usedTier3));
+  });
+
+  it('every tier returns a value matching the ShortId pattern', () => {
+    const shortIdPattern = /^[0-9a-z._-]+$/;
+
+    // Tier 1
+    expect(deriveShortIdFromUlid(ulid, new Set())).toMatch(shortIdPattern);
+
+    // Tier 2
+    expect(deriveShortIdFromUlid(ulid, new Set(tier1Windows))).toMatch(shortIdPattern);
+
+    // Tier 3
+    expect(deriveShortIdFromUlid(ulid, new Set(allFourCharWindows))).toMatch(shortIdPattern);
+  });
+});
+
+// =============================================================================
 // resolveDuplicateShortIds
 // =============================================================================
 

--- a/packages/tbd/tests/id-mapping-duplicate-short-ids.test.ts
+++ b/packages/tbd/tests/id-mapping-duplicate-short-ids.test.ts
@@ -23,6 +23,7 @@ import {
   parseIdMappingFromYaml,
 } from '../src/file/id-mapping.js';
 import { formatDisplayId } from '../src/lib/ids.js';
+import { MergeConflictError } from '../src/utils/yaml-utils.js';
 
 // =============================================================================
 // parseAllIdEntries
@@ -485,5 +486,70 @@ a1b2: 01hx5zzkbkxctav9wevgemmabc`;
     // Displaced ULID has a replacement
     expect(mapping.ulidToShort.has('01hx5zzkbkxctav9wevgemmabc')).toBe(true);
     expect(mapping.ulidToShort.get('01hx5zzkbkxctav9wevgemmabc')).not.toBe('a1b2');
+  });
+});
+
+// =============================================================================
+// Merge conflict markers must throw even when duplicates are present
+// =============================================================================
+
+describe('conflict markers take priority over duplicate-key resolution', () => {
+  async function createTempDir(): Promise<string> {
+    const baseDir = join(
+      tmpdir(),
+      `tbd-test-conflict-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(join(baseDir, 'mappings'), { recursive: true });
+    return baseDir;
+  }
+
+  it('parseIdMappingFromYaml throws MergeConflictError when content has both conflict markers and duplicate keys', () => {
+    // Conflicted content that also has duplicate keys — the conflict marker
+    // check must run first, not be bypassed by the duplicate-key branch.
+    const conflictedWithDuplicates = `00wl: 01aaaaaaaaaaaaaaaaaaaaaaaa
+<<<<<<< HEAD
+00wl: 01bbbbbbbbbbbbbbbbbbbbbbbb
+=======
+c3d4: 01cccccccccccccccccccccccc
+>>>>>>> origin/tbd-sync`;
+
+    expect(() => parseIdMappingFromYaml(conflictedWithDuplicates)).toThrow(MergeConflictError);
+  });
+
+  it('parseIdMappingFromYaml still throws on conflict markers without duplicate keys', () => {
+    const conflictedNoDuplicates = `<<<<<<< HEAD
+a1b2: 01aaaaaaaaaaaaaaaaaaaaaaaa
+=======
+c3d4: 01bbbbbbbbbbbbbbbbbbbbbbbb
+>>>>>>> origin/tbd-sync`;
+
+    expect(() => parseIdMappingFromYaml(conflictedNoDuplicates)).toThrow(MergeConflictError);
+  });
+
+  it('loadIdMapping throws MergeConflictError when file has both conflict markers and duplicate keys', async () => {
+    const baseDir = await createTempDir();
+    const conflictedWithDuplicates = `00wl: 01aaaaaaaaaaaaaaaaaaaaaaaa
+<<<<<<< HEAD
+00wl: 01bbbbbbbbbbbbbbbbbbbbbbbb
+=======
+c3d4: 01cccccccccccccccccccccccc
+>>>>>>> origin/tbd-sync
+`;
+    await writeFile(join(baseDir, 'mappings', 'ids.yml'), conflictedWithDuplicates);
+
+    await expect(loadIdMapping(baseDir)).rejects.toThrow(MergeConflictError);
+  });
+
+  it('loadIdMapping still throws on conflict markers without duplicate keys', async () => {
+    const baseDir = await createTempDir();
+    const conflictedNoDuplicates = `<<<<<<< HEAD
+a1b2: 01aaaaaaaaaaaaaaaaaaaaaaaa
+=======
+c3d4: 01bbbbbbbbbbbbbbbbbbbbbbbb
+>>>>>>> origin/tbd-sync
+`;
+    await writeFile(join(baseDir, 'mappings', 'ids.yml'), conflictedNoDuplicates);
+
+    await expect(loadIdMapping(baseDir)).rejects.toThrow(MergeConflictError);
   });
 });

--- a/packages/tbd/tests/id-mapping-duplicate-short-ids.test.ts
+++ b/packages/tbd/tests/id-mapping-duplicate-short-ids.test.ts
@@ -17,53 +17,116 @@ import { tmpdir } from 'node:os';
 import {
   loadIdMapping,
   saveIdMapping,
-  parseAllIdEntries,
   deriveShortIdFromUlid,
   resolveDuplicateShortIds,
   parseIdMappingFromYaml,
 } from '../src/file/id-mapping.js';
 import { formatDisplayId } from '../src/lib/ids.js';
-import { MergeConflictError } from '../src/utils/yaml-utils.js';
+import {
+  MergeConflictError,
+  parseYamlDocumentEntries,
+  stringifyYaml,
+} from '../src/utils/yaml-utils.js';
 
 // =============================================================================
-// parseAllIdEntries
+// parseYamlDocumentEntries — the AST-based primitive
 // =============================================================================
 
-describe('parseAllIdEntries', () => {
-  it('parses all entries including duplicates', () => {
+describe('parseYamlDocumentEntries', () => {
+  it('extracts all entries including duplicates', () => {
     const content = `00wl: 01aaaaaaaaaaaaaaaaaaaaaaaa
 00wl: 01bbbbbbbbbbbbbbbbbbbbbbbb
 zzzz: 01cccccccccccccccccccccccc`;
 
-    const entries = parseAllIdEntries(content);
+    const { entries, duplicateKeys } = parseYamlDocumentEntries(content);
     expect(entries).toHaveLength(3);
-    expect(entries[0]).toEqual({ shortId: '00wl', ulid: '01aaaaaaaaaaaaaaaaaaaaaaaa' });
-    expect(entries[1]).toEqual({ shortId: '00wl', ulid: '01bbbbbbbbbbbbbbbbbbbbbbbb' });
-    expect(entries[2]).toEqual({ shortId: 'zzzz', ulid: '01cccccccccccccccccccccccc' });
+    expect(entries[0]).toEqual({ key: '00wl', value: '01aaaaaaaaaaaaaaaaaaaaaaaa' });
+    expect(entries[1]).toEqual({ key: '00wl', value: '01bbbbbbbbbbbbbbbbbbbbbbbb' });
+    expect(entries[2]).toEqual({ key: 'zzzz', value: '01cccccccccccccccccccccccc' });
+    expect(duplicateKeys).toEqual(['00wl']);
   });
 
-  it('skips comments and blank lines', () => {
-    const content = `# comment
-a1b2: 01aaaaaaaaaaaaaaaaaaaaaaaa
+  it('handles quoted keys (all-digit short IDs)', () => {
+    // stringifyYaml quotes all-digit keys since they look like YAML numbers.
+    // This is the shape produced by tbd's own serializer for numeric short IDs.
+    const content = `"1234": 01aaaaaaaaaaaaaaaaaaaaaaaa
+a1b2: 01bbbbbbbbbbbbbbbbbbbbbbbb
+"0000": 01cccccccccccccccccccccccc`;
 
+    const { entries, duplicateKeys } = parseYamlDocumentEntries(content);
+    expect(entries).toHaveLength(3);
+    expect(entries[0]).toEqual({ key: '1234', value: '01aaaaaaaaaaaaaaaaaaaaaaaa' });
+    expect(entries[1]).toEqual({ key: 'a1b2', value: '01bbbbbbbbbbbbbbbbbbbbbbbb' });
+    expect(entries[2]).toEqual({ key: '0000', value: '01cccccccccccccccccccccccc' });
+    expect(duplicateKeys).toEqual([]);
+  });
+
+  it('handles quoted special YAML scalars', () => {
+    const content = `"true": 01aaaaaaaaaaaaaaaaaaaaaaaa
+"null": 01bbbbbbbbbbbbbbbbbbbbbbbb
+"9999": 01cccccccccccccccccccccccc`;
+
+    const { entries } = parseYamlDocumentEntries(content);
+    expect(entries).toHaveLength(3);
+    expect(entries[0]!.key).toBe('true');
+    expect(entries[1]!.key).toBe('null');
+    expect(entries[2]!.key).toBe('9999');
+  });
+
+  it('handles trailing comments on lines', () => {
+    const content = `a1b2: 01aaaaaaaaaaaaaaaaaaaaaaaa # from clone A
 c3d4: 01bbbbbbbbbbbbbbbbbbbbbbbb`;
 
-    const entries = parseAllIdEntries(content);
+    const { entries } = parseYamlDocumentEntries(content);
     expect(entries).toHaveLength(2);
+    // Trailing comment is stripped by the YAML parser
+    expect(entries[0]).toEqual({ key: 'a1b2', value: '01aaaaaaaaaaaaaaaaaaaaaaaa' });
+    expect(entries[1]).toEqual({ key: 'c3d4', value: '01bbbbbbbbbbbbbbbbbbbbbbbb' });
   });
 
   it('handles empty content', () => {
-    expect(parseAllIdEntries('')).toEqual([]);
+    const { entries, duplicateKeys } = parseYamlDocumentEntries('');
+    expect(entries).toEqual([]);
+    expect(duplicateKeys).toEqual([]);
   });
 
-  it('handles short IDs with dots, dashes, and underscores', () => {
+  it('handles comments-only content', () => {
+    const { entries, duplicateKeys } = parseYamlDocumentEntries('# just a comment\n# another\n');
+    expect(entries).toEqual([]);
+    expect(duplicateKeys).toEqual([]);
+  });
+
+  it('handles duplicates with quoted keys', () => {
+    const content = `"1234": 01aaaaaaaaaaaaaaaaaaaaaaaa
+"1234": 01bbbbbbbbbbbbbbbbbbbbbbbb`;
+
+    const { entries, duplicateKeys } = parseYamlDocumentEntries(content);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]!.key).toBe('1234');
+    expect(entries[1]!.key).toBe('1234');
+    expect(duplicateKeys).toEqual(['1234']);
+  });
+
+  it('detects duplicates with trailing comments on duplicated lines', () => {
+    const content = `a1b2: 01aaaaaaaaaaaaaaaaaaaaaaaa # from clone A
+a1b2: 01bbbbbbbbbbbbbbbbbbbbbbbb # from clone B
+c3d4: 01cccccccccccccccccccccccc`;
+
+    const { entries, duplicateKeys } = parseYamlDocumentEntries(content);
+    expect(entries).toHaveLength(3);
+    expect(entries[0]!.value).toBe('01aaaaaaaaaaaaaaaaaaaaaaaa');
+    expect(entries[1]!.value).toBe('01bbbbbbbbbbbbbbbbbbbbbbbb');
+    expect(duplicateKeys).toEqual(['a1b2']);
+  });
+
+  it('handles keys with dots, dashes, and underscores', () => {
     const content = `stat-in_progress: 01aaaaaaaaaaaaaaaaaaaaaaaa
 v2.0: 01bbbbbbbbbbbbbbbbbbbbbbbb`;
 
-    const entries = parseAllIdEntries(content);
+    const { entries } = parseYamlDocumentEntries(content);
     expect(entries).toHaveLength(2);
-    expect(entries[0]!.shortId).toBe('stat-in_progress');
-    expect(entries[1]!.shortId).toBe('v2.0');
+    expect(entries[0]!.key).toBe('stat-in_progress');
+    expect(entries[1]!.key).toBe('v2.0');
   });
 });
 
@@ -97,8 +160,8 @@ describe('deriveShortIdFromUlid', () => {
 
   it('falls back to overlapping windows', () => {
     const ulid = '01aabbccddeeffffgghhjjkkll';
-    // Block all non-overlapping 4-char windows
-    const used = new Set<string>(['kkll', 'gghh', 'ccdd', 'ffff', 'aabb', 'jjkk', '01aa']);
+    // Block all non-overlapping 4-char windows: offsets 22, 18, 14, 10, 6, 2
+    const used = new Set<string>(['kkll', 'hhjj', 'ffgg', 'eeff', 'ccdd', 'aabb']);
     const result = deriveShortIdFromUlid(ulid, used);
     expect(result.length).toBe(4);
     expect(used.has(result)).toBe(false);
@@ -184,7 +247,7 @@ describe('deriveShortIdFromUlid escalation tiers', () => {
 
     // The single-offset loop starts at offset 22 and works down.
     // Offsets 22, 18, 14, 10, 6, 2 are blocked (same as tier 1).
-    // First new offset tried is 21 → 'npqr'.
+    // First new offset tried is 21 -> 'npqr'.
     expect(result).toBe('npqr');
     expect(result.length).toBe(4);
     expect(result).toMatch(/^[0-9a-z._-]+$/);
@@ -195,7 +258,7 @@ describe('deriveShortIdFromUlid escalation tiers', () => {
     const result = deriveShortIdFromUlid(ulid, used);
 
     // All 4-char windows exhausted, so the function tries 5-char windows
-    // starting at offset 21 → 'npqrs'.
+    // starting at offset 21 -> 'npqrs'.
     expect(result).toBe('npqrs');
     expect(result.length).toBe(5);
     expect(result).toMatch(/^[0-9a-z._-]+$/);
@@ -314,7 +377,7 @@ describe('resolveDuplicateShortIds', () => {
   it('tiebreak: lexicographically smallest ULID keeps the short ID', () => {
     // Deliberately put the larger ULID first in file order
     const entries = [
-      { shortId: 'x9m3', ulid: '01zzzzzzzzzzzzzzzzzzzzzzzzz' },
+      { shortId: 'x9m3', ulid: '01zzzzzzzzzzzzzzzzzzzzzzzz' },
       { shortId: 'x9m3', ulid: '01aaaaaaaaaaaaaaaaaaaaaaaa' },
     ];
     const duplicateKeys = ['x9m3'];
@@ -338,11 +401,10 @@ describe('convergence', () => {
 zzzz: 01cccccccccccccccccccccccc`;
 
     // Simulate two clones independently repairing the same file
-    const entries1 = parseAllIdEntries(content);
-    const mapping1 = resolveDuplicateShortIds(entries1, ['00wl']);
-
-    const entries2 = parseAllIdEntries(content);
-    const mapping2 = resolveDuplicateShortIds(entries2, ['00wl']);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const mapping1 = parseIdMappingFromYaml(content);
+    const mapping2 = parseIdMappingFromYaml(content);
+    warnSpy.mockRestore();
 
     // Both must produce identical results
     expect([...mapping1.shortToUlid.entries()].sort()).toEqual(
@@ -360,11 +422,10 @@ c3d4: 01cccccccccccccccccccccccc
 c3d4: 01dddddddddddddddddddddddd
 e5f6: 01eeeeeeeeeeeeeeeeeeeeeeee`;
 
-    const entries1 = parseAllIdEntries(content);
-    const mapping1 = resolveDuplicateShortIds(entries1, ['a1b2', 'c3d4']);
-
-    const entries2 = parseAllIdEntries(content);
-    const mapping2 = resolveDuplicateShortIds(entries2, ['a1b2', 'c3d4']);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const mapping1 = parseIdMappingFromYaml(content);
+    const mapping2 = parseIdMappingFromYaml(content);
+    warnSpy.mockRestore();
 
     expect([...mapping1.shortToUlid.entries()].sort()).toEqual(
       [...mapping2.shortToUlid.entries()].sort(),
@@ -385,8 +446,10 @@ zzzz: 01cccccccccccccccccccccccc`;
 00wl: 01bbbbbbbbbbbbbbbbbbbbbbbb
 zzzz: 01cccccccccccccccccccccccc`;
 
-    const mapping1 = resolveDuplicateShortIds(parseAllIdEntries(content1), ['00wl']);
-    const mapping2 = resolveDuplicateShortIds(parseAllIdEntries(content2), ['00wl']);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const mapping1 = parseIdMappingFromYaml(content1);
+    const mapping2 = parseIdMappingFromYaml(content2);
+    warnSpy.mockRestore();
 
     // Same result regardless of file order
     expect([...mapping1.shortToUlid.entries()].sort()).toEqual(
@@ -479,6 +542,126 @@ zzzz: 01cccccccccccccccccccccccc
     } finally {
       warnSpy.mockRestore();
     }
+  });
+});
+
+// =============================================================================
+// Quoted-key bystander test — the test that would have caught R1
+// =============================================================================
+
+describe('quoted keys (numeric short IDs) survive duplicate resolution', () => {
+  async function createTempDir(): Promise<string> {
+    const baseDir = join(
+      tmpdir(),
+      `tbd-test-quoted-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(join(baseDir, 'mappings'), { recursive: true });
+    return baseDir;
+  }
+
+  it('bystander with a quoted numeric short ID stays addressable after duplicate repair', async () => {
+    // This is the killer scenario: a file written by tbd's own stringifyYaml
+    // containing an at-risk short ID ("100", mirroring the real ids.yml which
+    // has 274 quoted entries) alongside a duplicate. The bystander must survive.
+    const bystander = { shortId: '100', ulid: '01cccccccccccccccccccccccc' };
+
+    // Build the file the way tbd's serializer would write it, then append a
+    // duplicate to simulate a union merge.
+    const data: Record<string, string> = {
+      '100': bystander.ulid,
+      a1b2: '01aaaaaaaaaaaaaaaaaaaaaaaa',
+    };
+    const base = stringifyYaml(data);
+    // Append a duplicate of a1b2 (simulating the other clone's allocation)
+    const merged = base + 'a1b2: 01bbbbbbbbbbbbbbbbbbbbbbbb\n';
+
+    const baseDir = await createTempDir();
+    await writeFile(join(baseDir, 'mappings', 'ids.yml'), merged);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const mapping = await loadIdMapping(baseDir);
+    warnSpy.mockRestore();
+
+    // The bystander must still be addressable
+    expect(mapping.ulidToShort.has(bystander.ulid)).toBe(true);
+    expect(mapping.ulidToShort.get(bystander.ulid)).toBe(bystander.shortId);
+    expect(() => formatDisplayId(`is-${bystander.ulid}`, mapping)).not.toThrow();
+
+    // Both duplicate ULIDs must also be addressable
+    expect(mapping.ulidToShort.has('01aaaaaaaaaaaaaaaaaaaaaaaa')).toBe(true);
+    expect(mapping.ulidToShort.has('01bbbbbbbbbbbbbbbbbbbbbbbb')).toBe(true);
+
+    // All 3 ULIDs present
+    expect(mapping.shortToUlid.size).toBe(3);
+  });
+
+  it('parseIdMappingFromYaml handles quoted keys with duplicates', () => {
+    // File with a quoted key and a duplicate — the shape that broke with regex parsing
+    const content = `"0622": 01cccccccccccccccccccccccc
+a1b2: 01aaaaaaaaaaaaaaaaaaaaaaaa
+a1b2: 01bbbbbbbbbbbbbbbbbbbbbbbb`;
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const mapping = parseIdMappingFromYaml(content);
+    warnSpy.mockRestore();
+
+    expect(mapping.ulidToShort.size).toBe(3);
+    expect(mapping.shortToUlid.size).toBe(3);
+    expect(mapping.ulidToShort.get('01cccccccccccccccccccccccc')).toBe('0622');
+    expect(() => formatDisplayId('is-01cccccccccccccccccccccccc', mapping)).not.toThrow();
+  });
+
+  it('loadIdMapping handles a file produced by stringifyYaml with no duplicates', async () => {
+    // Verify that the normal (non-duplicate) path also handles quoted keys
+    const data: Record<string, string> = {
+      '1234': '01aaaaaaaaaaaaaaaaaaaaaaaa',
+      '0000': '01bbbbbbbbbbbbbbbbbbbbbbbb',
+      wxyz: '01cccccccccccccccccccccccc',
+    };
+    const content = stringifyYaml(data);
+
+    const baseDir = join(
+      tmpdir(),
+      `tbd-test-normal-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(join(baseDir, 'mappings'), { recursive: true });
+    await writeFile(join(baseDir, 'mappings', 'ids.yml'), content);
+
+    const mapping = await loadIdMapping(baseDir);
+    expect(mapping.shortToUlid.size).toBe(3);
+    expect(mapping.shortToUlid.get('1234')).toBe('01aaaaaaaaaaaaaaaaaaaaaaaa');
+    expect(mapping.shortToUlid.get('0000')).toBe('01bbbbbbbbbbbbbbbbbbbbbbbb');
+    expect(mapping.shortToUlid.get('wxyz')).toBe('01cccccccccccccccccccccccc');
+  });
+});
+
+// =============================================================================
+// Trailing comments on duplicated lines (R3 regression test)
+// =============================================================================
+
+describe('trailing comments on duplicated lines', () => {
+  it('trailing comments do not prevent duplicate detection or value extraction', () => {
+    // The old regex parser could not match lines with trailing comments,
+    // causing entries to be silently dropped. The AST parser handles them.
+    const content = `a1b2: 01aaaaaaaaaaaaaaaaaaaaaaaa # from clone A
+a1b2: 01bbbbbbbbbbbbbbbbbbbbbbbb # from clone B
+c3d4: 01cccccccccccccccccccccccc`;
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const mapping = parseIdMappingFromYaml(content);
+    warnSpy.mockRestore();
+
+    // All 3 ULIDs must be addressable
+    expect(mapping.ulidToShort.size).toBe(3);
+    expect(mapping.shortToUlid.size).toBe(3);
+
+    // Smallest ULID keeps a1b2
+    expect(mapping.shortToUlid.get('a1b2')).toBe('01aaaaaaaaaaaaaaaaaaaaaaaa');
+    // Displaced ULID has a replacement
+    expect(mapping.ulidToShort.has('01bbbbbbbbbbbbbbbbbbbbbbbb')).toBe(true);
+    expect(mapping.ulidToShort.get('01bbbbbbbbbbbbbbbbbbbbbbbb')).not.toBe('a1b2');
+    // Bystander unchanged
+    expect(mapping.shortToUlid.get('c3d4')).toBe('01cccccccccccccccccccccccc');
   });
 });
 
@@ -612,6 +795,31 @@ a1b2: 01hx5zzkbkxctav9wevgemmabc`;
     // Displaced ULID has a replacement
     expect(mapping.ulidToShort.has('01hx5zzkbkxctav9wevgemmabc')).toBe(true);
     expect(mapping.ulidToShort.get('01hx5zzkbkxctav9wevgemmabc')).not.toBe('a1b2');
+  });
+});
+
+// =============================================================================
+// Validation on the repair path (R5)
+// =============================================================================
+
+describe('repair path validates entries loudly', () => {
+  it('throws on invalid short ID in file with duplicates', async () => {
+    // A file with a duplicate AND an entry whose key is not a valid ShortId.
+    // The repair path must fail loudly, not silently skip.
+    const baseDir = join(
+      tmpdir(),
+      `tbd-test-validation-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await mkdir(join(baseDir, 'mappings'), { recursive: true });
+
+    // "UPPER" contains uppercase which ShortId rejects
+    const content = `a1b2: 01aaaaaaaaaaaaaaaaaaaaaaaa
+a1b2: 01bbbbbbbbbbbbbbbbbbbbbbbb
+UPPER: 01cccccccccccccccccccccccc
+`;
+    await writeFile(join(baseDir, 'mappings', 'ids.yml'), content);
+
+    await expect(loadIdMapping(baseDir)).rejects.toThrow(/Invalid short ID/);
   });
 });
 

--- a/packages/tbd/tests/ids.test.ts
+++ b/packages/tbd/tests/ids.test.ts
@@ -6,7 +6,7 @@
  * - Short ID: Base36, human-friendly for CLI (a7k2)
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   generateInternalId,
   generateShortId,
@@ -807,8 +807,10 @@ c3d4: 01hx5zzkbkcctav9wevgemmvrx
 vb4g: 01hx5zzkbkdctav9wevgemmvry
 vb4g: 01hx5zzkbkdctav9wevgemmvry`;
 
-    // Should NOT throw — this is the fix
+    // Suppress the expected duplicate-key warning
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const mapping = parseIdMappingFromYaml(yamlWithDuplicates);
+    warnSpy.mockRestore();
 
     // All unique entries should be present
     expect(mapping.shortToUlid.size).toBe(4); // 5j0r, a1b2, c3d4, vb4g
@@ -826,8 +828,10 @@ vb4g: 01hx5zzkbkdctav9wevgemmvry`;
 c3d4: 01hx5zzkbkbctav9wevgemmvrw
 a1b2: 01hx5zzkbkxctav9wevgemmabc`;
 
-    // Should NOT throw
+    // Suppress the expected duplicate-key warning
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const mapping = parseIdMappingFromYaml(yamlWithConflictingDuplicates);
+    warnSpy.mockRestore();
 
     // All 3 ULIDs preserved (no data loss)
     expect(mapping.shortToUlid.size).toBe(3);

--- a/packages/tbd/tests/ids.test.ts
+++ b/packages/tbd/tests/ids.test.ts
@@ -819,7 +819,9 @@ vb4g: 01hx5zzkbkdctav9wevgemmvry`;
   });
 
   it('handles duplicate keys mapping to different ULIDs', () => {
-    // Edge case: same short ID maps to different ULIDs after merge
+    // Edge case: same short ID maps to different ULIDs after merge.
+    // Both ULIDs must be preserved — the smaller ULID keeps the original
+    // short ID, and the displaced ULID gets a deterministic replacement.
     const yamlWithConflictingDuplicates = `a1b2: 01hx5zzkbkactav9wevgemmvrz
 c3d4: 01hx5zzkbkbctav9wevgemmvrw
 a1b2: 01hx5zzkbkxctav9wevgemmabc`;
@@ -827,10 +829,15 @@ a1b2: 01hx5zzkbkxctav9wevgemmabc`;
     // Should NOT throw
     const mapping = parseIdMappingFromYaml(yamlWithConflictingDuplicates);
 
-    expect(mapping.shortToUlid.size).toBe(2);
-    // Last occurrence wins (yaml parser behavior with uniqueKeys: false)
-    expect(mapping.shortToUlid.get('a1b2')).toBe('01hx5zzkbkxctav9wevgemmabc');
+    // All 3 ULIDs preserved (no data loss)
+    expect(mapping.shortToUlid.size).toBe(3);
+    expect(mapping.ulidToShort.size).toBe(3);
+    // Smallest ULID keeps the contested short ID
+    expect(mapping.shortToUlid.get('a1b2')).toBe('01hx5zzkbkactav9wevgemmvrz');
     expect(mapping.shortToUlid.get('c3d4')).toBe('01hx5zzkbkbctav9wevgemmvrw');
+    // Displaced ULID has a deterministic replacement
+    expect(mapping.ulidToShort.has('01hx5zzkbkxctav9wevgemmabc')).toBe(true);
+    expect(mapping.ulidToShort.get('01hx5zzkbkxctav9wevgemmabc')).not.toBe('a1b2');
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes a data-loss bug where `merge=union` of `ids.yml` across two clones that independently allocated the same short ID for different beads caused one bead to become unrenderable (`formatDisplayId` throws) and the other to silently address the wrong bead.

Tracking bead: tbd-ysz0

## Problem

`ids.yml` uses `merge=union` in `.gitattributes`, so when two clones both allocate short ID `00wl` for different ULIDs while offline, the merged file contains:

```yaml
00wl: 01aaaaaaaaaaaaaaaaaaaaaaaa
00wl: 01bbbbbbbbbbbbbbbbbbbbbbbb
```

`parseYamlToleratingDuplicateKeys` resolves this as last-occurrence-wins, silently dropping ULID A from both maps. The consequences:

1. **Bead A becomes unrenderable.** `formatDisplayId` throws: "No short ID mapping found for internal ID" — any command that formats that bead (including `tbd list`) fails outright.
2. **`tbd-00wl` silently addresses the wrong bead** (B instead of A).

Neither the `generateUniqueShortId` retry loop (checks only local disk under local lock), the `saveIdMapping` append-only size check (entry count does not shrink), nor the "auto-fixed on next save" warning (false — the losing ULID is dropped at parse time) caught or corrected this.

## Fix

**Repair at load time** in `loadIdMapping` (and `parseIdMappingFromYaml`, `loadIdMappingRaw`), so no code path ever sees a mapping with missing ULIDs:

1. **Check merge conflict markers first.** All three read paths now call `hasMergeConflictMarkers` before any other parsing — including before the duplicate-key branch. This ensures content with both conflict markers and duplicate keys always throws `MergeConflictError` rather than being silently processed as live data.
2. **Parse via YAML AST.** A new `parseYamlDocumentEntries` function uses the yaml library's `parseDocument` with `uniqueKeys: false`, which retains every key-value pair in the AST — including duplicates. This replaces the former regex-based `parseAllIdEntries`, which could not match quoted YAML keys (`"1234"`, `"0000"`, `"true"`, `"null"`) that `stringifyYaml` produces for numeric-looking short IDs. Roughly 15.8% of live `ids.yml` entries have quoted keys — the regex silently skipped them all.
3. **Validate every entry** against `ShortId` and `Ulid` Zod schemas in `extractValidatedIdEntries`. Invalid entries cause a loud error rather than being silently skipped.
4. **Resolve deterministically** via `resolveDuplicateShortIds`:
   - For each contested short ID, the **lexicographically smallest ULID keeps it** (ULIDs are time-ordered, so the earlier-created bead wins).
   - Each displaced ULID receives a replacement short ID **derived from its own characters** via `deriveShortIdFromUlid` — successive windows extracted from the ULID string (length determined by `calculateOptimalLength`), no randomness.
   - Duplicate keys are processed in sorted order; displaced ULIDs are processed in sorted order — full determinism at every step.
5. **On next save**, the corrected mapping is written (the normal `saveIdMapping` read-merge-write path picks up the repaired in-memory mapping), fulfilling the "auto-fixed on next save" promise that was previously false.

### Why deterministic derivation, not random re-allocation

If the displaced ULID's replacement short ID were generated via `generateShortId` (random), two clones repairing the same merged file would pick different replacements. The next union merge would then produce two different short IDs pointing at the same ULID — trading a hard failure for slow divergence. Deriving the replacement from the ULID's own characters makes the repair a pure function of the file content, so every clone converges to the same result.

Window candidates are taken from the **tail of the ULID first**, so they come from its 80 random bits rather than the shared 48-bit timestamp prefix. Two beads created in the same millisecond share their leading characters, so a front-first scan would collide constantly.

### Known residual: alias creation across clones at different sync states

Two clones at different sync states have different `usedShortIds` sets when deriving replacements for displaced ULIDs. This means they can derive different replacement short IDs for the same displaced ULID, creating **aliases** — two short IDs that both point to the same ULID. This is acceptable: aliases are a cosmetic inconsistency (both short IDs work), not data loss, and the next `saveIdMapping` on either clone writes a clean file. The fundamental guarantee — every ULID is addressable on every clone — holds.

### Design decisions

- **Repair at load, not only at save or in `tbd doctor --fix`**: The crash happens at load time when any command formats the displaced bead. Repairing at load prevents the crash on every code path without requiring the user to run a separate repair command first. The file is still corrected on next save.
- **Warning text updated**: The warning now accurately says "Displaced entries have been assigned deterministic replacement short IDs" instead of the previously-false "The file will be auto-fixed on next save" (the auto-fix promise is now true, but the warning also explains what happened to the displaced entries).
- **`tbd doctor` not modified**: This is a load-time data-integrity repair, not a health check. Adding a doctor check for this condition would be reasonable future work but is out of scope for this fix.

## Tests added

New test file: `packages/tbd/tests/id-mapping-duplicate-short-ids.test.ts` (44 tests)

- **`parseYamlDocumentEntries` unit tests** (10 tests): quoted keys, special YAML scalars (`true`, `null`, `0000`), trailing comments, empty content, comments-only, duplicates with quoted keys, duplicates with trailing comments, keys with dots/dashes/underscores, malformed YAML throws
- **Quoted-key bystander tests** (3 tests): uses `stringifyYaml` to produce a file with numeric short ID alongside a duplicate — the scenario that broke the former regex parser — verifying quoted bystander entries survive repair intact
- **Exact bug report scenario**: both ULIDs stay addressable, neither `formatDisplayId` call throws
- **Tiebreak rule pinned**: lexicographically smallest ULID keeps the contested short ID regardless of file order
- **Convergence tests**: two independent repairs of the same input produce identical output, including with multiple duplicate keys and different file orderings
- **End-to-end union merge simulation**: write merged file, load (repair), save, reload — verifies the file is clean after save and produces no warnings on reload
- **Two-clone convergence**: two separate temp dirs with the same merged content produce identical mappings
- **`parseIdMappingFromYaml`** with conflicting duplicates: verifies the same fix applies to the conflict-resolution parse path
- **Conflict markers take priority**: 4 tests ensuring `MergeConflictError` is thrown when content has both conflict markers and duplicate keys (in both `loadIdMapping` and `parseIdMappingFromYaml`), and when content has conflict markers without duplicate keys
- **Repair path validation** (R5): invalid short ID causes loud error; invalid ULID causes loud error naming both the offending value and its key
- **Trailing comment regression** (R3): duplicate lines with trailing comments are parsed and repaired correctly
- **`deriveShortIdFromUlid` escalation tiers under collision pressure**: 5 tests that saturate `usedShortIds` to drive each fallback tier — the single-offset window loop, the 5-char fallback, and the terminal throw — pinning the exact returned value at each tier, asserting determinism and `ShortId` pattern conformance at every tier
- **Unit tests** for `deriveShortIdFromUlid` and `resolveDuplicateShortIds`

Updated existing test in `ids.test.ts`: the "handles duplicate keys mapping to different ULIDs" test previously asserted the old broken behavior (size 2, last-wins). Updated to assert the correct behavior (size 3, all ULIDs preserved, smallest ULID wins).

## Validation

`pnpm precommit` (format, lint, build, full test suite): **138 test files, 2076 tests passed, 0 failures.**

## Scope

Production changes in `id-mapping.ts` and `yaml-utils.ts`. Doc update in `tbd-design.md`. No changes to the on-disk format, sync engine, integrations, or ID system structure. No new dependencies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GF8v1VycQoBxB1s2C2LQri)_