### PR TITLE
process: batch patch releases behind one candidate gate

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -322,19 +322,28 @@ publishes `get-tbd` to npm, and creates a GitHub Release whose body is the match
 
 ### Release process
 
-1. From clean `main`, review `git log <last-tag>..HEAD` and choose the version by the
+1. Open one release train and obtain explicit human approval for one published version.
+   A merged fix does not trigger a release.
+   Batch related fixes into one candidate; if validation finds another defect, fix that
+   candidate and restart validation instead of publishing an intermediate patch.
+   Any additional version requires new explicit approval.
+   See [publishing.md](publishing.md) §Step 0 for the emergency exception.
+2. From clean `main`, review `git log <last-tag>..HEAD` and choose the version by the
    substance of the user-facing change, not the commit-type label: a new CLI capability
    → minor; fixes, docs, and guidance-content changes → patch (even when a commit is
    labeled `feat`); breaking → major.
    Note for `0.x` a semver minor is `0.MINOR.0`. See [publishing.md](publishing.md)
    §Step 2 for details.
-2. On a `claude/release-vX.Y.Z` branch: bump `version` in `packages/tbd/package.json`
+3. On a `claude/release-vX.Y.Z` branch: bump `version` in `packages/tbd/package.json`
    and prepend a `## X.Y.Z` section to `packages/tbd/CHANGELOG.md` with notes written
    per
    [`release-notes-guidelines`](../packages/tbd/docs/guidelines/release-notes-guidelines.md).
-3. `pnpm release:verify` (build and publint) and `pnpm test`; open the release PR; merge
-   once CI is green.
-4. **Gate before tagging:** wait until main CI has reached `conclusion=success` on the
+4. Run `pnpm qa:upgrade-package`, `pnpm release:verify`, and `pnpm test`. For setup,
+   launcher, installation, fallback, format, or upgrade changes, validate the packed
+   candidate in a fresh first-party downstream checkout before opening the release PR.
+   Record the evidence in the PR and rerun it after any candidate change.
+5. Open the release PR and merge once CI is green.
+6. **Gate before tagging:** wait until main CI has reached `conclusion=success` on the
    merge commit itself (filter the run by that SHA—right after a merge an unfiltered
    query can return the previous run).
    Only then tag `vX.Y.Z` on that exact commit and push it—the Release workflow

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -82,6 +82,45 @@ commits at release time.
 
 Follow these steps to publish a new version.
 
+### Step 0: Open One Release Train and Decide Whether to Publish
+
+A merged fix is not, by itself, a reason to publish.
+Collect related fixes into one release candidate, validate that candidate, and publish
+once. A request to release authorizes one published version.
+Publishing an additional patch requires a new, explicit human approval after reporting
+what failed, what changed, and why the new release cannot wait for the next train.
+
+Before creating the release branch:
+
+1. Open or identify one release bead for the candidate version.
+2. Inventory commits since the previous tag, open fix PRs, release-blocking beads, and
+   known downstream upgrade findings.
+3. Merge every fix intended for the train or record an explicit deferral.
+   Do not start the release while another known fix for the same failure class is still
+   in flight.
+4. Freeze the candidate scope and complete the supply-chain, package, upgrade, and
+   downstream checks below.
+
+If validation finds another defect, fix it on the same train and restart candidate
+validation. Do not publish an intermediate patch merely to test the next patch against
+the registry. Packed candidates and temporary downstream branches provide that proof
+without creating a public version.
+
+After publication, queue a newly discovered problem for the next train.
+An immediate patch is reserved for an emergency that affects the published release, such
+as active data loss or corruption, a severe exploitable runtime vulnerability, or an
+install or startup regression that blocks normal use.
+The emergency record must include:
+
+- the concrete user impact and affected published versions;
+- why waiting for the next batched release is unsafe;
+- the smallest corrective scope and its validation evidence; and
+- a new human approval for that specific additional version.
+
+The ordinary release gates still apply to an emergency.
+When time makes one impossible, the approval record must name the skipped evidence and
+the follow-up that will restore it.
+
 ### Step 1: Prepare
 
 ```bash
@@ -211,6 +250,18 @@ published same-format and previous-format baselines.
 Update `TBD_UPGRADE_SAME_FORMAT_FROM`, `TBD_UPGRADE_COMMON_FROM`, or
 `TBD_UPGRADE_PREVIOUS_FORMAT_FROM` when validating a different usage or compatibility
 boundary.
+
+For changes to setup, generated launchers, installation, fallback selection, format
+migration, or upgrade recovery, also exercise the packed candidate in a first-party
+downstream repository such as `jlevy/tryscript`. Start from a fresh clone or temporary
+branch at the representative old version, preserve the resulting diff for review, run
+the downstream repository’s complete quality gate, and repeat the upgrade to prove
+idempotency. The downstream test uses the packed candidate directly; publishing a patch
+is never a prerequisite for testing the next patch.
+
+Record the candidate commit, baseline versions, downstream starting commit, commands,
+and results in the release PR. Any candidate change after this evidence was collected
+invalidates it: rerun the applicable package and downstream proofs before tagging.
 
 **If the release bumps `tbd_format`** (`CURRENT_FORMAT` in
 [`tbd-format.ts`](../packages/tbd/src/lib/tbd-format.ts) differs from the last release):


### PR DESCRIPTION
## Summary

- define one release request as authorization for exactly one published version
- keep pre-tag findings on the same candidate and restart validation; batch post-publish findings into the next train
- require packed-candidate proof in a fresh first-party downstream checkout for upgrade and install changes
- reserve emergency patches for severe published-release impact with a new explicit human approval

## Root cause

The release runbook enforced technical publication gates but did not contain a release-decision or cadence gate. That allowed each downstream discovery to become its own patch instead of being accumulated and proven on one candidate.

## Process effect

Future fixes accumulate in one release train. Packed artifacts and temporary downstream branches are the test mechanism; publishing to the registry is not a QA step. Any additional public version requires a new human decision.

## Validation

- full local pre-push gate: formatting, Markdown formatting, typecheck, ESLint, production build, and 2,032 tests
- exact project-pinned flowmark-rs 0.3.1 check
- git diff --check

Tracking: tbd-rtha

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to release process; no runtime, auth, or dependency behavior is modified.
> 
> **Overview**
> **Release cadence and decision gates** are added so a merged fix alone does not justify publishing. Maintainers must open one release train with explicit approval for exactly one public version, batch related work, and—if validation finds more issues—fix on the same candidate and restart checks rather than shipping intermediate patches. Post-publish findings go to the next train; out-of-band patches are limited to severe published-release impact and need a new approval plus a documented emergency record (`publishing.md` **Step 0**, mirrored in `development.md`).
> 
> **Pre-tag verification** is tightened: the development release checklist now runs `pnpm qa:upgrade-package`, `pnpm release:verify`, and full tests before the release PR, and for setup, launcher, install, fallback, format, or upgrade changes requires proving the **packed** candidate in a fresh first-party downstream repo (e.g. `jlevy/tryscript`)—registry publish is explicitly not a QA step. Release PRs must record baseline versions, commands, and results; any candidate change invalidates that evidence and requires reruns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff8ff520e51b3e2eb1171674e505564e46a39a94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->