### PR TITLE
process: Senior review and expansion of the desktop app guidelines

### DIFF
--- a/.agents/skills/tbd/SKILL.md
+++ b/.agents/skills/tbd/SKILL.md
@@ -406,6 +406,7 @@ Load the **General engineering** group first, then the language or framework gro
 | electrobun-app-development-patterns | Building desktop apps with Electrobun—runtime and process model, typed RPC, project layout, packaging and the delta updater, plus an evidence-based maturity and security assessment |
 | release-notes-guidelines | Guidelines for writing clear, accurate release notes |
 | supply-chain-hardening | Strongly recommended for EVERY repo—apply it if a repo has not been hardened yet. Cross-ecosystem policy for installing dependencies safely (the 14-day cool-off, disabled install scripts, lockfile discipline, untrusted-repo handling). Use whenever a user mentions hardening, security, supply chain, or setting up a new repo; before adding/upgrading dependencies; when auditing for compromised packages; or when reviewing install/build/run commands across npm/pnpm, PyPI, Cargo, or Go. |
+| tauri-app-development-patterns | Building desktop apps with Tauri 2—the Rust core and system webview model, capabilities and permissions, typed commands and IPC, attaching Rust or non-Rust backends, packaging, signing, and the signed updater |
 | tbd-sync-troubleshooting | Common issues and solutions for tbd sync and workspace operations |
 
 <!-- END SHORTCUT DIRECTORY -->

--- a/.agents/skills/tbd/SKILL.md
+++ b/.agents/skills/tbd/SKILL.md
@@ -369,7 +369,7 @@ Load the **General engineering** group first, then the language or framework gro
 | Name | Description |
 | --- | --- |
 | bun-monorepo-patterns | Modern patterns for Bun-based TypeScript monorepo architecture |
-| electron-app-development-patterns | Guidelines for Electron development ecosystems including npm, pnpm, and Bun, with security baselines and framework comparisons |
+| electron-app-development-patterns | Building a clean, minimal, standalone Electron app—process model, modern Vite-based build system, attaching a Node/Bun/Python backend, security baseline, packaging, code signing, and auto-update |
 | pnpm-monorepo-patterns | Modern patterns for pnpm-based TypeScript monorepo architecture |
 | typescript-cli-tool-rules | Rules for building CLI tools with Commander.js, picocolors, and TypeScript |
 | typescript-code-coverage | Best practices for code coverage in TypeScript with Vitest and v8 provider |

--- a/.agents/skills/tbd/SKILL.md
+++ b/.agents/skills/tbd/SKILL.md
@@ -403,6 +403,7 @@ Load the **General engineering** group first, then the language or framework gro
 | --- | --- |
 | cli-agent-skill-patterns | A concise decision guide for portable skills, CLI-backed skills, safe bundle installation, and agent integration |
 | common-doc-guidelines | Common cross-project standards for writing and organizing docs, code comments, and text files—how to organize, structure, write, and format documents, plus the guideline footer convention. Downstream of github.com/jlevy/practical-prose. Use whenever writing or editing any documentation, README, guideline, or design doc. |
+| electrobun-app-development-patterns | Building desktop apps with Electrobun—runtime and process model, typed RPC, project layout, packaging and the delta updater, plus an evidence-based maturity and security assessment |
 | release-notes-guidelines | Guidelines for writing clear, accurate release notes |
 | supply-chain-hardening | Strongly recommended for EVERY repo—apply it if a repo has not been hardened yet. Cross-ecosystem policy for installing dependencies safely (the 14-day cool-off, disabled install scripts, lockfile discipline, untrusted-repo handling). Use whenever a user mentions hardening, security, supply chain, or setting up a new repo; before adding/upgrading dependencies; when auditing for compromised packages; or when reviewing install/build/run commands across npm/pnpm, PyPI, Cargo, or Go. |
 | tbd-sync-troubleshooting | Common issues and solutions for tbd sync and workspace operations |

--- a/.claude/skills/tbd/SKILL.md
+++ b/.claude/skills/tbd/SKILL.md
@@ -406,6 +406,7 @@ Load the **General engineering** group first, then the language or framework gro
 | electrobun-app-development-patterns | Building desktop apps with Electrobun—runtime and process model, typed RPC, project layout, packaging and the delta updater, plus an evidence-based maturity and security assessment |
 | release-notes-guidelines | Guidelines for writing clear, accurate release notes |
 | supply-chain-hardening | Strongly recommended for EVERY repo—apply it if a repo has not been hardened yet. Cross-ecosystem policy for installing dependencies safely (the 14-day cool-off, disabled install scripts, lockfile discipline, untrusted-repo handling). Use whenever a user mentions hardening, security, supply chain, or setting up a new repo; before adding/upgrading dependencies; when auditing for compromised packages; or when reviewing install/build/run commands across npm/pnpm, PyPI, Cargo, or Go. |
+| tauri-app-development-patterns | Building desktop apps with Tauri 2—the Rust core and system webview model, capabilities and permissions, typed commands and IPC, attaching Rust or non-Rust backends, packaging, signing, and the signed updater |
 | tbd-sync-troubleshooting | Common issues and solutions for tbd sync and workspace operations |
 
 <!-- END SHORTCUT DIRECTORY -->

--- a/.claude/skills/tbd/SKILL.md
+++ b/.claude/skills/tbd/SKILL.md
@@ -369,7 +369,7 @@ Load the **General engineering** group first, then the language or framework gro
 | Name | Description |
 | --- | --- |
 | bun-monorepo-patterns | Modern patterns for Bun-based TypeScript monorepo architecture |
-| electron-app-development-patterns | Guidelines for Electron development ecosystems including npm, pnpm, and Bun, with security baselines and framework comparisons |
+| electron-app-development-patterns | Building a clean, minimal, standalone Electron app—process model, modern Vite-based build system, attaching a Node/Bun/Python backend, security baseline, packaging, code signing, and auto-update |
 | pnpm-monorepo-patterns | Modern patterns for pnpm-based TypeScript monorepo architecture |
 | typescript-cli-tool-rules | Rules for building CLI tools with Commander.js, picocolors, and TypeScript |
 | typescript-code-coverage | Best practices for code coverage in TypeScript with Vitest and v8 provider |

--- a/.claude/skills/tbd/SKILL.md
+++ b/.claude/skills/tbd/SKILL.md
@@ -403,6 +403,7 @@ Load the **General engineering** group first, then the language or framework gro
 | --- | --- |
 | cli-agent-skill-patterns | A concise decision guide for portable skills, CLI-backed skills, safe bundle installation, and agent integration |
 | common-doc-guidelines | Common cross-project standards for writing and organizing docs, code comments, and text files—how to organize, structure, write, and format documents, plus the guideline footer convention. Downstream of github.com/jlevy/practical-prose. Use whenever writing or editing any documentation, README, guideline, or design doc. |
+| electrobun-app-development-patterns | Building desktop apps with Electrobun—runtime and process model, typed RPC, project layout, packaging and the delta updater, plus an evidence-based maturity and security assessment |
 | release-notes-guidelines | Guidelines for writing clear, accurate release notes |
 | supply-chain-hardening | Strongly recommended for EVERY repo—apply it if a repo has not been hardened yet. Cross-ecosystem policy for installing dependencies safely (the 14-day cool-off, disabled install scripts, lockfile discipline, untrusted-repo handling). Use whenever a user mentions hardening, security, supply chain, or setting up a new repo; before adding/upgrading dependencies; when auditing for compromised packages; or when reviewing install/build/run commands across npm/pnpm, PyPI, Cargo, or Go. |
 | tbd-sync-troubleshooting | Common issues and solutions for tbd sync and workspace operations |

--- a/.tbd/config.yml
+++ b/.tbd/config.yml
@@ -106,6 +106,7 @@ docs_cache:
     guidelines/common-doc-guidelines.md: internal:guidelines/common-doc-guidelines.md
     guidelines/convex-limits-best-practices.md: internal:guidelines/convex-limits-best-practices.md
     guidelines/convex-rules.md: internal:guidelines/convex-rules.md
+    guidelines/electrobun-app-development-patterns.md: internal:guidelines/electrobun-app-development-patterns.md
     guidelines/electron-app-development-patterns.md: internal:guidelines/electron-app-development-patterns.md
     guidelines/error-handling-rules.md: internal:guidelines/error-handling-rules.md
     guidelines/general-coding-rules.md: internal:guidelines/general-coding-rules.md
@@ -120,6 +121,7 @@ docs_cache:
     guidelines/python-rules.md: internal:guidelines/python-rules.md
     guidelines/release-notes-guidelines.md: internal:guidelines/release-notes-guidelines.md
     guidelines/supply-chain-hardening.md: internal:guidelines/supply-chain-hardening.md
+    guidelines/tauri-app-development-patterns.md: internal:guidelines/tauri-app-development-patterns.md
     guidelines/tbd-sync-troubleshooting.md: internal:guidelines/tbd-sync-troubleshooting.md
     guidelines/typescript-cli-tool-rules.md: internal:guidelines/typescript-cli-tool-rules.md
     guidelines/typescript-code-coverage.md: internal:guidelines/typescript-code-coverage.md

--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ opinionated rules with concrete examples, built from months of heavy agentic cod
 | [cli-agent-skill-patterns](packages/tbd/docs/guidelines/cli-agent-skill-patterns.md) | Building CLIs that function as agent skills in Claude Code |
 | [electron-app-development-patterns](packages/tbd/docs/guidelines/electron-app-development-patterns.md) | Standalone Electron apps: process model, Vite build, Node/Bun/Python backends, security, signing, updates |
 | [electrobun-app-development-patterns](packages/tbd/docs/guidelines/electrobun-app-development-patterns.md) | Electrobun apps: runtime and process model, typed RPC, packaging and the delta updater, maturity and security assessment |
+| [tauri-app-development-patterns](packages/tbd/docs/guidelines/tauri-app-development-patterns.md) | Tauri 2 apps: Rust core and system webview, capabilities and permissions, sidecars and non-Rust backends, signing and the signed updater |
 | [typescript-yaml-handling-rules](packages/tbd/docs/guidelines/typescript-yaml-handling-rules.md) | YAML parsing/serialization with the `yaml` package, Zod validation, consistent formatting |
 | [python-rules](packages/tbd/docs/guidelines/python-rules.md) | Type hints, docstrings, exception handling, resource management |
 | [python-cli-patterns](packages/tbd/docs/guidelines/python-cli-patterns.md) | Modern Python CLI stack: uv, Typer, Rich, Ruff, BasedPyright |

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ opinionated rules with concrete examples, built from months of heavy agentic cod
 | [bun-monorepo-patterns](packages/tbd/docs/guidelines/bun-monorepo-patterns.md) | Bun workspaces, Bunup, Biome, bun test, standalone executables |
 | [typescript-cli-tool-rules](packages/tbd/docs/guidelines/typescript-cli-tool-rules.md) | Commander.js patterns, picocolors, terminal formatting |
 | [cli-agent-skill-patterns](packages/tbd/docs/guidelines/cli-agent-skill-patterns.md) | Building CLIs that function as agent skills in Claude Code |
-| [electron-app-development-patterns](packages/tbd/docs/guidelines/electron-app-development-patterns.md) | Electron ecosystems (npm, pnpm, Bun), security baselines, Electrobun comparison |
+| [electron-app-development-patterns](packages/tbd/docs/guidelines/electron-app-development-patterns.md) | Standalone Electron apps: process model, Vite build, Node/Bun/Python backends, security, signing, updates |
 | [typescript-yaml-handling-rules](packages/tbd/docs/guidelines/typescript-yaml-handling-rules.md) | YAML parsing/serialization with the `yaml` package, Zod validation, consistent formatting |
 | [python-rules](packages/tbd/docs/guidelines/python-rules.md) | Type hints, docstrings, exception handling, resource management |
 | [python-cli-patterns](packages/tbd/docs/guidelines/python-cli-patterns.md) | Modern Python CLI stack: uv, Typer, Rich, Ruff, BasedPyright |

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ opinionated rules with concrete examples, built from months of heavy agentic cod
 | [typescript-cli-tool-rules](packages/tbd/docs/guidelines/typescript-cli-tool-rules.md) | Commander.js patterns, picocolors, terminal formatting |
 | [cli-agent-skill-patterns](packages/tbd/docs/guidelines/cli-agent-skill-patterns.md) | Building CLIs that function as agent skills in Claude Code |
 | [electron-app-development-patterns](packages/tbd/docs/guidelines/electron-app-development-patterns.md) | Standalone Electron apps: process model, Vite build, Node/Bun/Python backends, security, signing, updates |
+| [electrobun-app-development-patterns](packages/tbd/docs/guidelines/electrobun-app-development-patterns.md) | Electrobun apps: runtime and process model, typed RPC, packaging and the delta updater, maturity and security assessment |
 | [typescript-yaml-handling-rules](packages/tbd/docs/guidelines/typescript-yaml-handling-rules.md) | YAML parsing/serialization with the `yaml` package, Zod validation, consistent formatting |
 | [python-rules](packages/tbd/docs/guidelines/python-rules.md) | Type hints, docstrings, exception handling, resource management |
 | [python-cli-patterns](packages/tbd/docs/guidelines/python-cli-patterns.md) | Modern Python CLI stack: uv, Typer, Rich, Ruff, BasedPyright |

--- a/packages/tbd/docs/guidelines/electrobun-app-development-patterns.md
+++ b/packages/tbd/docs/guidelines/electrobun-app-development-patterns.md
@@ -13,6 +13,7 @@ category: desktop
 - [Electrobun documentation](https://framework.blackboard.sh/electrobun/)
 - [Electrobun source](https://github.com/blackboardsh/electrobun)
 - [Companion: Electron App Development Patterns](https://github.com/jlevy/tbd/blob/main/packages/tbd/docs/guidelines/electron-app-development-patterns.md)
+- [Companion: Tauri App Development Patterns](https://github.com/jlevy/tbd/blob/main/packages/tbd/docs/guidelines/tauri-app-development-patterns.md)
 
 * * *
 
@@ -713,6 +714,7 @@ platform-specific bugs that a larger project would have found already.
 ## Related Guidelines
 
 - For Electron, see `tbd guidelines electron-app-development-patterns`
+- For Tauri, see `tbd guidelines tauri-app-development-patterns`
 - For dependency policy, see `tbd guidelines supply-chain-hardening`
 - For TypeScript conventions, see `tbd guidelines typescript-rules`
 

--- a/packages/tbd/docs/guidelines/electrobun-app-development-patterns.md
+++ b/packages/tbd/docs/guidelines/electrobun-app-development-patterns.md
@@ -93,8 +93,8 @@ repository:
   There is also no `contextIsolation` equivalent.
 
 - **The bus factor is one.** Roughly 12,700 GitHub stars and genuine engineering depth,
-  but effectively a single maintainer, 86 open issues against about a dozen closed, no
-  CHANGELOG, and versioning that carries no semver signal.
+  but effectively a single maintainer, 86 open issues against about a dozen visibly
+  closed, no CHANGELOG, and versioning that carries no semver signal.
 
 **Recommendation in one line:** promising for internal tools, prototypes, and apps you
 distribute to a trusted audience without auto-update; not currently a responsible choice
@@ -142,7 +142,8 @@ From `package/src/config/ElectrobunConfig.ts`:
 mainProcess?: "bun" | "cottontail" | "zig" | "rust" | "go" | "odin";
 ```
 
-**Cottontail is the default** and is what the templates use.
+**Cottontail is the default**—the config type declares `@default "cottontail"`—and it is
+what the templates use.
 It is Electrobun’s own JavaScriptCore-based runtime.
 Choose `bun` only if you specifically need Bun APIs; note that doing so ties you to
 Bun’s FFI layer at a moment when Bun is rewriting its core.
@@ -362,9 +363,10 @@ framework-independent and applies here unchanged.
 Two Electrobun-specific cautions:
 
 - **Signing nested binaries is unverifiable from source.** Signing lives inside the
-  closed-source Hutch CLI, so you cannot audit how, or whether, it signs binaries you
-  add to the bundle. Expect to debug notarization failures without being able to read the
-  signing code.
+  Hutch CLI, which ships as a binary and is not part of the open repository—the repo
+  contains the launcher, core, extractor, and SDKs, but no signing code—so you cannot
+  audit how, or whether, it signs binaries you add to the bundle.
+  Expect to debug notarization failures without being able to read the signing code.
 - **The macOS bundle layout is unconventional.** Binaries live in `Contents/MacOS/` with
   a `Resources/` directory nested inside `MacOS/` rather than at the standard
   `Contents/Resources/`. If you have tooling or expectations built around Apple’s
@@ -503,15 +505,16 @@ and Tauri’s updater requires a signature made with a key you hold.
 **If you ship Electrobun today, disable the updater and distribute through a channel
 that provides its own integrity guarantees.**
 
-One honest caveat: the Hutch CLI is closed-source, so build-time behavior cannot be
-fully audited. But the code that runs on a user’s machine at update time is the code
-above, and the verification is absent there.
+One honest caveat: the Hutch CLI ships as a binary outside the open repository, so
+build-time behavior cannot be fully audited.
+But the code that runs on a user’s machine at update time is the code above, and the
+verification is absent there.
 
 ### Code Signing
 
 | Platform | State |
 | --- | --- |
-| **macOS** | Configurable via `mac.codesign` and `mac.entitlements`, but the implementation lives inside the closed-source Hutch CLI and cannot be audited. Open issue [#515](https://github.com/blackboardsh/electrobun/issues/515) reports the signing setup exposing a personal Apple ID credential. |
+| **macOS** | Configurable via `mac.codesign` and `mac.entitlements`, but the implementation ships inside the Hutch CLI binary rather than the open repository, so it cannot be audited from source. Open issue [#515](https://github.com/blackboardsh/electrobun/issues/515) reports the signing setup exposing a personal Apple ID credential. |
 | **Windows** | **No code signing at all.** No Authenticode, no SignTool integration. Binaries ship unsigned, which means SmartScreen warnings and no trust chain. |
 | **Linux** | No GPG signing and no repository integration. |
 
@@ -626,9 +629,9 @@ should be evaluated on those terms rather than on its star count.
    governs whether Electrobun can be recommended for public distribution.
    Recheck `Updater.ts` on every upgrade.
 
-2. **What does the closed-source Hutch CLI do at signing time?** macOS entitlements,
-   hardened runtime flags, and nested-binary signing are all unverifiable from source
-   today.
+2. **What does the Hutch CLI actually do at signing time?** It ships as a binary outside
+   the open repository, so macOS entitlements, hardened runtime flags, and nested-binary
+   signing are all unverifiable from source today.
 
 3. **Does Cottontail change the performance and compatibility story versus Bun?** It is
    now the default runtime, but there is no published comparison of JavaScriptCore-based

--- a/packages/tbd/docs/guidelines/electrobun-app-development-patterns.md
+++ b/packages/tbd/docs/guidelines/electrobun-app-development-patterns.md
@@ -1,0 +1,721 @@
+---
+title: Electrobun App Development Patterns
+description: Building desktop apps with Electrobun—runtime and process model, typed RPC, project layout, packaging and the delta updater, plus an evidence-based maturity and security assessment
+author: Joshua Levy (github.com/jlevy) with LLM assistance
+category: desktop
+---
+# Electrobun App Development Patterns
+
+**Last Updated**: 2026-08-16
+
+**Related**:
+
+- [Electrobun documentation](https://framework.blackboard.sh/electrobun/)
+- [Electrobun source](https://github.com/blackboardsh/electrobun)
+- [Companion: Electron App Development Patterns](https://github.com/jlevy/tbd/blob/main/packages/tbd/docs/guidelines/electron-app-development-patterns.md)
+
+* * *
+
+## Updating This Document
+
+Electrobun moves fast and its stable channel lags its development channel by months, so
+version facts here go stale quickly.
+Recheck the npm dist-tags and the open security issues before relying on anything below.
+
+### Last Researched Versions
+
+Observed 2026-08-16 by querying the npm registry and reading a clone of the repository
+at `main`.
+
+| Thing | Version | Check For Updates |
+| --- | --- | --- |
+| **electrobun (stable)** | 1.18.1 | [npmjs.com/package/electrobun](https://www.npmjs.com/package/electrobun)—`latest` published **2026-05-04**. |
+| **electrobun (beta)** | 2.0.1-beta.14 | Same registry, `beta` tag—published **2026-08-15**. The 2.0 line adds multi-runtime main processes and decouples from Bun. There is no stable 2.0. |
+| **Release cadence** | 296 versions since 2024-08-08 | Beta releases land most days; the stable tag moves every few months. **The two channels are roughly 3.5 months apart.** |
+| **Bundled Bun** | 1.3.13 | `package/src/shared/bun-version.ts`—only relevant when `mainProcess: "bun"`. |
+| **Bundled CEF** | 147.0.10+chromium-147.0.7727.118 | `package/src/shared/cef-version.ts`—shipped as a separate tarball, downloaded only when `bundleCEF` is set. |
+| **macOS support** | 14+, arm64 only | `README.md`, `platform.ts`. x86_64 macOS is not supported ([#485](https://github.com/blackboardsh/electrobun/issues/485)). |
+| **Windows support** | 11+, x64 only | `platform.ts:27` hardcodes `x64` for Windows; ARM64 runs only under emulation. Requires the Evergreen WebView2 runtime, which is **not** bundled. |
+| **Linux support** | Ubuntu 24.04+ | Needs GTK3, WebKitGTK 4.1, Ayatana AppIndicator, librsvg. Other distributions are community-supported. |
+
+### Reminders When Updating
+
+1. **Recheck the two dist-tags first.** `latest` and `beta` diverge substantially, and
+   which one you document changes the config schema (see
+   [Project Layout and Configuration](#project-layout-and-configuration)).
+
+2. **Recheck the open security issues**, particularly
+   [#518](https://github.com/blackboardsh/electrobun/issues/518) (RPC transport) and
+   [#515](https://github.com/blackboardsh/electrobun/issues/515) (signing credentials),
+   and re-verify whether the updater has gained signature verification.
+   That single question governs the recommendation in this document.
+
+3. **Verify claims against source, not documentation.** The published docs currently
+   describe a config schema that the templates on `main` no longer use.
+   Treat the repository as authoritative.
+
+4. **Recheck the platform matrix.** Architecture support is narrower than the marketing
+   surface suggests and has been changing.
+
+5. **Recheck whether a CHANGELOG exists.** As of this writing there is none, and release
+   notes are auto-generated commit ranges, so upgrades require reading diffs.
+
+* * *
+
+## Executive Summary
+
+Electrobun builds desktop apps from TypeScript with a native Zig core, system webviews,
+and a typed RPC layer between the two.
+It targets a much smaller bundle than Electron by not shipping Chromium, and it ships a
+bsdiff-based delta updater.
+
+**The headline for anyone arriving from older material: Electrobun is no longer a
+Bun-first framework.** The `mainProcess` config option now selects among
+`bun | cottontail | zig | rust | go | odin`, and the default is **cottontail**,
+Electrobun’s own JavaScriptCore runtime.
+The source states plainly that “Bun is an optional Electrobun application runtime.”
+The maintainer has attributed the decoupling to Bun’s Zig-to-Rust core rewrite
+destabilizing downstream FFI bindings.
+
+Three findings determine whether you should use it, and all three are verifiable in the
+repository:
+
+- **The auto-updater verifies nothing.** There is no signature verification and no
+  content-digest check of the downloaded payload anywhere in the client update path.
+  Anyone able to serve or tamper with your update endpoint gets arbitrary code execution
+  on every user’s machine.
+  Details and the exact evidence are in [The Updater](#the-updater-verifies-nothing).
+
+- **Sandboxing and IPC are mutually exclusive.** A sandboxed webview cannot use RPC at
+  all, so the Electron posture of “sandboxed renderer talking over a narrow audited
+  bridge” is not available.
+  There is also no `contextIsolation` equivalent.
+
+- **The bus factor is one.** Roughly 12,700 GitHub stars and genuine engineering depth,
+  but effectively a single maintainer, 86 open issues against about a dozen closed, no
+  CHANGELOG, and versioning that carries no semver signal.
+
+**Recommendation in one line:** promising for internal tools, prototypes, and apps you
+distribute to a trusted audience without auto-update; not currently a responsible choice
+for a security-sensitive product or one shipped to the general public.
+The full form is in [Recommendations](#recommendations).
+
+**Research questions this document answers**:
+
+1. What actually runs where in an Electrobun app, now that Bun is optional?
+2. What does a minimal, correct project look like, and which config schema applies?
+3. What is the real security boundary, and how does it compare to Electron’s?
+4. What does it take to package, sign, and update an Electrobun app, and what is
+   missing?
+
+* * *
+
+## 1. Architecture and Process Model
+
+### The Layers
+
+An Electrobun app is a stack of four things, verified by reading the repository:
+
+| Layer | Implementation | Role |
+| --- | --- | --- |
+| **Launcher** | Zig binary (`launcher/main.zig`) | Reads `build.json`, selects and spawns the main-process runtime. On Linux sets `LD_LIBRARY_PATH` and, when CEF is present, `LD_PRELOAD`. On Windows uses `CreateProcessW` with `CREATE_NO_WINDOW`. |
+| **Main process** | Cottontail (default), or Bun, Zig, Rust, Go, Odin | Runs your application code. Owns the native event loop through FFI. Full system access. |
+| **Native core** | Zig (`core/main.zig`, ~4,100 lines) plus per-platform wrappers | Window and webview lifecycle, the WebSocket transport, thread-safe registries. Exposed over a C ABI. |
+| **Webviews** | WKWebView (macOS), WebView2 (Windows), WebKitGTK (Linux), or bundled CEF | Your UI. Separate OS processes. |
+
+The native wrappers are `nativeWrapper.mm` (Objective-C++) on macOS and
+`nativeWrapper.cpp` (C++) on Windows and Linux, sharing 35-plus header-only C++
+libraries. The TypeScript SDK reaches them through `bun:ffi`, binding over 100 symbols.
+
+A detail worth knowing because it explains a class of bug: the main thread runs the
+blocking native GUI event loop, while your application code runs in a **worker thread**.
+Native callbacks therefore fire on a different thread from your JavaScript, which is why
+every `JSCallback` is created with `threadsafe: true`, and why a 2ms delay still sits in
+`preload/internalRpc.ts` labelled “work around Bun JSCallback threading issue.”
+
+### Choosing a Main-Process Runtime
+
+From `package/src/config/ElectrobunConfig.ts`:
+
+```ts
+mainProcess?: "bun" | "cottontail" | "zig" | "rust" | "go" | "odin";
+```
+
+**Cottontail is the default** and is what the templates use.
+It is Electrobun’s own JavaScriptCore-based runtime.
+Choose `bun` only if you specifically need Bun APIs; note that doing so ties you to
+Bun’s FFI layer at a moment when Bun is rewriting its core.
+The compiled-language options exist in the 2.0 line and replace the main process
+entirely—they are not a sidecar mechanism.
+
+### Webview Selection and the Linux Exception
+
+Per platform you choose a system webview or bundled Chromium:
+
+```ts
+mac:   { bundleCEF: false },
+linux: { bundleCEF: true },
+win:   { bundleCEF: false },
+```
+
+macOS links CEF weakly and falls back to WebKit gracefully; Windows detects CEF at
+runtime; **Linux ships two separate native binaries** (`libNativeWrapper.so` at ~1.46MB
+for GTK, `libNativeWrapper_cef.so` at ~3.47MB for CEF) because Linux lacks reliable weak
+linking.
+
+The Linux case deserves attention because it undercuts the framework’s main selling
+point. Electrobun’s own documentation recommends CEF over WebKitGTK on Linux, citing
+WebKitGTK’s severe limitations, and the shipped `photo-booth` template does exactly
+that.
+Bundling CEF means bundling Chromium, which is the cost Electron is criticised for.
+**On Linux you largely give up the size advantage**, or you accept a materially
+different rendering engine from your other platforms.
+
+* * *
+
+## 2. Reference Architecture
+
+### Project Layout and Configuration
+
+```
+my-app/
+├── src/
+│   ├── bun/
+│   │   └── index.ts          # main process entry (despite the directory name)
+│   └── mainview/
+│       ├── index.ts          # webview entry
+│       ├── index.html
+│       └── index.css
+└── electrobun.config.ts
+```
+
+The directory is conventionally `src/bun/` even when the runtime is Cottontail; that is
+template convention, not a requirement.
+
+**Which config schema applies depends on your channel, and this trips people up.** The
+published build-configuration documentation describes `build.bun.entrypoint` and
+`build.views`. The templates on `main` use a different shape.
+This is the current form, taken verbatim from the `photo-booth` template:
+
+```ts
+import type { ElectrobunConfig } from 'electrobun';
+
+export default {
+  app: {
+    name: 'photo-booth',
+    identifier: 'photobooth.electrobun.dev',
+    version: '0.0.1',
+  },
+  build: {
+    mainProcess: 'cottontail',
+    cottontail: { entrypoint: 'src/bun/index.ts' },
+    views: {
+      mainview: { entrypoint: 'src/mainview/index.ts' },
+    },
+    copy: {
+      'src/mainview/index.html': 'views/mainview/index.html',
+      'src/mainview/index.css': 'views/mainview/index.css',
+    },
+    mac: {
+      bundleCEF: false,
+      codesign: true,
+      entitlements: {
+        'com.apple.security.device.camera': 'This app needs camera access to take photos',
+      },
+    },
+    linux: { bundleCEF: true },
+    win: { bundleCEF: false },
+  },
+} satisfies ElectrobunConfig;
+```
+
+Top-level keys are `app`, `build`, `runtime`, `scripts`, and `release`.
+
+### Bringing Your Own Frontend Build
+
+Electrobun bundles view code with Bun’s bundler, but you can run any frontend toolchain
+and map its output in through `copy`. The React template does exactly this with Vite:
+
+```ts
+build: {
+  mainProcess: 'cottontail',
+  cottontail: { entrypoint: 'src/bun/index.ts' },
+  copy: {
+    'dist/index.html': 'views/mainview/index.html',
+    'dist/assets': 'views/mainview/assets',
+  },
+  watchIgnore: ['dist/**'],   // Vite owns dist; do not double-watch it
+}
+```
+
+This is the pattern the community has converged on: React plus Tailwind plus Vite, built
+by Vite, copied into the bundle.
+
+### Creating a Window
+
+```ts
+import { BrowserWindow } from 'electrobun/main';
+
+const mainWindow = new BrowserWindow({
+  title: 'Hello Electrobun!',
+  url: 'views://mainview/index.html',
+  frame: { width: 800, height: 800, x: 200, y: 200 },
+});
+```
+
+The `views://` scheme resolves to assets bundled by `build.views` and `build.copy`.
+Views must be declared in the config to exist at runtime.
+
+The main API surface is `BrowserWindow`, `BrowserView`, `Electroview` (browser side),
+`Tray`, `ApplicationMenu`, `Utils`, and `Updater`.
+
+### Typed RPC
+
+This is the part of Electrobun that is genuinely nicer than Electron’s equivalent.
+The contract is a plain TypeScript type, split into awaitable `requests` and
+fire-and-forget `messages`, and both sides are typed from it with no codegen.
+
+Main process:
+
+```ts
+import { BrowserView, Utils, type RPCSchema } from 'electrobun/main';
+
+export type BunnyRPC = {
+  bun: RPCSchema<{
+    requests: {};
+    messages: { bunnyClicked: void };
+  }>;
+  webview: RPCSchema<{
+    requests: {};
+    messages: {
+      cursorMove: { screenX: number; screenY: number };
+    };
+  }>;
+};
+
+const rpc = BrowserView.defineRPC<BunnyRPC>({
+  maxRequestTime: 5000,
+  handlers: {
+    requests: {},
+    messages: {
+      bunnyClicked: () => {
+        Utils.openExternal('https://framework.blackboard.sh/electrobun/');
+      },
+    },
+  },
+});
+```
+
+Webview side, importing the same type:
+
+```ts
+import Electrobun, { Electroview } from 'electrobun/view';
+import type { BunnyRPC } from '../bun/index';
+
+const rpc = Electroview.defineRPC<BunnyRPC>({
+  maxRequestTime: 5000,
+  handlers: { requests: {}, messages: {} },
+});
+
+const electrobun = new Electrobun.Electroview({ rpc });
+```
+
+Underneath, traffic runs over a **loopback WebSocket** (`ws://127.0.0.1:{random port}`)
+encrypted per webview with AES-256-GCM, falling back to a native postMessage bridge on
+Windows. Every webview also gets a built-in `evaluateJavascriptWithResponse` method.
+
+### The Development Loop
+
+`bunx electrobun init` scaffolds from one of roughly 31 official templates, then
+`bun start` runs the app; the underlying CLI is Hutch.
+DevTools are available through `webview.openDevTools()`, source maps come from the
+bundler config, and the main process can be debugged with a standard inspector.
+
+**There is no documented hot module replacement or hot reload.** Code changes require a
+restart. If you are coming from electron-vite’s renderer HMR plus main-process
+hot-restart, this is a real step down in iteration speed.
+
+* * *
+
+## 3. Attaching a Backend
+
+Electrobun has **no documented sidecar mechanism and no equivalent of electron-builder’s
+`extraResources`.** Nothing here is framework-supported; it is the pattern the community
+has assembled.
+
+The working approach has three parts:
+
+1. **Place the binary** with `build.copy`, mapping it into the bundle like any other
+   asset.
+2. **Spawn it** with the runtime’s process API—`Bun.spawn()` when the main process is
+   Bun.
+3. **Resolve its path** at runtime through `RESOURCES_FOLDER`.
+
+Bridge it with newline-delimited JSON over stdio, for the same reasons that apply in any
+desktop app: no port to bind, nothing else on the machine can reach it, and it dies with
+its parent. The
+[Electron guideline’s backend section](https://github.com/jlevy/tbd/blob/main/packages/tbd/docs/guidelines/electron-app-development-patterns.md)
+covers transport choice, loopback risk, and process lifecycle in depth; that analysis is
+framework-independent and applies here unchanged.
+
+Two Electrobun-specific cautions:
+
+- **Signing nested binaries is unverifiable from source.** Signing lives inside the
+  closed-source Hutch CLI, so you cannot audit how, or whether, it signs binaries you
+  add to the bundle. Expect to debug notarization failures without being able to read the
+  signing code.
+- **The macOS bundle layout is unconventional.** Binaries live in `Contents/MacOS/` with
+  a `Resources/` directory nested inside `MacOS/` rather than at the standard
+  `Contents/Resources/`. If you have tooling or expectations built around Apple’s
+  canonical layout, they will not transfer.
+
+If your backend is a compiled language, consider instead making it the main process:
+`mainProcess` accepts `zig`, `rust`, `go`, and `odin` in the 2.0 line, which avoids the
+sidecar problem entirely at the cost of writing your window management in that language.
+
+* * *
+
+## 4. Security Baseline
+
+This section is longer than the equivalent in the Electron guideline because Electrobun
+does not ship a comparable set of defaults, and because **there is no security
+documentation for the framework at all**. That absence is itself the most important
+thing to know before choosing it.
+
+### What Electrobun Gets Right
+
+- **Webview code has no direct runtime access.** There is no ambient Bun, Node, or
+  filesystem API in the page.
+  The RPC surface is the only way out.
+- **Webviews are separate OS processes**, so a renderer crash does not take the app
+  down.
+- **RPC traffic is encrypted** with AES-256-GCM, which matters given the transport is a
+  loopback socket.
+- **Navigation control exists** through glob-pattern URL rules.
+
+### The Sandbox and RPC Are Mutually Exclusive
+
+Two preload variants exist in the source.
+The sandboxed one states its own limits:
+
+> No RPC, NO encryption, NO webview tags … No RPC handlers — sandboxed webviews cannot
+> communicate with Bun.
+
+So the choice is binary.
+A sandboxed webview is inert—lifecycle events and one-way emission only.
+A webview that can talk to your application is not sandboxed.
+**Electron’s default posture, a sandboxed renderer communicating over a narrow audited
+bridge, has no equivalent here**, and sandboxing is opt-in rather than the default.
+
+The practical consequence: cross-site scripting in an Electrobun webview yields the full
+RPC surface, which in a typical app carries filesystem and OS access.
+In Electron the same bug is contained by context isolation and a deliberately narrow
+`contextBridge` surface.
+
+### There Is No Context Isolation
+
+Electron’s `contextIsolation` runs preload code in a separate JavaScript context so page
+script cannot reach or overwrite the bridge.
+Electrobun has no equivalent.
+The preload globals `window.__electrobun` and `window.__electrobun_encrypt` are
+reachable from page JavaScript and can be overwritten, which means the RPC encryption
+key lives in a location the page can read.
+The encryption protects the transport against other local processes; it does not protect
+the bridge from the page itself.
+
+Open issue [#518](https://github.com/blackboardsh/electrobun/issues/518) tracks further
+transport weaknesses, including a 500MB payload cap and no authentication on the
+WebSocket upgrade.
+
+### Practical Rules
+
+Given the above, the discipline has to come from your application rather than the
+framework:
+
+- **Never load remote or untrusted content into a webview that has RPC.** In Electron
+  this is a strong recommendation; here it is closer to a hard requirement, because you
+  have no second line of defence.
+- **Keep the RPC surface narrow and specific**, exactly as you would a `contextBridge`
+  surface: named capabilities, no generic pass-through, no method that takes an
+  arbitrary path or command.
+- **Validate every RPC payload** in the main process.
+  The type contract is compile-time only; it guarantees nothing at runtime.
+- **Set a Content-Security-Policy yourself.** The framework offers no guidance and no
+  default.
+- **Use navigation rules** to pin the app to its own `views://` origin.
+- **Be deliberate about `bundleCEF`.** CEF and the system webviews have different
+  security update cadences: system webviews are patched by the OS vendor, while bundled
+  CEF is only as current as your last release.
+
+* * *
+
+## 5. Packaging and Distribution
+
+### Build Output
+
+The distributable is a **self-extracting binary**: a Zstandard-compressed tar with a Zig
+extractor. Installation targets are `%LOCALAPPDATA%` on Windows and `~/.local/share/` on
+Linux; on macOS it is a `.app` bundle.
+An uncompressed tar is retained on disk to support future delta patching.
+
+**On Linux the only output is a self-extracting archive.** There is no `.deb`, `.rpm`,
+`.AppImage`, Flatpak, or Snap target, which means no package-manager integration and no
+distribution through the channels Linux users expect.
+
+### Bundle Size, Honestly
+
+The advertised figure is roughly 12 to 14MB compressed with a system webview, against
+Electron’s much larger baseline.
+That number is real but describes a minimal app, compressed.
+Independent measurements of a React application land closer to **64.5MB on disk**, and
+the same discrepancy came up repeatedly in public discussion of the v1 release.
+
+If you are choosing Electrobun for size, measure your own app rather than trusting the
+headline, and remember that a Linux build following the project’s own CEF recommendation
+carries Chromium anyway.
+
+### The Updater Verifies Nothing
+
+Electrobun ships a bsdiff-based delta updater: patches are generated against the
+immediately preceding version, with a full `.tar.zst` fallback, and Windows applies
+post-exit updates through Task Scheduler.
+
+**It performs no verification of what it installs.** This is verifiable directly:
+
+- Searching `Updater.ts` and `extractor/main.zig` for `ed25519`, `rsa`, `publickey`,
+  `verifySignature`, `minisign`, `signify`, `gpg`, and `pgp` returns **no signature
+  verification of any kind**.
+- The only `createHash("sha256")` in `Updater.ts` builds a Windows Task Scheduler task
+  name.
+- Every SHA-256 site in `extractor/main.zig` is used for naming, locking, or checking a
+  Linux `.desktop` entry—never the update payload.
+- The `hash` field in `update.json` is a change sentinel: it is compared against the
+  local hash purely to decide whether an update exists.
+
+The consequence is direct.
+Anyone who can serve or tamper with your update endpoint—a compromised host, a
+misconfigured bucket, a hostile network without strict transport guarantees—can execute
+arbitrary code on every user’s machine.
+For comparison, Squirrel.Mac refuses to apply an update that is not correctly signed,
+and Tauri’s updater requires a signature made with a key you hold.
+
+**If you ship Electrobun today, disable the updater and distribute through a channel
+that provides its own integrity guarantees.**
+
+One honest caveat: the Hutch CLI is closed-source, so build-time behavior cannot be
+fully audited. But the code that runs on a user’s machine at update time is the code
+above, and the verification is absent there.
+
+### Code Signing
+
+| Platform | State |
+| --- | --- |
+| **macOS** | Configurable via `mac.codesign` and `mac.entitlements`, but the implementation lives inside the closed-source Hutch CLI and cannot be audited. Open issue [#515](https://github.com/blackboardsh/electrobun/issues/515) reports the signing setup exposing a personal Apple ID credential. |
+| **Windows** | **No code signing at all.** No Authenticode, no SignTool integration. Binaries ship unsigned, which means SmartScreen warnings and no trust chain. |
+| **Linux** | No GPG signing and no repository integration. |
+
+The Windows position is the sharpest practical problem after the updater: an unsigned
+Windows binary is an immediate friction point for any non-technical audience.
+
+### Runtime Dependencies
+
+Windows assumes the Evergreen WebView2 runtime is already installed and **bundles no
+bootstrapper**. On a machine without it, the app does not run.
+Linux requires GTK3, WebKitGTK 4.1, Ayatana AppIndicator, and librsvg.
+
+* * *
+
+## 6. What Shipping Apps Actually Do
+
+The ecosystem is real but small.
+Roughly 200 repositories appear in the dependents graph, but most are single-star
+experiments; the honest count of maintained, non-trivial open-source applications is
+about a dozen.
+
+| Project | Stars | Why it is worth reading |
+| --- | --- | --- |
+| [co(lab)](https://github.com/blackboardsh/colab) | 203 | Blackboard’s own product: browser plus Monaco plus PTY terminal. The maintainer dogfooding the framework is the strongest existence proof available. In developer preview. |
+| [llm-space](https://github.com/deer-flow/llm-space) | 1.6k | Largest community app. Monorepo structure, React. |
+| [dev-3.0](https://github.com/h0x91b/dev-3.0) | 243 | Parallel AI coding agent control panel; React 19, terminal embedding. |
+| [guerillaglass](https://github.com/okikeSolutions/guerillaglass) | 10 | **The best sidecar reference.** Swift sidecars on macOS plus Rust sidecars cross-platform. |
+| [spectrum](https://github.com/fmsouza/spectrum) | 6 | **Signed and notarized macOS releases**—the clearest worked example of shipping. |
+| [MaplatEditor](https://github.com/code4history/MaplatEditor) | 17 | An in-progress migration from Electron; useful for seeing what does and does not port. |
+
+Patterns that recur across these projects:
+
+- **React plus Tailwind plus Vite**, with Vite output mapped in through `build.copy`.
+  The official templates offer Vue, Svelte, Solid, and Angular, but the community
+  converged on React.
+- **`bundleCEF: false`** on macOS and Windows, relying on system webviews.
+- **`mainProcess: "cottontail"`**, not Bun.
+- **Developer and AI tooling dominates.** Almost every non-trivial app is a developer
+  tool, which reflects the early-adopter audience rather than a limitation of the
+  framework.
+- **macOS-first.** Several projects are macOS-only, and cross-platform support in
+  practice trails the matrix on paper.
+
+No widely recognised consumer product has been publicly identified as built on
+Electrobun.
+
+* * *
+
+## 7. Maturity and Risk
+
+This section exists because for Electrobun, unlike Electron or Tauri, project risk is a
+first-order engineering consideration rather than a footnote.
+
+**Signals of genuine capability.** Roughly 12,700 stars and about 2,300 commits.
+The native layer is substantial real engineering: a 4,100-line Zig core, three
+platform-specific native wrappers, over 100 FFI bindings, working CEF integration with
+per-platform linking strategies.
+The typed RPC design is cleaner than Electron’s IPC. Version 1.0 shipped 2026-01-28 and
+the line has continued to 1.18.1.
+
+**Signals of risk.**
+
+- **Bus factor of one.** Every sampled period shows a single author writing the
+  overwhelming majority of commits.
+  The contribution policy explicitly warns that pull requests requiring excessive review
+  effort “will be ruthlessly closed without explanation,” and no response timelines are
+  offered.
+- **No external funding identified.** The backing company is the maintainer’s own.
+- **86 open issues against roughly a dozen visibly closed**, including security issues
+  (#515, #518), platform crashes (#490), and an architectural FFI problem (#520).
+- **No CHANGELOG and no migration guides.** Release notes are auto-generated commit
+  ranges, so evaluating an upgrade means reading diffs.
+- **Version numbers carry no contract.** The project went 0.13.0 to 1.0.0 in two days
+  and skips numbers freely.
+  Majors mark feature milestones, not API stability.
+- **Documentation trails the source**, including on the config schema.
+- **The maintainer describes the project as “10% of the vision”** in `CONTRIBUTING.md`.
+- **A runtime migration is in flight.** The 2.0 line is decoupling from Bun in response
+  to Bun’s Zig-to-Rust core rewrite, which the maintainer has cited publicly.
+  Whatever the merits, a framework changing its main-process runtime mid-flight is a
+  moving target.
+
+None of this says the project is bad.
+It says the risk profile is that of an early-stage single-maintainer project, and it
+should be evaluated on those terms rather than on its star count.
+
+* * *
+
+## Best Practices
+
+- [ ] Pin an exact version.
+  Semver gives you no protection here.
+- [ ] Read the diff before upgrading; there is no CHANGELOG.
+- [ ] Verify config-schema questions against the templates in the repository, not the
+  published docs.
+- [ ] Keep the RPC surface narrow and named; validate every payload in the main process.
+- [ ] Never load remote or untrusted content into an RPC-enabled webview.
+- [ ] Set a CSP explicitly; the framework provides none.
+- [ ] Use navigation rules to pin the app to `views://`.
+- [ ] **Disable the updater** unless you have independently verified that signature
+  verification has landed.
+- [ ] Measure your real bundle size rather than citing the headline figure.
+- [ ] On Windows, expect unsigned binaries and plan for SmartScreen friction.
+- [ ] Confirm the Evergreen WebView2 runtime is present on target Windows machines.
+- [ ] Test on every platform you ship; the support matrix is narrower than it looks.
+
+* * *
+
+## Open Research Questions
+
+1. **Will the updater gain signature verification, and when?** This single question
+   governs whether Electrobun can be recommended for public distribution.
+   Recheck `Updater.ts` on every upgrade.
+
+2. **What does the closed-source Hutch CLI do at signing time?** macOS entitlements,
+   hardened runtime flags, and nested-binary signing are all unverifiable from source
+   today.
+
+3. **Does Cottontail change the performance and compatibility story versus Bun?** It is
+   now the default runtime, but there is no published comparison of JavaScriptCore-based
+   Cottontail against Bun for real workloads.
+
+4. **How stable is the 2.0 config schema?** The templates on `main` and the published
+   documentation disagree, and 2.0 has no stable release.
+
+5. **Does the Bun decoupling reduce or increase risk?** Removing the dependency on a
+   runtime undergoing a core rewrite is defensible, but it means the default runtime is
+   now a bespoke one maintained by the same single person.
+
+* * *
+
+## Recommendations
+
+### When Electrobun Is a Reasonable Choice
+
+- Internal tools and prototypes where you control distribution and can update out of
+  band.
+- Apps for a technical, trusted audience, shipped without the auto-updater.
+- macOS-first developer tooling, which is where the framework and its community are
+  strongest.
+- Cases where bundle size genuinely dominates and you have measured that Electrobun
+  actually delivers it for your app.
+- Exploratory work where you want the typed RPC ergonomics and can absorb churn.
+
+### When to Choose Something Else
+
+- **Anything security-sensitive**, because of the update path, the absent context
+  isolation, and the sandbox/RPC exclusivity.
+- **Consumer software distributed at scale**, where unsigned Windows binaries and an
+  unverified updater are not acceptable.
+- **Long-lived products with small teams**, where a bus factor of one in a core
+  dependency is a real risk.
+- **Linux-first products**, where you lose the size advantage to CEF and get no
+  package-manager integration.
+- **Anything needing broad platform coverage**, given macOS arm64-only, Windows
+  x64-only, and Ubuntu 24.04+.
+
+Choose **Electron** when you need maturity, ecosystem, signing and update
+infrastructure, and a security model with real defaults; see
+`tbd guidelines electron-app-development-patterns`. Choose **Tauri** when you want a
+small bundle with a multi-maintainer project and an update path that verifies what it
+installs.
+
+### If You Adopt It
+
+Pin an exact version, disable the updater, ship signed on macOS and accept unsigned on
+Windows, keep the RPC surface minimal, never load remote content, and budget time for
+platform-specific bugs that a larger project would have found already.
+
+* * *
+
+## References
+
+### Official
+
+- [Electrobun documentation](https://framework.blackboard.sh/electrobun/)
+- [Architecture overview](https://framework.blackboard.sh/electrobun/guides/architecture/overview/)
+- [Build configuration](https://framework.blackboard.sh/electrobun/apis/cli/build-configuration/)
+- [Source repository](https://github.com/blackboardsh/electrobun)
+- [v1 announcement](https://blackboard.sh/blog/electrobun-v1/)
+
+### Issues Cited
+
+- [#515: code signing setup exposes a personal Apple ID credential](https://github.com/blackboardsh/electrobun/issues/515)
+- [#518: RPC WebSocket transport security](https://github.com/blackboardsh/electrobun/issues/518)
+- [#520: Bun FFI eager symbol binding breaks non-macOS loading](https://github.com/blackboardsh/electrobun/issues/520)
+- [#484: Windows white bands during resize](https://github.com/blackboardsh/electrobun/issues/484)
+- [#490: Windows Dev Drive path corruption crash](https://github.com/blackboardsh/electrobun/issues/490)
+- [#485: macOS x86_64 launch crashes](https://github.com/blackboardsh/electrobun/issues/485)
+
+### Projects Surveyed
+
+- [co(lab)](https://github.com/blackboardsh/colab),
+  [llm-space](https://github.com/deer-flow/llm-space),
+  [dev-3.0](https://github.com/h0x91b/dev-3.0),
+  [guerillaglass](https://github.com/okikeSolutions/guerillaglass),
+  [spectrum](https://github.com/fmsouza/spectrum),
+  [MaplatEditor](https://github.com/code4history/MaplatEditor)
+
+## Related Guidelines
+
+- For Electron, see `tbd guidelines electron-app-development-patterns`
+- For dependency policy, see `tbd guidelines supply-chain-hardening`
+- For TypeScript conventions, see `tbd guidelines typescript-rules`
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/packages/tbd/docs/guidelines/electron-app-development-patterns.md
+++ b/packages/tbd/docs/guidelines/electron-app-development-patterns.md
@@ -397,6 +397,27 @@ the Electron binary in Node mode.
 `utilityProcess` is the supported path that survives hardening, which makes it the right
 default rather than merely the modern one.
 
+### Wrapping an Existing Local Web App
+
+A recurring case deserves its own name: the product is already a local server plus a
+browser UI—a tool normally launched from the CLI and used at `http://127.0.0.1:{port}`.
+Wrapping one in a desktop shell is the thinnest possible Electron app, and three rules
+keep it that way:
+
+- **The shell is a window plus lifecycle, nothing more.** One `BrowserWindow` pointed at
+  the loopback URL, plus tray, menus, file associations, and single-instance handling.
+  There is no IPC surface to design; the page already talks to the server over HTTP.
+- **Keep the frontend framework-free.** If the page never imports Electron APIs and
+  speaks only HTTP and WebSocket to its server, the shell stays a commodity: it can be
+  replaced by another shell—or by a plain browser tab—without touching the product.
+  The moment the frontend calls shell APIs, you have coupled the UI to one framework.
+- **If the product also runs shell-less** (installed from a package registry and opened
+  in a normal browser), keep that tier working.
+  The shell is then one consumer of the same server, not a fork of it.
+
+Everything in [Local Server Security](#local-server-security) applies with full
+force—wrapping a server in a shell does not make its loopback port private.
+
 ### Node Backends
 
 `utilityProcess` has been stable since Electron 22. It runs a Node script in a Chromium
@@ -479,6 +500,13 @@ Note the signing consequence: a Python tree contains many Mach-O objects (the
 interpreter plus every compiled extension module’s `.so`). Every one of them must be
 signed. See [Signing Nested Binaries](#signing-nested-binaries).
 
+On performance: before considering a rewrite of a Python backend in a compiled language,
+move the measured hot paths into **native wheels** (Rust via PyO3/maturin is the current
+standard—`pydantic-core` and `watchfiles` are the pattern).
+Wheels flow through the same environment, lockfile, and update chain as every other
+dependency, and they leave the backend hackable in Python—which is often part of the
+product, not an implementation detail.
+
 ### Compiled Sidecars
 
 Go and Rust backends are the least troublesome sidecars: a single static binary, no
@@ -527,6 +555,39 @@ const binDir = app.isPackaged
 ([electron-builder#1790](https://github.com/electron-userland/electron-builder/issues/1790)).
 Fix it in an `afterPack` hook, and defensively `fs.chmodSync(bin, 0o755)` before
 spawning on non-Windows.
+
+### Runtime-Extensible Apps: The Two-Layer Artifact
+
+If users install plugins that are real packages—Python wheels, npm modules, anything a
+package manager materializes on disk—one rule reshapes the whole packaging design:
+**never write into the app bundle after it is signed.** On macOS, installing anything
+into the `.app` breaks the code-signature seal; on every platform it collides with how
+updaters replace the install atomically.
+
+Split the artifact in two:
+
+- **Immutable layer, inside the signed bundle**: the shell, the runtime tree (for
+  example a python-build-standalone interpreter), a pinned copy of the package installer
+  itself (for example a `uv` binary), the application code, and a **hash-pinned
+  lockfile** for the base environment.
+- **Mutable layer, in per-user app data**: a real environment, materialized on first run
+  by the bundled installer syncing the bundled lock.
+  Plugins install here at runtime, through the same installer.
+
+This split preserves a clean **update-integrity chain**: shell updates arrive through
+the platform’s signed updater; each shell version carries a new hash-pinned lock; the
+bundled installer applies only what that signed lock names.
+The only code outside the chain is what the user explicitly chose to install—which is
+the package manager’s own trust model, stated honestly rather than laundered through
+your updater.
+
+Two consequences to plan for.
+Native code loaded from the mutable layer runs inside your signed processes, so on macOS
+the loading process needs `com.apple.security.cs.disable-library-validation` (see
+[Signing Nested Binaries](#signing-nested-binaries))—without it, natively compiled
+plugin packages fail to load under the hardened runtime.
+And first-run materialization is a real user-visible step: budget for progress UI and
+for recovery when it is interrupted.
 
 ### Signing Nested Binaries
 

--- a/packages/tbd/docs/guidelines/electron-app-development-patterns.md
+++ b/packages/tbd/docs/guidelines/electron-app-development-patterns.md
@@ -1746,6 +1746,8 @@ Pull request builds should package without signing, which is fast and needs no s
 
 - For monorepo setup with pnpm, see `tbd guidelines pnpm-monorepo-patterns`
 - For monorepo setup with Bun, see `tbd guidelines bun-monorepo-patterns`
+- For Tauri, see `tbd guidelines tauri-app-development-patterns`
+- For Electrobun, see `tbd guidelines electrobun-app-development-patterns`
 - For dependency policy, see `tbd guidelines supply-chain-hardening`
 - For TypeScript conventions, see `tbd guidelines typescript-rules`
 

--- a/packages/tbd/docs/guidelines/electron-app-development-patterns.md
+++ b/packages/tbd/docs/guidelines/electron-app-development-patterns.md
@@ -35,7 +35,7 @@ given as the pin, per [Supply-Chain Mitigation](#supply-chain-mitigation).
 | Tool / Package | Version | Check For Updates |
 | --- | --- | --- |
 | **Electron** | ^43.2.0 (43.3.0/43.4.0 too recent) | [releases.electronjs.org](https://releases.electronjs.org/)—**43.4.0** (2026-08-11) is current stable: Chromium 150, Node 24.18.1, V8 15.0. Supported majors are **41, 42, 43**; **41 reaches EOL 2026-08-25**, so 42 is the practical floor. 44 is in beta and **drops macOS 12, 32-bit Windows (ia32), and linux-armv7l**. Security fixes ship on the supported line only—track the latest patch, not just the major. |
-| **Node.js (host toolchain)** | 24 (LTS “Krypton”) | [nodejs.org/releases](https://nodejs.org/en/about/previous-releases)—Node 24 Active LTS (EOL Apr 2028; moves to maintenance when Node 26 enters LTS in Oct 2026); Node 26 Current; Node 22 in maintenance; **Node 20 EOL 2026-03-24**. Note the Node version *inside* Electron is set by Electron, not by your host Node. |
+| **Node.js (host toolchain)** | 24 (LTS “Krypton”) | [nodejs.org/releases](https://nodejs.org/en/about/previous-releases)—Node 24 Active LTS (EOL Apr 2028; moves to maintenance when Node 26 enters LTS in Oct 2026); Node 26 Current; Node 22 in maintenance; **Node 20 EOL 2026-03-24**. Note the Node version *inside* Electron is set by Electron, not by your host Node (Electron 43.4.0 embeds Node 24.18.1). |
 | **electron-vite** | ^5.0.0 | [electron-vite.org](https://electron-vite.org/)—5.0.0 (2025-12-07). Supports Vite 7 and 8. Added `build.isolatedEntries` for multi-entry isolation and stronger bytecode string protection. 6.0.0-beta.1 exists; not stable. |
 | **vite-plugin-electron** | ^1.1.0 (1.1.1 too recent) | [github.com/electron-vite/vite-plugin-electron](https://github.com/electron-vite/vite-plugin-electron)—**Pinned to 1.1.0 (2026-06-24) per the 14-day rule**; 1.1.1 (2026-08-03) is 12 days old today. Same org as electron-vite, currently the more frequently released of the two. Auto-selects `rolldownOptions` on Vite 8+ and `rollupOptions` below. Use when you want a plugin inside a standard Vite project rather than a separate CLI. |
 | **Vite** | ^8.2.0 (8.2.1 too recent) | [vite.dev](https://vite.dev/blog/announcing-vite8)—Vite 8 (2026-03-12) ships **Rolldown as its sole bundler**, replacing the esbuild-for-dev / Rollup-for-prod split. Requires Node 20.19+ or 22.12+. |
@@ -545,11 +545,15 @@ Notarization rejects the bundle if any of them is unsigned.
 locations; TN2206 directs that scripts and other non-Mach-O executables belong in
 `Contents/Resources`. Since `extraResources` writes to `Contents/Resources`, a Mach-O
 sidecar placed there sits outside its canonical location.
-Signed nested Mach-O binaries under `Resources` do ship successfully in practice, so
-treat this as a risk to verify rather than a guaranteed rejection—but if you hit
-notarization errors about nested code, relocating the binary to `Contents/Frameworks` or
+In practice this passes notarization, and the evidence is stronger than “some apps get
+away with it”: every Electron app that ships a native module already places individually
+signed Mach-O `.node` files under `Contents/Resources/app.asar.unpacked`—asar archives
+cannot be `dlopen`ed, so unpacking them is mechanical necessity—and those apps, Signal
+with `better-sqlite3` among the ones surveyed here, notarize and ship.
+Notarization checks that each Mach-O it finds is signed with the hardened runtime; it
+does not reject binaries for living under `Resources`. If an unusual layout does produce
+a nested-code error, relocating the binary to `Contents/Frameworks` or
 `Contents/Helpers` in an `afterPack` hook is the standard fix.
-See [Open Research Questions](#open-research-questions).
 
 **Hardened runtime and entitlements.** Notarization requires signing with
 `--options runtime`. Electron’s V8 needs, at minimum:
@@ -866,9 +870,11 @@ Node, so a module built for your system Node will fail to load inside Electron.
   Prefer dependencies that ship them.
 - **For SQLite, check `node:sqlite` first.** It is built into Node, so it needs no
   rebuild step and no native dependency at all.
-  It reached release-candidate stability in Node and ships in the Node embedded in
-  current Electron. Use `better-sqlite3` when you need its richer API—transactions
-  wrapper, user-defined function options, BigInt control—and accept the rebuild step.
+  In the Node line Electron 43 embeds (24.18.1 as of Electron 43.4.0), `node:sqlite` is
+  at **Stability 1.2, release candidate**, promoted at Node 24.15.0—so treat the API as
+  settling rather than frozen, and keep data access behind a thin wrapper.
+  Use `better-sqlite3` when you need its richer API—transactions wrapper, user-defined
+  function options, BigInt control—and accept the rebuild step.
   This single change removes the most common source of native-module pain in Electron
   apps.
 
@@ -1136,27 +1142,16 @@ Wails and Neutralino are not covered.
 
 ## Open Research Questions
 
-1. **Do Mach-O sidecars under `Contents/Resources` reliably pass notarization?** Apple’s
-   TN2206 designates `Resources` for scripts and non-Mach-O executables, yet signed
-   binaries placed there by `extraResources` are widely shipped.
-   Resolving this needs a controlled test: notarize one build with a Mach-O sidecar in
-   `Resources` and another with it relocated to `Contents/Helpers`, and compare.
-
-2. **Is `node:sqlite` at full stability in the Node embedded in Electron 43?** It
-   reached release-candidate status in Node and stabilized in later Node versions than
-   Electron 43 embeds. Confirm before recommending it without qualification for
-   production data.
-
-3. **When does the Bun `--compile` macOS 27 signature defect
+1. **When does the Bun `--compile` macOS 27 signature defect
    ([bun#32159](https://github.com/oven-sh/bun/issues/32159)) land a fix?** This gates
    Bun-compiled sidecars on the newest macOS.
 
-4. **Will electron-builder 27 ship, and on what timeline?** The alpha has been in
+2. **Will electron-builder 27 ship, and on what timeline?** The alpha has been in
    progress for a while.
    Its ESM migration and consolidated signing config are worth adopting, but not before
    it is stable.
 
-5. **Does Electron Forge 8 close the gap with electron-builder** on Linux targets and
+3. **Does Electron Forge 8 close the gap with electron-builder** on Linux targets and
    differential updates?
    If so, the default recommendation here should move to the officially supported tool.
 

--- a/packages/tbd/docs/guidelines/electron-app-development-patterns.md
+++ b/packages/tbd/docs/guidelines/electron-app-development-patterns.md
@@ -1,841 +1,1698 @@
 ---
 title: Electron App Development Patterns
-description: Guidelines for Electron development ecosystems including npm, pnpm, and Bun, with security baselines and framework comparisons
+description: Building a clean, minimal, standalone Electron app—process model, modern Vite-based build system, attaching a Node/Bun/Python backend, security baseline, packaging, code signing, and auto-update
+author: Joshua Levy (github.com/jlevy) with LLM assistance
 category: electron
 ---
 # Electron App Development Patterns
 
-Modern Electron app development: package manager ecosystems (npm, pnpm, Bun),
-alternative frameworks (Electrobun, Tauri), and security best practices.
-Use this when building desktop applications with Electron or evaluating lightweight
-alternatives.
+**Last Updated**: 2026-08-16
 
-## Document Structure
+**Related**:
 
-This guideline is organized in three parts:
+- [Electron Documentation](https://www.electronjs.org/docs/latest/)
+- [Electron Security Checklist](https://www.electronjs.org/docs/latest/tutorial/security)
+- [electron-vite](https://electron-vite.org/)
+- [electron-builder](https://www.electron.build/)
+- [Electron Forge](https://www.electronforge.io/)
+- [Companion: pnpm Monorepo Patterns](https://github.com/jlevy/tbd/blob/main/packages/tbd/docs/guidelines/pnpm-monorepo-patterns.md)
+- [Companion: Supply-Chain Hardening](https://github.com/jlevy/tbd/blob/main/packages/tbd/docs/guidelines/supply-chain-hardening.md)
 
-1. **Part 1: Verified Facts**—Technical details verified through direct testing, source
-   code analysis, and documented issue reports
-2. **Part 2: Third-Party Perspectives**—Community opinions and blog posts, clearly
-   marked as such
-3. **Part 3: Analysis and Recommendations**—Decision frameworks and recommendations
-   based on available evidence, with explicit uncertainty acknowledgment
+* * *
 
-## Research Methodology
+## Updating This Document
 
-### Primary Sources (Direct Verification)
+Electron ships a major version every 8 weeks and supports only the latest three, so this
+document goes stale faster than most.
+Recheck it at least every two majors.
 
-| Source | Verification Method |
-| --- | --- |
-| Electron 39.x + macOS 14.x | Direct testing on local machine + CI comparison |
-| craft-agents-oss | Full source code analysis (`/repos/craft-agents-oss`) |
-| Electrobun | Full source code analysis (`/repos/electrobun`) |
-| GitHub issue reports | Reviewed error messages and reproduction steps |
-| tbd guidelines | bun-monorepo-patterns, pnpm-monorepo-patterns |
+### Last Researched Versions
 
-### Verification Confidence Levels
+Versions observed 2026-08-16 by querying the npm registry and official release pages
+directly. Where the newest release is younger than 14 days, the older aged version is
+given as the pin, per [Supply-Chain Mitigation](#supply-chain-mitigation).
 
-- **Verified**: Directly tested or confirmed in source code
-- **Documented**: Appears in issue trackers with reproduction steps
-- **Reported**: Community reports without independent verification
-
-# Part 1: Verified Facts
-
-## 1. Electron Architecture Fundamentals
-
-### How Electron Works (Verified)
-
-Electron applications consist of three process types:
-
-```
-┌─────────────────────────────────────────────────┐
-│                Electron Application              │
-├─────────────────────────────────────────────────┤
-│  Main Process (Node.js)                         │
-│  ├── App lifecycle (app.whenReady, etc.)        │
-│  ├── Window management (BrowserWindow)          │
-│  ├── Native OS integration                      │
-│  └── IPC main-side handlers                     │
-├─────────────────────────────────────────────────┤
-│  Preload Scripts (Node.js, sandboxed)           │
-│  ├── contextBridge API exposure                 │
-│  └── IPC bridge to renderer                     │
-├─────────────────────────────────────────────────┤
-│  Renderer Process (Chromium)                    │
-│  ├── HTML/CSS/JavaScript                        │
-│  └── Web application (React, Vue, etc.)         │
-└─────────────────────────────────────────────────┘
-```
-
-**Critical fact**: Main and preload processes execute in **Node.js**, not Bun.
-Even when using Bun for package management, Electron itself runs Node.js internally.
-
-### Module Format Requirements (Verified)
-
-| Process | Runtime | Required Format | Reason |
-| --- | --- | --- | --- |
-| Main | Node.js | CJS or ESM | Electron loads via Node.js |
-| Preload | Node.js | CJS or ESM | Sandboxed Node.js context |
-| Renderer | Chromium | ESM (preferred) | Web standard |
-
-## 2. Package Manager Technical Characteristics
-
-### npm (Verified)
-
-**Technical implementation:**
-- Flat `node_modules` with hoisting
-- `package-lock.json` for determinism
-- No symlinks (copies files directly)
-- Electron tooling designed natively for npm
-
-**Electron compatibility**: Full support for all Electron tooling
-
-### pnpm (Verified)
-
-**Technical implementation:**
-- Content-addressable store (`~/.local/share/pnpm/store`)
-- Symlinks from `node_modules` to store
-- Strict dependency isolation (no phantom dependencies)
-- `pnpm-lock.yaml` for determinism
-
-**Electron compatibility**: Full support.
-electron-builder works without modification.
-
-**Required configuration (`.npmrc`):**
-```ini
-save-workspace-protocol=true
-prefer-workspace-packages=true
-```
-
-### Bun (Verified)
-
-**Technical implementation:**
-- Flat `node_modules` (similar to npm)
-- `bun.lock` (JSONC format since Bun 1.2, text-based and diffable)
-- Native TypeScript execution (no transpilation for scripts)
-- Reported 5-10x faster installs than npm (vendor claim; varies by workload)
-
-**Electron compatibility**: Partial.
-See “Verified Compatibility Issues” below.
-
-## 3. Verified Compatibility Issues
-
-### 3.1 Electron 39.x + macOS 14.x Incompatibility
-
-**Status**: Verified via direct testing
-
-**Test environment comparison:**
-
-| Factor | Local (FAILED) | CI (PASSED) |
+| Tool / Package | Version | Check For Updates |
 | --- | --- | --- |
-| macOS | 14.6 (Darwin 23.6.0) | 15.7.3 (Darwin 24.x) |
-| Node.js | 22.22.0 | 22.x |
-| Electron | 39.5.1 | 39.5.1 |
-| npm | 10.9.4 | ~10.x |
-| Architecture | ARM64 | ARM64 |
+| **Electron** | ^43.2.0 (43.3.0/43.4.0 too recent) | [releases.electronjs.org](https://releases.electronjs.org/)—**43.4.0** (2026-08-11) is current stable: Chromium 150, Node 24.18.1, V8 15.0. Supported majors are **41, 42, 43**; **41 reaches EOL 2026-08-25**, so 42 is the practical floor. 44 is in beta and **drops macOS 12, 32-bit Windows (ia32), and linux-armv7l**. Security fixes ship on the supported line only—track the latest patch, not just the major. |
+| **Node.js (host toolchain)** | 24 (LTS “Krypton”) | [nodejs.org/releases](https://nodejs.org/en/about/previous-releases)—Node 24 Active LTS until Apr 2028; Node 26 Current (LTS Oct 2026); Node 22 in maintenance; **Node 20 EOL 2026-03-24**. Note the Node version *inside* Electron is set by Electron, not by your host Node. |
+| **electron-vite** | ^5.0.0 | [electron-vite.org](https://electron-vite.org/)—5.0.0 (2025-12-07). Supports Vite 7 and 8. Added `build.isolatedEntries` for multi-entry isolation and stronger bytecode string protection. 6.0.0-beta.1 exists; not stable. |
+| **vite-plugin-electron** | ^1.1.1 | [github.com/electron-vite/vite-plugin-electron](https://github.com/electron-vite/vite-plugin-electron)—1.1.1 (2026-08-03). Same org as electron-vite, currently the more frequently released of the two. Auto-selects `rolldownOptions` on Vite 8+ and `rollupOptions` below. Use when you want a plugin inside a standard Vite project rather than a separate CLI. |
+| **Vite** | ^8.2.0 (8.2.1 too recent) | [vite.dev](https://vite.dev/blog/announcing-vite8)—Vite 8 (2026-03-12) ships **Rolldown as its sole bundler**, replacing the esbuild-for-dev / Rollup-for-prod split. Requires Node 20.19+ or 22.12+. |
+| **Rolldown** | ^1.2.1 (1.2.2+ too recent) | [rolldown.rs](https://rolldown.rs/)—1.0 stable May 2026; 1.2.4 (2026-08-12) newest. Adopted Rollup’s plugin API, so most Vite plugins work unmodified. Maintained by VoidZero, **acquired by Cloudflare 2026-06-04**; tools remain MIT. |
+| **esbuild** | ^0.28.1 (0.28.2 too recent) | [github.com/evanw/esbuild/releases](https://github.com/evanw/esbuild/releases)—still pre-1.0. No longer inside Vite’s production path, but still the simplest standalone choice for bundling a main process without adopting a framework. |
+| **electron-builder** | ^26.15.7 | [electron.build](https://www.electron.build/)—**The `latest` dist-tag points at 26.15.3 (2026-06-09) while 26.15.7 (2026-07-18) is the newest v26**, published under a separate `v26` tag; a bare `npm i electron-builder` therefore pins lower than you may expect. 27.0.0-alpha.6 is in progress: native ESM, Node 22.12+, signing consolidated under `mac.sign`/`win.sign`, APFS DMGs, MSIX target, Azure Artifact Signing via `signtool /dlib`, and an `electron-builder migrate-schema` CLI. |
+| **electron-updater** | ^6.8.9 | [npmjs.com/package/electron-updater](https://www.npmjs.com/package/electron-updater)—6.8.9 (2026-06-05). 7.0.0-alpha.5 tracks electron-builder 27. |
+| **Electron Forge** | ^7.11.2 | [electronforge.io](https://www.electronforge.io/)—7.11.2 (2026-05-20). 8.0.0-alpha.10 targets Node 22.12+, ESM-only, and Vite 8. The Vite plugin is still marked experimental. Supports npm, Yarn Classic, and pnpm (since 7.7.0, requires hoisted `node_modules`); **Bun is not supported** ([forge#3906](https://github.com/electron/forge/issues/3906)). |
+| **@electron/packager** | ^20.0.4 (20.1.0+ too recent) | [npmjs.com/package/@electron/packager](https://www.npmjs.com/package/@electron/packager)—20.3.0 (2026-08-11) newest. The low-level bundler that Forge wraps; use directly only for a custom pipeline. |
+| **@electron/rebuild** | ^4.2.0 | [github.com/electron/rebuild](https://github.com/electron/rebuild)—4.2.0 (2026-07-07). Requires Node ≥22.12.0. |
+| **@electron/notarize** | ^3.1.1 | [github.com/electron/notarize](https://github.com/electron/notarize)—3.1.1 (2025-10-31). Wraps `xcrun notarytool`. |
+| **@electron/osx-sign** | ^2.6.0 | [github.com/electron/osx-sign](https://github.com/electron/osx-sign)—2.6.0 (2026-07-17). |
+| **@electron/fuses** | ^2.1.3 | [github.com/electron/fuses](https://github.com/electron/fuses)—2.1.3 (2026-06-29). |
+| **@electron/asar** | ^4.2.1 | [github.com/electron/asar](https://github.com/electron/asar)—4.2.1 (2026-07-21). ASAR integrity needs ≥3.1.0; the macOS integrity digest added in Electron 41 needs ≥4.1.0. |
+| **@electron/universal** | ^3.0.6 | [github.com/electron/universal](https://github.com/electron/universal)—3.0.6 (2026-07-02). Merges x64 and arm64 macOS builds. |
+| **update-electron-app** | ^3.3.0 | [github.com/electron/update-electron-app](https://github.com/electron/update-electron-app)—3.3.0 (2026-06-28). |
+| **Playwright** | ^1.62.1 | [playwright.dev](https://playwright.dev/docs/api/class-electron)—1.62.1 (2026-07-30). `_electron` is still an experimental namespace but is the standard way to drive a packaged app in tests. |
+| **better-sqlite3** | ^13.0.2 (13.0.3 too recent) | [npmjs.com/package/better-sqlite3](https://www.npmjs.com/package/better-sqlite3)—13.0.3 (2026-08-05) newest. Needs `@electron/rebuild`. Consider `node:sqlite` first (see [Native Modules](#native-modules)). |
+| **pnpm** | ^11.21.0 | [github.com/pnpm/pnpm/releases](https://github.com/pnpm/pnpm/releases)—pnpm 11 moved `nodeLinker` and `shamefullyHoist` out of `.npmrc` into `pnpm-workspace.yaml`, replaced `onlyBuiltDependencies` with `allowBuilds`, and made `strictDepBuilds` default to `true`. |
+| **npm** | ^12.0.2 | [npmjs.com/package/npm](https://www.npmjs.com/package/npm)—npm 12 (2026-07-08) **disables dependency install scripts by default** (`allowScripts`); approve with `npm approve-scripts`. |
+| **Bun** | ^1.3.14 | [bun.com/blog](https://bun.com/blog)—1.3.14 (2026-05-13). Fine as a package manager and as a sidecar runtime; **not** a supported driver for Forge, and still unreliable through electron-builder’s script hooks. |
 
-**Test code used:**
-```javascript
-const { app } = require('electron');
-console.log('app type:', typeof app);
-console.log('process.type:', process.type);
-console.log('electron version:', process.versions.electron);
+### Reminders When Updating
+
+1. **Recheck the Electron support window first.** Only the latest three majors get
+   fixes. If the version in the table has fallen out of that window, everything
+   downstream in this document is suspect.
+
+2. **Read the breaking-changes page for every major you skip**, at
+   [electronjs.org/docs/latest/breaking-changes](https://www.electronjs.org/docs/latest/breaking-changes).
+   Platform minimums and dropped architectures are the changes most likely to break a
+   shipping app.
+
+3. **Recheck platform minimums.** Electron follows Chromium’s OS deprecations, so the
+   macOS and Windows floors move roughly annually.
+
+4. **Reverify the security checklist**, which is versioned with the docs and gains items
+   over time.
+
+5. **Recheck fuse names and defaults**, which have changed as fuses were added.
+
+6. **Update code examples**, not just the table—versions appear in `package.json`
+   examples, the GitHub Actions workflow in Appendix F, and `electron-builder.yml`.
+
+7. **Honor the 14-day package-age rule** when bumping versions here, with the documented
+   exception for security fixes.
+   Electron itself frequently qualifies for that exception.
+
+8. **Review [Open Research Questions](#open-research-questions)** for anything now
+   settled.
+
+* * *
+
+## Executive Summary
+
+This document is a reference for building a **clean, minimal, standalone Electron
+desktop app** with a modern build system and a backend written in whatever language
+suits the problem—Node.js, Bun, Python, Go, or a combination.
+
+The recommended default: **Electron 43 + electron-vite + TypeScript +
+electron-builder**, with the renderer as an ordinary Vite web app, the main process as a
+thin bundled CommonJS entry point, a CommonJS preload exposing a narrow typed API over
+`contextBridge`, and any substantial backend work pushed into a **`utilityProcess`**
+(for Node) or a **signed sidecar executable** (for anything else).
+
+Three claims in this document are worth stating up front because they contradict advice
+that is still widely repeated:
+
+- **Electron’s security defaults have been correct for years.** `sandbox: true`,
+  `contextIsolation: true`, and `nodeIntegration: false` are all defaults.
+  The work is not turning them on.
+  It is refusing to turn them off, and designing a preload API narrow enough that an XSS
+  bug cannot escalate into code execution.
+
+- **`require('electron')` returning a file path is not a bug.** The npm package exports
+  the path to the Electron binary when it is loaded by plain Node.js.
+  Seeing a string instead of the API object means the script was run by `node`, not by
+  `electron`.
+
+- **The postinstall-binary problem is mostly over.** Since Electron 42, the npm package
+  downloads its binary lazily on first run rather than in a `postinstall` script.
+  This lands at the same time as npm 12, pnpm 11, and Bun all blocking dependency
+  lifecycle scripts by default, and it resolves that collision for current Electron.
+
+**Research questions this document answers**:
+
+1. What is the minimum coherent structure of a standalone Electron app in 2026, and what
+   builds what?
+
+2. Where should backend code live, and how do you ship a non-JavaScript runtime inside a
+   signed desktop app?
+
+3. What is the current security baseline beyond the three `webPreferences` flags
+   everyone quotes?
+
+4. What does it actually take to get a signed, notarized, auto-updating app onto three
+   platforms?
+
+* * *
+
+## 1. The Process Model
+
+### Four Process Types
+
+Electron is Chromium plus Node.js, and understanding which is which explains nearly
+every constraint in the rest of this document.
+
+| Process | Runtime | Has DOM | Has Node built-ins | Purpose |
+| --- | --- | --- | --- | --- |
+| **Main** | Node.js | No | Yes | App lifecycle, windows, menus, native OS integration, and the only process that may hold privileged capability. |
+| **Renderer** | Chromium | Yes | No (by default) | Your UI. Treat it as an ordinary web page that happens to be local. |
+| **Preload** | Node.js-adjacent, in the renderer’s context | Access to `window` | Limited (`electron`, and Node built-ins only when unsandboxed) | The bridge. Runs before page scripts and decides exactly what the renderer may ask for. |
+| **Utility** | Node.js | No | Yes | Background work: backends, parsers, watchers, anything you do not want blocking the main process. |
+
+The main process is a single-threaded event loop that also drives your window UI
+responsiveness. Blocking it blocks the app.
+This is the reason `utilityProcess` exists and the reason it belongs in your
+architecture early rather than as a later optimization.
+
+### What Runs Where
+
+A rule that resolves most confusion: **there is no Node.js in the renderer, and there
+should never be.** If the renderer needs to read a file, call an API with a secret, or
+spawn a process, it asks the main process to do it through a named, validated channel.
+
+### Module Format: The ESM Situation
+
+Electron has supported ESM since version 28, but support differs by process and the
+differences matter.
+
+| Process | ESM supported | How to opt in | Caveats |
+| --- | --- | --- | --- |
+| Main | Yes | `.mjs` extension or `"type": "module"` | ESM loads **asynchronously**. Only side effects of the entry point’s own imports run before the `ready` event, so anything that must happen pre-`ready` needs an explicit `await`. |
+| Preload | Yes, but | **`.mjs` extension only**—`"type": "module"` is ignored for preload | **Sandboxed preloads cannot use ESM at all.** They run as plain scripts and must use `require('electron')`. Unsandboxed ESM preloads run *after* page load on zero-length responses, and dynamic Node imports there require `contextIsolation: true`. |
+| Renderer | Yes | Native to Chromium | No Node built-ins, no `node_modules` resolution. Use a bundler. |
+
+The practical consequence is worth stating plainly: **if you keep `sandbox: true`—and
+you should—your preload is CommonJS.** This is not a limitation you are working around;
+it is the sandboxed preload contract.
+Bundle the preload to a single CJS file and stop thinking about it.
+
+For the main process, either format works.
+CommonJS output from a bundler is the lower-friction choice because it sidesteps the
+async-initialization caveat entirely, which is why most shipping apps still emit CJS
+there.
+
+### The Sandbox and the Preload Boundary
+
+With `sandbox: true` (the default since Electron 20), the renderer runs in an OS-level
+sandboxed process with no direct Node access, and the preload gets a polyfilled subset
+rather than full Node.
+
+`contextIsolation: true` (default since Electron 12) means the preload’s JavaScript
+context is separate from the page’s. The page cannot reach into preload internals by
+walking prototypes; the only crossing point is what you explicitly publish through
+`contextBridge`.
+
+That crossing point is your entire attack surface.
+Treat it as a network API boundary owned by a service that does not trust its callers,
+because that is exactly what it is.
+The common Electron security failure is not a missing flag—it is a preload that exposes
+something like `invoke(channel, ...args)` or `readFile(path)`, which converts any XSS in
+the renderer into arbitrary IPC or arbitrary file reads.
+
+* * *
+
+## 2. Reference Architecture for a Standalone App
+
+### Project Layout
+
+A single-package app.
+No monorepo until a second deliverable actually exists.
+
+```
+my-app/
+├── src/
+│   ├── main/
+│   │   ├── index.ts            # app lifecycle, windows
+│   │   ├── ipc.ts              # channel handlers, one per capability
+│   │   └── backend.ts          # utilityProcess or sidecar supervision
+│   ├── preload/
+│   │   └── index.ts            # contextBridge surface only
+│   ├── renderer/
+│   │   ├── index.html
+│   │   └── src/                # ordinary Vite web app
+│   └── shared/
+│       └── contract.ts         # IPC types shared by main and renderer
+├── resources/                  # icons, and any sidecar binaries
+├── build/                      # entitlements.plist, installer assets
+├── electron.vite.config.ts
+├── electron-builder.yml
+├── tsconfig.json               # references the three below
+├── tsconfig.node.json          # main + preload
+├── tsconfig.web.json           # renderer
+└── package.json                # "main": "./out/main/index.js"
 ```
 
-**Results:**
-- macOS 15.x: `app type: object`, `process.type: browser` → SUCCESS
-- macOS 14.x: `app type: undefined`, `process.type: undefined` → FAIL
+`src/shared/` is the important piece.
+It holds only types and constants—never runtime imports that pull Node built-ins into
+the renderer bundle—and it is what makes IPC type-safe on both ends without codegen.
 
-**Root cause analysis:**
-1. Electron binary executes (`npx electron --version` works)
-2. Node.js module interception does NOT activate
-3. `require('electron')` returns string (path) instead of API object
-4. JavaScript bridge initialization fails silently
+### Why Three Builds
 
-**Evidence**: CI run on macOS 15.7.3 demonstrating successful Electron 39.x execution
-(internal reference: actions/runs/21639950110)
+Main, preload, and renderer have different targets, so they get different builds:
 
-**Observed behavior**: Electron 39.5.1 fails to initialize on macOS 14.6 (arm64) while
-succeeding on macOS 15.7.3.
+- **Main** targets Node, externalizes `electron`, and bundles everything else so the
+  packaged app does not depend on `node_modules` layout.
+- **Preload** targets a browser-ish context, must emit a **single CJS file** under the
+  sandbox, and must externalize `electron`.
+- **Renderer** targets the browser and is an ordinary Vite build with code splitting,
+  asset hashing, and HMR.
 
-**Status**: Suspected bug or OS-specific regression.
-Electron’s official platform policy states v38+ requires macOS 12+, so macOS 14 should
-be supported. Needs upstream confirmation.
+Trying to serve all three from one config is the most common way Electron build setups
+become unmaintainable.
 
-**Next actions**:
-1. Test latest Electron 39 patch + Electron 40 on macOS 14
-2. Reproduce on a second macOS 14 machine
-3. File upstream Electron issue with minimal repro
+### Choosing a Build Tool
 
-### 3.2 electron-builder + Bun Segmentation Faults
+| Approach | Use when | Tradeoff |
+| --- | --- | --- |
+| **electron-vite** (recommended default) | You want one config covering all three targets, HMR for the renderer, and hot restart for main and preload, without adopting a full framework. | A separate CLI rather than plain `vite`. Release cadence is slower than `vite-plugin-electron`. |
+| **vite-plugin-electron** | You want to keep a stock Vite project and add Electron as a plugin. | You wire more of the three-target split yourself. |
+| **Electron Forge + `plugin-vite`** | You want build, package, make, and publish from one tool with official Electron backing. | The Vite plugin is still marked experimental; Forge is more opinionated about the whole pipeline. |
+| **Hand-rolled esbuild + Vite** | You have unusual constraints and want no framework at all. | You own the dev loop, the watch/restart logic, and the sourcemap wiring. This is a real cost that is easy to underestimate. |
 
-**Status**: Documented in GitHub issue tracker
+Forge is the Electron team’s own tool and the only one with official support, so it is
+the right answer when you want a single supported pipeline.
+electron-vite is the recommended default here because it does one job—building three
+targets well—and composes with electron-builder, which remains the more capable
+packager.
 
-**Source**: [oven-sh/bun#18249](https://github.com/oven-sh/bun/issues/18249) (March
-2025\)
+A complete `electron.vite.config.ts` is in
+[Appendix A](#appendix-a-electronviteconfigts).
 
-**Reported error:**
-```
-panic(main thread): Segmentation fault at address 0x0
-```
+### TypeScript Configuration
 
-**Context**: Occurs during electron-builder’s build phase on macOS
+Use project references so the renderer cannot accidentally import Node built-ins and the
+main process cannot accidentally import DOM globals.
+`tsconfig.node.json` covers `src/main`, `src/preload`, and `src/shared` with
+`"types": ["node", "electron"]`; `tsconfig.web.json` covers `src/renderer` and
+`src/shared` with `"lib": ["ESNext", "DOM", "DOM.Iterable"]` and no Node types.
+`src/shared` appears in both, which is exactly why it must stay type-only.
 
-**Analysis**: This is a crash in Bun’s runtime during electron-builder’s module
-scanning, not a configuration issue.
+### The Development Loop
 
-### 3.3 electron-builder Script Resolution Failure
+The dev loop you want:
 
-**Status**: Documented in GitHub issue tracker
+- Renderer edits apply through **HMR** without losing app state.
+- Preload edits **reload the renderer**, since the preload runs at document start.
+- Main edits **restart the Electron process**, since there is no way to hot-swap app
+  lifecycle code safely.
 
-**Source**: [oven-sh/bun#9895](https://github.com/oven-sh/bun/issues/9895) (April 2024)
+electron-vite implements all three.
+If you hand-roll, budget real time for the restart logic: debouncing rebuilds, waiting
+for the write to settle before relaunching, and killing the previous Electron instance
+cleanly.
 
-**Reported error:**
-```
-cannot execute cause=exit status 1 errorOut=error: Script not found "rebuild"
-```
+### Main Process Entry Point
 
-**Analysis**: electron-builder relies on npm lifecycle scripts that Bun resolves
-differently.
+The full annotated entry point is in [Appendix C](#appendix-c-main-process-entry-point).
+The parts that matter:
 
-### 3.4 electron-forge npm Version Check
-
-**Status**: Documented (Stack Overflow, verified in forge source)
-
-**Source**:
-[stackoverflow.com/questions/77295981](https://stackoverflow.com/questions/77295981/how-run-electron-js-with-bun)
-
-**Error:**
-```
-Incompatible version of NPM detected
-```
-
-**Analysis**: electron-forge explicitly checks for npm and rejects other package
-managers. This is intentional behavior.
-
-### 3.5 Lockfile Mismatches with Bun
-
-**Status**: Documented in Quasar issue tracker
-
-**Source**:
-[github.com/quasarframework/quasar/issues/17085](https://github.com/quasarframework/quasar/issues/17085)
-
-**Issue**: electron-builder creates UnPackaged folder with lockfile that doesn’t match
-the Bun lockfile.
-
-**Workaround**: `--no-frozen-lockfile` (defeats dependency pinning)
-
-### 3.6 Windows File Locking with Bun
-
-**Status**: Verified in craft-agents-oss codebase
-
-**Source**: Comment in `apps/electron/electron-builder.yml`
-
-**Error**: EBUSY when electron-builder tries to copy `bun.exe`
-
-**Solution implemented:**
-```yaml
-win:
-  files:
-    - "!vendor/bun/**/*"
-  extraResources:
-    - from: vendor/bun/bun.exe
-      to: vendor/bun/bun.exe
+```ts
+const win = new BrowserWindow({
+  show: false, // avoid the white flash; show on 'ready-to-show'
+  webPreferences: {
+    preload: path.join(__dirname, '../preload/index.cjs'),
+    // sandbox, contextIsolation, nodeIntegration are already correct by default.
+    // They are listed in Appendix C explicitly, as documentation, not as a fix.
+  },
+});
+win.once('ready-to-show', () => win.show());
 ```
 
-### 3.7 Development vs Production Build Behavior
+Load the renderer from the dev server in development and from a file (or better, a
+custom protocol) in production:
 
-**Status**: Reported by multiple community members
-
-**Sources**:
-- [Reddit: Electron app works in dev but fails after build](https://www.reddit.com/r/electronjs/comments/1gnm7g5/help_needed_electron_app_works_in_dev_but_fails/)
-- Community reports in Bun issues
-
-**Pattern observed**: Development builds (`bun run dev`, `electron .`) often work
-correctly, while production builds (`electron-builder`, packaging) fail with crashes or
-errors.
-
-**Analysis**: This suggests the issues are specifically in electron-builder’s
-packaging/bundling phase, not in Electron itself.
-Development mode doesn’t trigger the problematic code paths.
-
-### 3.8 Electron Installation Issues with Bun
-
-**Status**: Documented in GitHub issue tracker
-
-**Source**: [oven-sh/bun#1588](https://github.com/oven-sh/bun/issues/1588) - “Electron
-failed to install correctly”
-
-**Issue**: Early Bun versions had issues installing Electron’s native binaries correctly
-due to postinstall script handling differences.
-
-**Current status**: Partially resolved in newer Bun versions, but edge cases remain.
-
-## 4. Reference Implementation Analysis: craft-agents-oss
-
-**Source**: Full analysis of `/repos/craft-agents-oss`
-
-### Architecture (Verified from Source)
-
-```
-craft-agents-oss/
-├── apps/
-│   ├── electron/           # Electron desktop app
-│   │   ├── src/
-│   │   │   ├── main/       # → esbuild → dist/main.cjs
-│   │   │   ├── preload/    # → esbuild → dist/preload.cjs
-│   │   │   └── renderer/   # → Vite → dist/renderer/
-│   │   ├── electron-builder.yml
-│   │   └── vite.config.ts
-│   └── viewer/
-├── packages/
-│   ├── core/               # Types (no external deps)
-│   ├── shared/             # Business logic
-│   └── ui/                 # React components
-├── scripts/
-│   ├── electron-build-main.ts
-│   ├── electron-build-preload.ts
-│   └── electron-dev.ts
-├── bunfig.toml
-└── bun.lock
+```ts
+if (process.env.ELECTRON_RENDERER_URL) {
+  await win.loadURL(process.env.ELECTRON_RENDERER_URL);
+} else {
+  await win.loadFile(path.join(__dirname, '../renderer/index.html'));
+}
 ```
 
-### Build Configuration (Verified from Source)
+The security checklist prefers a custom protocol over `file://`, because `file://` pages
+carry extra privileges that a custom protocol does not.
+For a minimal app, `loadFile` is acceptable; for anything rendering untrusted content,
+register a custom protocol as standard and secure, and disable the
+`grantFileProtocolExtraPrivileges` fuse.
+This is what serious apps do—VS Code serves the workbench over `vscode-file://` and
+Element over `vector://`.
 
-**Main process build** (`scripts/electron-build-main.ts`):
-```typescript
-const proc = spawn({
-  cmd: [
-    "bun", "run", "esbuild",
-    "apps/electron/src/main/index.ts",
-    "--bundle",
-    "--platform=node",
-    "--format=cjs",
-    "--outfile=apps/electron/dist/main.cjs",
-    "--external:electron",
-  ],
+### Typed IPC Across the Context Bridge
+
+There is no dominant framework for typed Electron IPC, and you do not need one.
+This is not an aesthetic preference: of the production apps surveyed in
+[§8](#8-what-shipping-apps-actually-do), **none** use tRPC-over-IPC, comlink, or
+electron-trpc. Every one hand-writes a typed preload and gets its guarantees from
+TypeScript interfaces.
+A shared contract type plus a hand-written bridge gives full type safety in about thirty
+lines, with no runtime dependency and no magic.
+
+Define the contract once:
+
+```ts
+// src/shared/contract.ts — types only, no runtime imports
+export type Api = {
+  openProject: (id: string) => Promise<Project>;
+  saveNote: (note: NoteInput) => Promise<void>;
+  onProgress: (cb: (p: Progress) => void) => () => void;
+};
+```
+
+Expose exactly those in the preload, one named channel per capability
+([Appendix D](#appendix-d-preload-and-typed-ipc)), and validate on the main side:
+
+```ts
+ipcMain.handle('project:open', async (event, rawId) => {
+  assertSender(event); // checklist item 17: validate the sender
+  const id = ProjectId.parse(rawId); // validate the payload; never trust it
+  return openProject(id);
 });
 ```
 
-Key decisions:
-- **Format**: CJS (CommonJS) for Node.js compatibility
-- **Platform**: `node` (not browser)
-- **External**: Only `electron` is externalized
+Two rules make this safe:
 
-### Workarounds Implemented (Verified)
+- **Never expose a generic pass-through.** `invoke(channel, ...args)` on the bridge
+  defeats the entire boundary.
+- **Validate the sender and the payload in every handler.** A renderer displaying remote
+  content is untrusted input; so is a compromised renderer.
+  Use a schema validator (Zod or equivalent) rather than hand-rolled checks.
 
-| Issue | Solution in codebase |
-| --- | --- |
-| File write timing | Poll 3x (100ms each) to detect stabilization |
-| Syntax validation | `node --check` after bundling |
-| SDK path resolution | Explicit `setPathToClaudeCodeExecutable()` call |
-| Windows file locking | `extraResources` instead of `files` |
-| React duplication | Vite `resolve.dedupe` + explicit aliases |
+* * *
 
-### SDK Path Resolution Issue (Verified)
+## 3. Attaching a Backend
 
-**Problem**: Packages using `import.meta.url` break after esbuild bundling.
+This is the section the rest of the architecture exists to support: you have real
+work—indexing, inference, a database, a document pipeline, an existing Python
+codebase—and it needs to live somewhere that is not the main process and not the
+renderer.
 
-**Error observed:**
-```
-Error: The "path" argument must be of type string or an instance of URL. Received undefined
-```
+### Choosing a Mechanism
 
-**Solution in code:**
-```typescript
-const cliPath = join(process.cwd(), 'node_modules', '@anthropic-ai', 'claude-agent-sdk', 'cli.js');
-setPathToClaudeCodeExecutable(cliPath);
-```
-
-## 5. Electrobun Technical Analysis
-
-**Source**: Full analysis of `/repos/electrobun`
-
-**See also**:
-[Electrobun Desktop Framework Research](./research-2026-02-03-electrobun-desktop-framework.md)
-for detailed analysis including Anthropic/Bun acquisition implications, RPC system
-details, and build/distribution best practices.
-
-### Architecture (Verified from Source)
-
-```
-┌─────────────────────────────────────────────────┐
-│                Electrobun Application            │
-├─────────────────────────────────────────────────┤
-│  Main Process                                   │
-│  ├── Runtime: Bun (NOT Node.js)                 │
-│  ├── FFI calls to libNativeWrapper              │
-│  └── Window/view management                     │
-├─────────────────────────────────────────────────┤
-│  Webview (choose one)                           │
-│  ├── System: WKWebView / WebView2 / WebKitGTK   │
-│  └── CEF: Chromium Embedded Framework           │
-├─────────────────────────────────────────────────┤
-│  Native Bridge                                  │
-│  ├── macOS: Objective-C (nativeWrapper.mm)      │
-│  ├── Windows: C++ (nativeWrapper.cpp)           │
-│  └── Linux: C++ with GTK+                       │
-└─────────────────────────────────────────────────┘
-```
-
-**Key difference from Electron**: Electrobun uses Bun runtime directly, not Node.js.
-
-### Build Output Size (Verified from Build System)
-
-| Component | Size |
-| --- | --- |
-| Bun runtime | ~12MB |
-| System webview | 0 (uses OS) |
-| CEF (optional) | ~100MB+ |
-| **Total (system webview)** | **~12MB** |
-| **Total (with CEF)** | **~120MB** |
-
-### Platform Support (Verified from Source)
-
-| Platform | Architectures | System Webview | CEF |
-| --- | --- | --- | --- |
-| macOS | ARM64, x64 | WKWebView | Yes |
-| Windows | x64 (ARM via emulation) | WebView2 | Yes |
-| Linux | x64, ARM64 | WebKitGTK | Yes |
-
-### Update System (Verified from Source)
-
-Uses bsdiff for delta patches.
-Documentation claims ~14KB patches for small changes (not independently verified).
-
-### Known Technical Limitations (from Source Code Comments)
-
-1. **Bun FFI threading**: JSCallback has memory issues during concurrent operations
-   - Workaround in code: 2ms delay for resize events
-2. **WebView2 requirement**: Windows requires runtime installed
-3. **Linux launcher**: Requires bash wrapper for LD_PRELOAD handling
-
-### Reported Stability Issues
-
-**Source**: [oven-sh/bun#24876](https://github.com/oven-sh/bun/issues/24876) (November
-2025\)
-
-**Issue**: Crash reports on macOS with Apple Silicon (M2 Pro specifically)
-
-**Status**: Resolved in Electrobun 0.1.21-beta.0+ (closed as duplicate of #21068).
-Demonstrates that Electrobun is actively maintained with platform-specific issues being
-addressed.
-
-### Current Version
-
-**As of 2026-02-03:** ~0.0.19-beta.x (see
-[GitHub releases](https://github.com/blackboardsh/electrobun/releases))
-
-**Note:** Version numbers in npm/GitHub may appear inconsistent.
-The project uses prerelease tags; treat as beta regardless of semver appearance.
-
-## 6. Alternative Lightweight Frameworks
-
-### Buntralino
-
-**Source**: [buntralino.github.io](https://buntralino.github.io)
-
-**What it is**: Combines Bun with [Neutralino.js](https://neutralino.js.org) as a
-lighter Electron alternative.
-
-**Architecture**:
-- Uses Bun for backend/main process
-- Uses Neutralino.js for the webview layer
-- Neutralino.js uses system webviews (like Electrobun and Tauri)
-
-**Bundle size**: Smaller than Electron (~5-10MB range)
-
-**Maturity**: Early stage, smaller community than Electrobun
-
-**When to consider**: If you want Bun runtime but Electrobun doesn’t meet your needs
-
-### Tauri (for comparison)
-
-**Source**: [tauri.app](https://tauri.app)
-
-**What it is**: Rust-based desktop framework using system webviews
-
-**Relevance**: Often compared to Electrobun; uses similar system webview approach but
-with Rust backend instead of Bun
-
-**Bundle size**: ~5-10MB
-
-**Maturity**: More mature than Electrobun (1.0+ released)
-
-### Desktop Support Discussion in Bun
-
-**Source**: [oven-sh/bun#790](https://github.com/oven-sh/bun/discussions/790) - “Desktop
-support (Electron replacement)”
-
-**Context**: Long-running discussion about native desktop app support in Bun ecosystem.
-Shows community interest and various approaches being explored.
-
-## 7. Summary of Verified Facts
-
-### Package Manager Electron Support
-
-| Package Manager | electron-builder | electron-forge | Stability |
-| --- | --- | --- | --- |
-| npm | Full | Full | High |
-| pnpm | Full | Supported | High |
-| Bun | Crashes/issues | Blocked | Low |
-
-### Electron Version + macOS Compatibility (Observed)
-
-*Note: Based on local testing and CI runs.
-Official Electron policy states v38+ requires macOS 12+, so all versions below should
-theoretically be supported.*
-
-| Electron | macOS 14.x | macOS 15.x | Notes |
-| --- | --- | --- | --- |
-| 34.x | ✅ | ✅ | Stable |
-| 37-38.x | ✅ | ✅ | Stable |
-| 39.x | ⚠️ | ✅ | Observed failure on 14.x (see Section 3.1) |
-
-⚠️ = Issue observed in our environment; not confirmed as intentional platform drop.
-
-### Bundle Size Comparison
-
-| Framework | Minimum Bundle |
-| --- | --- |
-| Electron | ~150MB |
-| Electrobun (system webview) | ~12MB* |
-| Electrobun (with CEF) | ~120MB* |
-
-*Vendor-claimed values from [Blackboard](https://blackboard.sh/opensource/). Independent
-verification recommended for production decisions.
-
-### Update Mechanisms
-
-Electron update payloads are typically large because the runtime is bundled, but
-differential update mechanisms exist:
-
-- **Squirrel deltas**: Built-in support via `autoUpdater` for macOS/Windows
-  ([docs](https://electronjs.org/docs/latest/tutorial/updates))
-- **electron-updater blockmap**: Differential downloads for NSIS targets
-  ([docs](https://www.electron.build/auto-update.html))
-
-These can reduce downloads to MB-to-tens-of-MB range (vs full ~~150MB), but not KB-level
-like Electrobun’s bsdiff patches (which claim ~~14KB for small changes).
-
-# Part 2: Third-Party Perspectives
-
-*Note: The following represents community opinions and blog posts, not independently
-verified facts.*
-
-## Community Reports on Bun + Electron
-
-### electron-forge Issue #3906 (April 2025)
-
-**Source**:
-[github.com/electron/forge/issues/3906](https://github.com/electron/forge/issues/3906)
-
-A commenter states “bun works decently now with Electron” and requests official Bun
-support. This suggests improving compatibility but is a single user report.
-
-### Stack Overflow Discussion
-
-**Source**:
-[stackoverflow.com/questions/77295981](https://stackoverflow.com/questions/77295981/how-run-electron-js-with-bun)
-
-Community consensus is to install both Node.js and Bun, using Bun for speed but Node.js
-for Electron tooling.
-
-## Blog Post Perspectives
-
-### “Why We Ditched Node for Bun in 2026”
-
-**Source**:
-[dev.to article](https://dev.to/rayenmabrouk/why-we-ditched-node-for-bun-in-2026-and-why-you-should-too-48kg)
-
-Claims >95% Node API compatibility in Bun.
-This is a promotional piece, not a technical audit.
-
-### Hacker News Discussion on Electrobun
-
-**Source**:
-[news.ycombinator.com/item?id=42199486](https://news.ycombinator.com/item?id=42199486)
-
-Mixed reactions. Praise for small bundle size, concerns about beta stability and system
-webview limitations.
-
-## Industry Events
-
-### Anthropic Acquisition of Bun (December 2025)
-
-**Sources**:
-- [Anthropic announcement](https://www.anthropic.com/news/anthropic-acquires-bun-as-claude-code-reaches-usd1b-milestone)
-  (December 3, 2025)
-- [Bun blog post](https://bun.com/blog/bun-joins-anthropic) (December 2, 2025)
-
-Anthropic acquired Bun as its first-ever acquisition, announced alongside Claude Code
-reaching $1 billion in annual run-rate revenue.
-Bun will remain open-source and MIT-licensed.
-This signals significant investment in Bun’s future but doesn’t change current
-compatibility facts.
-
-# Part 3: Analysis and Recommendations
-
-## Comparative Analysis
-
-### Approach Comparison
-
-| Criterion | npm + Electron | pnpm + Electron | Bun Hybrid | Electrobun |
-| --- | --- | --- | --- | --- |
-| **Stability** | Verified High | Verified High | Medium (workarounds needed) | Beta |
-| **Install Speed** | Baseline | ~2-3x faster | ~5-10x faster* | ~5-10x faster* |
-| **Bundle Size** | ~150MB | ~150MB | ~150MB | ~12MB* |
-| **Tooling Support** | Full | Full | Partial | Framework-specific |
-| **Production Deployments** | Thousands | Many | Few documented | Very few |
-
-*Vendor-claimed values; actual performance varies by workload.
-
-### Uncertainty Acknowledgment
-
-| Claim | Confidence | Uncertainty |
+| Mechanism | Use when | Do not use when |
 | --- | --- | --- |
-| npm/pnpm work with Electron | High | None identified |
-| Bun + electron-builder crashes | Medium | May improve with Bun updates |
-| Electron 39.x needs macOS 15.x | High | May be unintended; could be fixed |
-| Electrobun ~12MB bundles | Medium | Depends on configuration |
-| Electrobun production readiness | Low | Beta status, limited deployments |
+| **In the main process** | The work is small, fast, and event-driven. Reading config; a few file operations. | Anything CPU-bound or long-running. It blocks your UI. |
+| **`utilityProcess`** | The backend is JavaScript/TypeScript running on Node. **This is the default choice.** | You need a runtime that is not Node. |
+| **Sidecar executable** | The backend is Python, Go, Rust, or a Bun-compiled binary, or it is an existing program you do not want to rewrite. | A Node module would have done. Sidecars cost you signing complexity and megabytes. |
+| **`child_process.fork`** | Rarely. `utilityProcess` supersedes it. | You have disabled the `runAsNode` fuse—which you should—because that breaks `fork`. |
+| **Local HTTP server** | An existing service already speaks HTTP and rewriting its transport is not worth it. | You have a choice. See [Local Server Security](#local-server-security). |
 
-## Decision Framework
+The `runAsNode` interaction deserves emphasis: hardening your app by disabling the
+`runAsNode` fuse **breaks `child_process.fork`**, because forking relies on relaunching
+the Electron binary in Node mode.
+`utilityProcess` is the supported path that survives hardening, which makes it the right
+default rather than merely the modern one.
 
-Building a desktop app involves three separate decisions:
+### Node Backends
 
-1. **Framework/runtime**: Electron vs Electrobun (vs Tauri, etc.)
-2. **Package manager**: npm vs pnpm vs Bun (as a toolchain)
-3. **Packaging and updates**: electron-builder vs electron-forge vs Electrobun’s
-   built-in pipeline
+`utilityProcess` has been stable since Electron 22. It runs a Node script in a Chromium
+services process, with no window and no renderer.
 
-The sections below address these decisions, starting with package manager choice for
-Electron apps, then framework choice (Electron vs Electrobun).
+```ts
+import { utilityProcess } from 'electron';
 
-### When to Use npm + Electron
-
-**Choose when:**
-- Production application with stability requirements
-- Team unfamiliar with pnpm/Bun
-- electron-forge is required
-- Strict dependency auditing needed
-
-**Risk level**: Low
-
-### When to Use pnpm + Electron
-
-**Choose when:**
-- Monorepo with multiple packages
-- Disk space efficiency matters
-- CI install speed is important
-- Team comfortable with modern tooling
-
-**Risk level**: Low
-
-### When to Use Bun Hybrid Approach
-
-**Choose when:**
-- Already using Bun for non-Electron code
-- Team has Bun expertise
-- Willing to maintain workarounds
-- electron-forge not required
-
-**Required mitigations:**
-1. Use `bun install` but invoke electron-builder via Node.js
-2. Implement file stabilization polling
-3. Validate syntax with `node --check`
-4. Handle SDK path resolution explicitly
-
-**Risk level**: Medium
-
-### When to Evaluate Electrobun
-
-**Choose when:**
-- Bundle size is critical constraint
-- Update bandwidth is constrained
-- Building internal tools / MVPs
-- Team accepts beta-quality software
-- System webview limitations acceptable
-
-**Uncertainties:**
-- API stability before 1.0
-- System webview feature parity varies by platform
-- Smaller community for troubleshooting
-
-**Risk level**: Medium-High
-
-## Recommended Stacks
-
-### Maximum Stability
-
-```
-npm 10.x + Node.js 24.x
-├── electron@38 (or @39 on macOS 15.x)
-├── electron-builder
-├── esbuild
-├── Vite
-└── TypeScript
+const child = utilityProcess.fork(path.join(__dirname, 'backend.js'), [], {
+  serviceName: 'my-app-backend', // shows up in app.getAppMetrics()
+  stdio: 'pipe',
+});
+child.on('spawn', () => {
+  /* ready to postMessage */
+});
+child.on('exit', (code) => {
+  /* supervise and restart with backoff */
+});
 ```
 
-### Modern Monorepo
+Constraints worth knowing before you commit:
 
-```
-pnpm 10.x + Node.js 24.x
-├── electron
-├── electron-builder
-├── tsdown (libraries)
-├── esbuild (Electron main/preload)
-├── Vite (renderer)
-├── TypeScript
-├── Vitest
-├── Changesets
-└── lefthook
-```
+- It can only be called **after the `app` `ready` event**.
+- **`stdin` is restricted to `ignore`.** You cannot drive it with a stdin-based
+  protocol; use message passing.
+- Native addons load normally.
+  The macOS-only `allowLoadingUnsignedLibraries` option exists precisely for loading
+  unsigned dylibs there.
 
-### Bun Hybrid
+The capability that makes `utilityProcess` more than a `fork` replacement is
+`MessagePort`: you can create a channel and hand one end to a renderer, so heavy traffic
+flows **directly between renderer and backend** without relaying every message through
+the main process. For a streaming or high-frequency workload this is the difference
+between a responsive app and a stuttering one.
 
-```
-Bun 1.3.x
-├── electron
-├── electron-builder (via npx, not bunx)
-├── esbuild
-├── Vite
-└── TypeScript
-```
+### Bun Backends
 
-### Future-Oriented (with caveats)
+`bun build --compile` produces a single-file executable, cross-compilable to 14 targets
+(Linux, Windows, and macOS across x64/arm64, plus musl and baseline variants).
+Ship it as a sidecar.
 
-```
-Bun + Electrobun
-├── TypeScript
-├── React/Svelte/Vue
-└── System webviews or CEF
-```
+Before choosing this, weigh three facts:
 
-## Electron Security Baseline
+- **Size.** A hello-world compiled binary is roughly 57MB; Bun’s own docs acknowledge
+  the binary is too big.
+  `--minify` and `--bytecode` reduce embedded source size and improve startup, not the
+  runtime baseline.
+- **Signing works, recently.** macOS codesigning of `--compile` output has been
+  supported since Bun 1.2.4 (Feb 2025), via a dedicated `__BUN,__bun` Mach-O section.
+- **There is an open signing defect.** As of August 2026,
+  [bun#32159](https://github.com/oven-sh/bun/issues/32159) reports that binaries
+  compiled with Bun 1.3.13+ have invalid signatures on macOS 27, causing the process to
+  be killed on launch; macOS 26 tolerated the same signature.
+  A fix is in progress.
+  Verify against your minimum macOS target before shipping.
 
-Per
-[Electron security documentation](https://electronjs.org/docs/latest/tutorial/security),
-these are non-optional defaults for any Electron application:
+Bun is a reasonable sidecar runtime and a reasonable package manager.
+It is not a good fit for driving the Electron *build*—see
+[Package Managers](#6-package-managers-and-the-electron-toolchain).
 
-### Required Settings
+### Python Backends
 
-| Setting | Value | Rationale |
+Shipping Python inside a desktop app has become substantially easier, and the current
+best practice is not the one most tutorials describe.
+
+| Approach | Status (Aug 2026) | Notes |
 | --- | --- | --- |
-| `contextIsolation` | `true` | Isolate preload from renderer |
-| `nodeIntegration` | `false` | Prevent direct Node.js access in renderer |
-| `sandbox` | `true` | OS-level process isolation |
+| **python-build-standalone + uv** (recommended) | Actively maintained by Astral since Dec 2024; release tag 20260610 ships CPython 3.13.14 and 3.14.6 | Relocatable CPython builds—statically linked, with the build system patched to use relative paths. Assemble the app environment at build time with `uv venv` and `uv pip sync` against a lockfile, then ship the tree. Most predictable and most debuggable. |
+| **PyInstaller** | 6.22.1, actively maintained, Python 3.8–3.15 | Mature and widely used. Sizes run ~28MB for a Flask app to ~180MB with PyTorch; startup ~2–3s, and onefile mode adds unpacking time that is worst on Windows. |
+| **Nuitka** | 4.x, actively maintained | Compiles to C. Faster execution, some IP protection. AGPLv3 with an exemption for compiled output; a commercial edition exists. Python 3.14 support is experimental. |
+| **Briefcase** (BeeWare) | Actively maintained | Whole-app packager rather than a backend packager. Cannot cross-build; you build on each target platform. |
+| **PyOxidizer** | **Dead** | Last meaningful commit Jan 2023; the author stated in Mar 2024 he is unlikely to return to it and asked for maintainers. None stepped forward. Do not start here. |
 
-### Preload Boundary
+The python-build-standalone route is worth the extra assembly step because it keeps a
+real Python tree in the bundle: you can read the traceback, you can `ls site-packages`,
+and startup is a normal interpreter start rather than an unpack.
+An end-to-end recipe is in [Appendix E](#appendix-e-python-sidecar-end-to-end).
 
-Use `contextBridge` to expose a minimal API. Treat the preload boundary like an internal
-RPC boundary—audit exposed APIs carefully.
+Note the signing consequence: a Python tree contains many Mach-O objects (the
+interpreter plus every compiled extension module’s `.so`). Every one of them must be
+signed. See [Signing Nested Binaries](#signing-nested-binaries).
 
-**Common failure mode**: Many Electron security incidents are effectively “XSS → RCE”
-due to overexposed preload APIs.
+### Compiled Sidecars
+
+Go and Rust backends are the least troublesome sidecars: a single static binary, no
+runtime tree, straightforward signing.
+Build one per `{os, arch}` you ship and select at runtime.
+
+### Node Single Executable Applications
+
+Node’s SEA feature reached a usable shape in 2026: `node --build-sea config.json` landed
+in Node 25.5.0, replacing the older `--experimental-sea-config` plus `postject` dance.
+It supports V8 snapshots, code cache, and asset bundling including `.node` addons.
+
+It remains **stability 1.1, active development**, and the resulting binary carries a
+full Node runtime. For an Electron app this is usually the wrong tool—you already have
+Node inside Electron, so use `utilityProcess`. SEA matters only when the backend must
+also run standalone outside the app.
+
+### Packaging a Sidecar
+
+electron-builder gives four placement mechanisms with materially different behavior:
+
+| Key | What it does | Lands at | Read it at runtime via |
+| --- | --- | --- | --- |
+| `files` | Selects what goes **into** the ASAR archive | inside `app.asar` | normal `require`/`import` |
+| `asarUnpack` | Pulls matching paths back **out** of the ASAR; reads are transparently redirected | `app.asar.unpacked/` | the same paths as if inside the ASAR |
+| `extraResources` | Copies **outside** the ASAR into the resources directory | macOS `Contents/Resources/`, elsewhere `resources/` | `process.resourcesPath` |
+| `extraFiles` | Copies into the app content directory | macOS `Contents/`, elsewhere the install root | relative to `app.getAppPath()` |
+
+An executable cannot be run from inside an ASAR archive, so every sidecar needs
+`asarUnpack`, `extraResources`, or `extraFiles`.
+
+```yaml
+extraResources:
+  - from: resources/bin/${os}/${arch}
+    to: bin
+    filter: ['**/*']
+```
+
+```ts
+const binDir = app.isPackaged
+  ? path.join(process.resourcesPath, 'bin')
+  : path.join(__dirname, '../../resources/bin', process.platform, process.arch);
+```
+
+**The executable bit gets lost.** Packaging does not reliably preserve `+x`
+([electron-builder#1790](https://github.com/electron-userland/electron-builder/issues/1790)).
+Fix it in an `afterPack` hook, and defensively `fs.chmodSync(bin, 0o755)` before
+spawning on non-Windows.
+
+### Signing Nested Binaries
+
+This is where sidecar projects lose the most time, so be precise about the rules.
+
+**Signing is not recursive.** Apple’s
+[TN2206](https://developer.apple.com/library/archive/technotes/tn2206/_index.html) is
+explicit that nested code must be signed from the inside out.
+Every Mach-O object you add to the bundle—the sidecar, the Python interpreter, every
+`.so` extension module, every bundled `.dylib`—must be signed individually **before**
+the outer `.app` is signed.
+Notarization rejects the bundle if any of them is unsigned.
+
+**Placement follows Apple’s bundle layout.** `Contents/MacOS`, `Contents/Helpers`,
+`Contents/Frameworks`, `Contents/PlugIns`, and `Contents/XPCServices` are the code
+locations; TN2206 directs that scripts and other non-Mach-O executables belong in
+`Contents/Resources`. Since `extraResources` writes to `Contents/Resources`, a Mach-O
+sidecar placed there sits outside its canonical location.
+Signed nested Mach-O binaries under `Resources` do ship successfully in practice, so
+treat this as a risk to verify rather than a guaranteed rejection—but if you hit
+notarization errors about nested code, relocating the binary to `Contents/Frameworks` or
+`Contents/Helpers` in an `afterPack` hook is the standard fix.
+See [Open Research Questions](#open-research-questions).
+
+**Hardened runtime and entitlements.** Notarization requires signing with
+`--options runtime`. Electron’s V8 needs, at minimum:
+
+```xml
+<key>com.apple.security.cs.allow-jit</key><true/>
+<key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+```
+
+Sidecars that load unsigned or third-party dylibs commonly also need
+`com.apple.security.cs.disable-library-validation`, and Python trees typically need it.
+Add entitlements because a specific failure requires them, not preemptively—each one
+widens what an attacker who compromises your process can do.
+
+**Order of operations**: `afterPack` signs nested binaries → the outer app is signed →
+`afterSign` triggers notarization via `@electron/notarize` → staple the ticket.
+
+### Choosing an IPC Transport
+
+| Transport | Choose when | Watch out for |
+| --- | --- | --- |
+| **`MessagePort`** (utilityProcess) | Node backend, especially high-frequency or renderer-direct traffic. | Electron-specific; no reuse outside the app. |
+| **stdio, newline-delimited JSON or JSON-RPC** | Sidecar in any language. **The default choice for sidecars.** | Backpressure and partial-line framing are yours to handle. Not available for `utilityProcess`, whose stdin is `ignore`. |
+| **Unix domain socket / Windows named pipe** | You need multiple concurrent streams or a long-lived connection. | Platform-specific path conventions; clean up stale socket files. |
+| **Loopback HTTP or WebSocket** | An existing service already speaks it. | See below. This is the transport that causes security incidents. |
+| **gRPC** | Polyglot backends, streaming, and a schema you want enforced. | Heavy toolchain for a desktop app. |
+
+Prefer stdio. It binds no port, is reachable by nothing else on the machine, needs no
+authentication, and dies with the process.
+
+### Local Server Security
+
+If you bind a loopback port, understand what you have exposed: **every other process on
+the machine can reach it, and so, via DNS rebinding, can a web page the user is
+visiting.** A hostile site can point a hostname it controls at `127.0.0.1` and issue
+requests to your server from the user’s browser.
+
+This is not theoretical.
+Two 2026 examples:
+
+- **CVE-2026-22812** (CVSS 8.8): a developer tool exposed an unauthenticated local HTTP
+  server with permissive CORS; any website could create sessions and execute shell
+  commands. The published analysis attributes it to assuming that localhost is inherently
+  safe.
+- **CVE-2025-66414** (CVSS 7.6): the MCP TypeScript SDK before 1.24.0 shipped without
+  DNS rebinding protection by default.
+
+If you must bind a port:
+
+1. Bind `127.0.0.1` explicitly, never `0.0.0.0`.
+2. Use an **ephemeral port** and a **secret token** minted at startup, passed to the
+   backend out of band (argv or an environment variable) and required on every request.
+3. **Validate the `Host` header** against an allowlist; this is what actually stops DNS
+   rebinding.
+4. Set a strict CORS origin allowlist.
+   Never call a CORS middleware with no arguments.
+
+Because a rebinding attack cannot carry the target’s cookies, real authentication on
+every endpoint defeats it—which is why the token in step 2 is the highest-value
+mitigation.
+
+### Process Lifecycle
+
+Orphaned backend processes are the most common bug in sidecar architectures, and they
+are invisible in development because you kill the terminal.
+
+- **Spawn from the main process, not the renderer.** Renderer-spawned children are not
+  cleaned up when the app closes.
+- **Kill explicitly on `before-quit`**, and treat a slow shutdown as a bug rather than
+  waiting on it forever.
+- **Let the child detect parent death**, because the parent will eventually crash
+  without running your handler.
+  On Linux, `prctl(PR_SET_PDEATHSIG)`. On macOS there is no equivalent: inherit a pipe
+  and exit on EOF, or poll `getppid()` for 1. On Windows there are no POSIX signals at
+  all.
+- **On Windows, use a Job Object** with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. This is
+  the only mechanism that survives a parent crash.
+  Node does not expose it; VS Code uses `windows-process-tree`. `taskkill /F /T /PID`
+  only helps when you still get to run code.
+- **On POSIX**, spawn `detached: true` and kill the group with
+  `process.kill(-child.pid, 'SIGTERM')` so grandchildren die too.
+
+* * *
+
+## 4. Security Baseline
+
+### The Defaults Are Already Correct
+
+| Setting | Default | Default since |
+| --- | --- | --- |
+| `sandbox` | `true` | Electron 20 |
+| `contextIsolation` | `true` | Electron 12 |
+| `nodeIntegration` | `false` | Electron 5 |
+| `nodeIntegrationInSubFrames` | `false` | — |
+| `nodeIntegrationInWorker` | `false` | — |
+| `webviewTag` | `false` | Electron 5 |
+| `webSecurity` | `true` | — |
+| `allowRunningInsecureContent` | `false` | — |
+
+Advice to “enable context isolation and disable node integration” describes the state
+your app is already in.
+The real risks are the deliberate downgrades—`nodeIntegration: true` to make a library
+work, `webSecurity: false` to silence a CORS error in development that then ships.
+Each of those is a decision that needs justification in review, not a default to
+restore.
+
+### The Preload Boundary Is an RPC Boundary
+
+Covered in [Typed IPC](#typed-ipc-across-the-context-bridge); restated here because it
+is the single highest-value control.
+Most Electron security incidents are effectively **XSS to RCE**, and the escalation path
+runs through an over-broad preload API. Expose named capabilities, never a generic
+channel. Validate the sender and the payload in every handler.
 
 ### Content Security Policy
 
-Apply strict CSP for renderer windows.
-Avoid `unsafe-eval` and `unsafe-inline`.
+Set a CSP and do not weaken it to make a bundler happy.
 
-### Additional Hardening
+```
+default-src 'self';
+script-src 'self';
+style-src 'self';
+img-src 'self' data:;
+connect-src 'self';
+object-src 'none';
+base-uri 'none';
+frame-ancestors 'none';
+```
 
-- Gate `shell.openExternal`, navigation, and protocol handlers
-- Validate all file paths before access
-- Treat remote content as hostile (avoid loading in privileged windows)
-- Use `webContents.setWindowOpenHandler` to control new windows
+Prefer a response header via `session.defaultSession.webRequest.onHeadersReceived` (or
+your custom protocol handler) over a `<meta>` tag, because the header cannot be
+manipulated by injected markup.
+`'unsafe-inline'` and `'unsafe-eval'` defeat the purpose; if a dependency requires
+`'unsafe-eval'`, that is information about the dependency.
 
-## Open Questions
+### Navigation, Windows, and Permissions
 
-1. **Will Electron 39.x macOS 14.x compatibility be fixed?** Unknown.
-   Could be intentional OS requirement or bug.
+Three handlers, all of which default to permissive and all of which you should set:
 
-2. **Will Bun + electron-builder crashes be resolved?** Uncertain.
-   Fundamental runtime crashes are harder to fix than configuration issues.
+```ts
+// 1. New windows: deny by default, open trusted external links in the real browser.
+contents.setWindowOpenHandler(({ url }) => {
+  if (isTrustedExternal(url)) shell.openExternal(url);
+  return { action: 'deny' };
+});
 
-3. **When will Electrobun reach 1.0?** Unknown.
-   Active development but no public roadmap.
+// 2. Navigation: pin the app to its own origin.
+contents.on('will-navigate', (event, url) => {
+  if (new URL(url).origin !== APP_ORIGIN) event.preventDefault();
+});
 
-4. **How does Anthropic’s Bun acquisition affect Electron compatibility?** Unclear.
-   Investment doesn’t automatically fix compatibility.
+// 3. Permissions: deny everything you have not deliberately enabled.
+session.defaultSession.setPermissionRequestHandler((_wc, permission, callback) => {
+  callback(ALLOWED_PERMISSIONS.has(permission));
+});
+```
+
+`shell.openExternal` with an unvalidated URL is a remote code execution primitive on
+every platform. Allowlist the scheme before calling it.
+
+### Fuses and ASAR Integrity
+
+Fuses are compile-time flags flipped into the binary at package time by
+`@electron/fuses`. Several defaults are permissive for developer convenience and should
+be changed for a shipping app.
+
+| Fuse | Default | Ship with | Why |
+| --- | --- | --- | --- |
+| `runAsNode` | Enabled | **Disabled** | `ELECTRON_RUN_AS_NODE` turns your signed app into a general-purpose Node interpreter—a living-off-the-land primitive. **Breaks `child_process.fork`; use `utilityProcess`.** |
+| `nodeCliInspect` | Enabled | **Disabled** | Prevents attaching a debugger to a shipped app via `--inspect`. |
+| `nodeOptions` | Enabled | **Disabled** | Stops `NODE_OPTIONS` and `NODE_EXTRA_CA_CERTS` from injecting behavior at launch. |
+| `grantFileProtocolExtraPrivileges` | Enabled | **Disabled** (with a custom protocol) | Removes the elevated privileges `file://` pages otherwise receive. |
+| `embeddedAsarIntegrityValidation` | Disabled | **Enabled** | Validates `app.asar` at load; the app terminates on mismatch. |
+| `onlyLoadAppFromAsar` | Disabled | **Enabled** | Stops an attacker from dropping a loose `app/` directory beside the archive. |
+| `cookieEncryption` | Disabled | Consider | Encrypts the cookie store at rest. **One-way: enabling and later disabling corrupts the store.** |
+
+Two ways to apply them: call `flipFuses` from `@electron/fuses` in an `afterPack` hook,
+or set electron-builder’s `electronFuses` config key and let it do the flipping.
+Both are used in production—see [§8](#8-what-shipping-apps-actually-do)—and the config
+key is the less error-prone of the two because it cannot be skipped by a hook that
+silently fails.
+
+ASAR integrity graduated from experimental to stable in Electron 39. It is supported on
+macOS (since Electron 16, via `ElectronAsarIntegrity` in `Info.plist`) and Windows
+(since Electron 30, via an `Integrity` resource), using SHA-256 over both blocks and the
+whole archive.
+Electron 41 added a digest so the integrity data is itself tamper-evident.
+Note that integrity validation and `onlyLoadAppFromAsar` together are what make code
+signing meaningful: without them, a signed app will happily load modified application
+code.
+
+### Keeping Current
+
+Checklist item 16 is “use a current version of Electron,” and it has teeth.
+**CVE-2026-70601**, patched 2026-08-05, is a context isolation bypass via a
+`Function.prototype.bind` hijack—it defeats the boundary the rest of this section is
+built on.
+Because only three majors are supported at a time, staying inside the window is
+a prerequisite for receiving fixes at all.
+
+The full 20-item
+[official checklist](https://www.electronjs.org/docs/latest/tutorial/security) is
+versioned with the docs; read it rather than relying on this summary, which is
+deliberately partial.
+
+* * *
+
+## 5. Packaging and Distribution
+
+### Choosing a Packager
+
+| Tool | Weekly downloads | Choose when |
+| --- | --- | --- |
+| **electron-builder** | ~3M | You want the most capable packager: more targets, differential updates, mature signing integration, Linux formats. **Default recommendation.** |
+| **Electron Forge** | — | You want official Electron-team support and one tool for build/package/make/publish. |
+| **@electron/packager** | ~570k | You are building a custom pipeline and want only the bundling step. Forge wraps this. |
+
+There is a genuine tension here.
+Electron Forge is the officially supported tool, lives under the `electron/` GitHub org,
+and is what the Electron docs point you to.
+electron-builder is a community project with an uneven release cadence—its `latest`
+dist-tag currently lags its newest v26 release, and v27 has been in alpha for a while.
+
+The recommendation still goes to electron-builder, for two reasons.
+The capability gap is wide, particularly for Linux targets and differential updates.
+And the adoption evidence is lopsided: of the production apps surveyed in
+[§8](#8-what-shipping-apps-actually-do), every one whose packager could be confirmed
+uses electron-builder except VS Code, and **none use Forge**. Choose Forge if official
+support matters more to you than capability and you are willing to be an early adopter
+of its Vite plugin; that is a defensible choice, not the common one.
+A minimal annotated config is in [Appendix B](#appendix-b-electron-builderyml).
+
+### macOS: Signing and Notarization
+
+Requirements: a paid Apple Developer account, a Developer ID Application certificate,
+and a machine with Xcode command line tools.
+
+The flow is: sign every nested binary inside out → sign the app with `--options runtime`
+and your entitlements → submit with `xcrun notarytool submit` → `xcrun stapler staple`
+the ticket → verify with `spctl`.
+
+- `altool --notarize-app` was removed from `xcrun` on 2023-11-01. `notarytool` is the
+  only path. `@electron/notarize` wraps it.
+- Store credentials once with `notarytool store-credentials` and reference the keychain
+  profile, rather than putting an app-specific password in CI logs.
+- Typical turnaround is a few minutes, but budget for it in release timing.
+- Mac App Store distribution still works, via electron-builder’s `mas` target, with its
+  own certificates and sandbox requirements.
+- Since Electron 42, **macOS notifications require the app to be code signed**, so an
+  unsigned local build will silently fail to show notifications.
+  This surprises people who assume signing only matters at release.
+
+### Windows: Authenticode
+
+Two facts overturn most older guidance:
+
+- **Since June 2023**, the CA/Browser Forum requires **all** code signing certificates,
+  OV and EV alike, to keep private keys on FIPS 140-2 Level 2 hardware.
+  Software `.pfx` files are no longer issued, which is why “copy the certificate into
+  CI” no longer works.
+- **Since 2024, EV certificates no longer grant an instant SmartScreen bypass.** All
+  certificate types build reputation the same way.
+  Paying the EV premium specifically to avoid SmartScreen warnings is no longer
+  justified.
+
+| Option | Cost | Notes |
+| --- | --- | --- |
+| **Azure Artifact Signing** (formerly Trusted Signing) | ~$10/month basic, ~$100/month premium | Cloud signing via Entra ID, no hardware token, integrates with CI. Renamed 2026-01-28. **The 3-year business-history requirement was dropped**, so individuals can now qualify. Availability: organizations in US, Canada, EU, UK; individuals in US and Canada. |
+| **Traditional OV/EV certificate** | Varies | Requires an HSM or token. Workable in CI only through a cloud HSM such as DigiCert KeyLocker, which is what the Electron project itself uses. |
+| **SignPath Foundation** | Free | OV-level signing for qualifying open-source projects. |
+
+### Linux: Target Formats
+
+There is no signing equivalent; distribution is about format.
+
+| Format | Status (2026) |
+| --- | --- |
+| **Flatpak** | The de facto desktop standard. Flathub passed 3,200 apps. Sandboxed, auto-updating, shared runtimes. |
+| **.deb / .rpm** | Still the right answer for distro-native installs. electron-builder generates both. |
+| **Snap** | Well integrated on Ubuntu; single vendor-controlled store. |
+| **AppImage** | Still works, increasingly niche. No sandbox, no built-in updates, and bundled libraries only get patched when you rebuild. GIMP 3 dropped it in 2025. |
+
+Ship `.deb` plus one sandboxed format; AppImage only if your users specifically want a
+portable single file.
+
+### Auto-Update
+
+| Option | Platforms | Constraints |
+| --- | --- | --- |
+| **`update-electron-app` + update.electronjs.org** | macOS, Windows | Free and hosted, but requires a **public GitHub repository**, releases published to GitHub Releases, and a **code-signed** app. **No Linux support.** |
+| **electron-updater** (electron-builder) | macOS, Windows, **Linux** | Works against GitHub Releases, S3, or any static host. NSIS differential updates via `.blockmap` download only changed byte ranges. |
+| **Electron `autoUpdater`** directly | macOS, Windows | The built-in module, backed by Squirrel.Mac and Squirrel.Windows. You supply the update feed. |
+
+Electron update payloads are large because the runtime ships with the app, but
+differential mechanisms reduce this substantially: Squirrel deltas on macOS and Windows,
+and blockmap-based partial downloads for NSIS. Expect megabytes to tens of megabytes for
+a typical update, not a full re-download.
+
+**Code signing is a prerequisite for auto-update, not an optional extra.** Squirrel.Mac
+refuses to apply an update that is not correctly signed.
+
+### Native Modules
+
+Native addons are compiled against a specific ABI, and Electron’s Node is not your host
+Node, so a module built for your system Node will fail to load inside Electron.
+
+- **`@electron/rebuild`** recompiles native modules against Electron’s headers, and
+  downloads prebuilds instead of compiling when the module publishes them.
+- **Node-API (N-API) prebuilds** are the preferred upstream pattern: one prebuild per
+  `{os, arch}` works across Node and Electron versions without recompilation.
+  Prefer dependencies that ship them.
+- **For SQLite, check `node:sqlite` first.** It is built into Node, so it needs no
+  rebuild step and no native dependency at all.
+  It reached release-candidate stability in Node and ships in the Node embedded in
+  current Electron. Use `better-sqlite3` when you need its richer API—transactions
+  wrapper, user-defined function options, BigInt control—and accept the rebuild step.
+  This single change removes the most common source of native-module pain in Electron
+  apps.
+
+* * *
+
+## 6. Package Managers and the Electron Toolchain
+
+The headline change since early 2026 is that **all three major package managers now
+block dependency lifecycle scripts by default**, and **Electron stopped needing one**.
+
+Since Electron 42, the npm package no longer downloads its binary in a `postinstall`
+script; it downloads on first run of its `bin` script, explicitly to remove a
+supply-chain attack surface.
+`ELECTRON_SKIP_BINARY_DOWNLOAD` was removed as a result, and
+`npm install electron --ignore-scripts` now works, with `npx install-electron` available
+to fetch on demand.
+
+So the build-script configuration below matters **only if you are on Electron 41 or
+older**. On current Electron you can leave dependency scripts blocked, which is the
+safer posture anyway.
+
+| Manager | Version | Electron status |
+| --- | --- | --- |
+| **npm** | 12.0.2 | Full support. npm 12 disables install scripts by default (`allowScripts`); approve with `npm approve-scripts electron` if you are on Electron ≤41. |
+| **pnpm** | 11.21.0 | Full support, with configuration. See below. |
+| **Bun** | 1.3.14 | Fine for `bun install` (Electron is in Bun’s default trusted-dependency allowlist). **Not supported by Electron Forge** ([forge#3906](https://github.com/electron/forge/issues/3906), open). electron-builder’s script hooks remain unreliable under Bun ([bun#9895](https://github.com/oven-sh/bun/issues/9895), open since April 2024). |
+
+**pnpm configuration.** pnpm 11 moved these settings out of `.npmrc`; they now live in
+`pnpm-workspace.yaml`, and `.npmrc` is only read for auth and registry settings:
+
+```yaml
+# pnpm-workspace.yaml
+nodeLinker: hoisted # electron-builder and Forge crawl node_modules and do not follow symlinks
+allowBuilds:
+  electron: true # only needed on Electron <= 41
+```
+
+Without `nodeLinker: hoisted`, packagers fail to resolve dependencies in the app
+directory.
+This requirement is documented in electron-builder’s issue tracker rather than
+its docs, and Electron Forge documents the equivalent requirement for its pnpm support
+added in 7.7.0.
+
+**On Bun specifically.** An older version of this document rated Bun’s Electron support
+“low” on the strength of four issue reports.
+Rechecking them in August 2026: the electron-builder segfault
+([bun#18249](https://github.com/oven-sh/bun/issues/18249)) is closed, the ancient
+install failure ([bun#1588](https://github.com/oven-sh/bun/issues/1588), filed against
+Bun 0.2.2 in 2022) is closed, and the Quasar lockfile mismatch is closed with a
+documented workaround.
+The two that remain open are the ones that matter: Forge does not support Bun, and
+electron-builder’s `rebuild` script lookup still fails under Bun.
+The accurate statement is narrower than the old one: **Bun is a fine package manager and
+sidecar runtime for an Electron project; it is not a supported driver for the Electron
+build step.** Install with Bun if you like, and invoke the packager through Node.
+
+* * *
+
+## 7. Testing and CI
+
+**Testing.** Playwright drives a real Electron app through its `_electron` namespace,
+launching the built main process and giving you a normal page object for the renderer.
+This is the highest-value test layer for a desktop app, because it covers the
+main/preload/renderer wiring that unit tests cannot.
+Keep unit tests for pure logic in `src/shared` and backend code, and use golden tests
+for IPC contracts.
+
+**CI.** Build on the OS you are targeting: macOS builds need macOS for signing and
+notarization, and Windows installers need Windows.
+A three-way matrix is the norm.
+
+Specific things that bite:
+
+- **Signing secrets in CI.** macOS needs the certificate imported into a temporary
+  keychain that is deleted afterward.
+  Windows needs a cloud signing service, since key material can no longer live in a
+  file.
+- **Notarization is slow and rate-limited.** Do not notarize on every pull request; sign
+  and notarize on release tags only.
+- **Universal macOS builds** via `@electron/universal` merge x64 and arm64 outputs,
+  which requires both to have been built.
+- **`@electron/rebuild` needs a native toolchain** on each runner.
+- **Cache the Electron binary download** between runs; it is the largest single cost in
+  a cold build.
+
+A complete release workflow is in
+[Appendix F](#appendix-f-github-actions-release-workflow).
+
+* * *
+
+## 8. What Shipping Apps Actually Do
+
+The recommendations above are not derived from first principles alone.
+The following is a survey of well-engineered open-source Electron apps, read from their
+actual build configuration on 2026-08-16.
+
+| App | Electron | Renderer bundler | Packager | Sandbox | Fuses |
+| --- | --- | --- | --- | --- | --- |
+| VS Code | 42.8.1 | esbuild (new pipeline) | custom (`@vscode/gulp-electron`) | Yes | Not visible in public config |
+| Signal Desktop | 43.0.0 | **Rolldown 1.0.1** (migrated from webpack) | electron-builder 26.11.1 | Partial (phased preloads) | `@electron/fuses` present |
+| Bitwarden | 43.2.0 | webpack 5.106.2 | electron-builder 26.9.0 | Yes | **7 flipped** |
+| Mattermost | 43.3.0 | webpack 5.100.2 | electron-builder 26.6.0 | — | — |
+| Joplin | 42.3.0 | esbuild | electron-builder 26.15.6 | — | — |
+| Element Desktop | 41.0.2 | n/a (wraps Element Web) | electron-builder 26.8.2 | Yes, `app.enableSandbox()` | **8 configured** |
+| Logseq | 38.4.0 | shadow-cljs + webpack + Vite | — | **No** (`sandbox: false`) | — |
+| Standard Notes | 35.2.0 | webpack | electron-builder 24.9.1 | — | — |
+
+What generalizes, and what does not:
+
+- **electron-builder wins on adoption, decisively.** Every app here uses it except VS
+  Code, which runs a custom pipeline justified by its scale, and Logseq, whose packager
+  could not be confirmed.
+  **None use Electron Forge**, despite Forge being the officially supported tool.
+  This is the strongest empirical signal in the survey, and it is why electron-builder
+  is the recommendation here despite not being an official Electron project.
+
+- **CJS for main and preload is universal.** Every app in the survey emits CJS for the
+  preload, and all but VS Code emit CJS for main.
+  ESM has been available since Electron 28 and production has not moved.
+  Treat “bundle main to CJS” as the boring, correct default.
+
+- **Nobody uses an IPC framework.** Not tRPC-over-IPC, not comlink, not electron-trpc.
+  Every app hand-writes a typed preload and gets its safety from TypeScript interfaces:
+  VS Code has a custom typed channel abstraction over `MessagePort` in
+  `src/vs/base/parts/ipc/`, Signal declares an `IPCType` interface, Bitwarden exposes
+  five namespaces (`ipc.auth`, `ipc.autofill`, `ipc.platform`, `ipc.keyManagement`,
+  `ipc.tools`) through `contextBridge`. The pattern in
+  [Appendix D](#appendix-d-preload-and-typed-ipc) is what these apps converge on.
+
+- **Sandboxing is the baseline, and exceptions are visible.** VS Code, Element, and
+  Bitwarden run sandboxed renderers.
+  Logseq sets `sandbox: false` and keeps `contextIsolation: true` as a compensating
+  control—which is the honest way to take that tradeoff if you must.
+
+- **Custom protocols are what serious apps use instead of `file://`.** VS Code registers
+  `vscode-file://` and Element registers `vector://`, both as standard and secure
+  schemes. This is the checklist’s advice and it is followed in practice.
+
+- **The two most security-focused apps have near-identical fuse configurations.**
+  Bitwarden flips seven in `apps/desktop/scripts/after-pack.js`; Element configures
+  eight through electron-builder’s `electronFuses` key in `electron-builder.ts`. Both
+  disable `runAsNode`, `enableNodeOptionsEnvironmentVariable`, and
+  `enableNodeCliInspectArguments`, and both enable `enableCookieEncryption`,
+  `enableEmbeddedAsarIntegrityValidation`, and `onlyLoadAppFromAsar`. They differ on
+  `grantFileProtocolExtraPrivileges`: Element disables it, Bitwarden leaves it enabled
+  and notes a CORS limitation.
+  That is the same table recommended in
+  [Fuses and ASAR Integrity](#fuses-and-asar-integrity), independently arrived at twice.
+
+- **Rust plus Node-API is the modern native module pattern**, replacing hand-written
+  C++. Signal ships `libsignal-client`, `ringrtc`, and `sqlcipher`; Bitwarden builds
+  `desktop_native/napi/` with `@napi-rs/cli` across six architectures.
+
+- **Bundler choice does not generalize yet.** Webpack is still the most common, but it
+  is legacy weight rather than a current recommendation: Signal has moved to Rolldown,
+  VS Code and Joplin use esbuild, and the maintained templates (`electron-vite-react`
+  pins Electron 42.1.0, Vite 8.0.16, React 19.2.7) are all Vite.
+  New projects should start on Vite/Rolldown; the webpack majority reflects when these
+  apps were built.
+
+- **Actively maintained apps stay inside the support window.** Six of the eight are on a
+  supported major (41 through 43), and five of those are on 42 or 43—within about ten
+  weeks of the newest release.
+  Logseq (38) and Standard Notes (35) have fallen outside it and are therefore no longer
+  receiving Electron security fixes.
+  Note that Element, at 41, is supported only until 2026-08-25; being inside the window
+  is not the same as having room to spare.
+
+One caution on templates: `electron-react-boilerplate` (~24k stars) still pins Electron
+35 and webpack, and the `electron-vite-boilerplate` template pins Electron 28.
+Popularity is not currency.
+`electron-vite-react` was the most current template found.
+
+* * *
+
+## Supply-Chain Mitigation
+
+This repository enforces a **14-day package-age rule**: do not install or upgrade to a
+version less than 14 days old, so that a compromised release has time to be discovered.
+See
+[supply-chain-hardening](https://github.com/jlevy/tbd/blob/main/packages/tbd/docs/guidelines/supply-chain-hardening.md)
+for the general policy and tooling.
+
+Electron-specific considerations:
+
+- **Security patches are the documented exception.** Electron ships fixes on supported
+  lines only, and an Electron CVE is usually a renderer-reachable one.
+  Take the patch and document the exception.
+- **Lifecycle scripts are now blocked by default** across npm, pnpm, and Bun, and
+  Electron no longer needs one.
+  Keep them blocked.
+- **A desktop app’s dependency tree ships to the user’s machine** and runs outside the
+  browser sandbox in the main process.
+  A compromised transitive dependency imported into main is worse than the same
+  dependency in a server, where at least it is not running with the user’s desktop
+  privileges. Keep the main process’s dependency list short and audited; push incidental
+  work into the renderer (sandboxed) or a sidecar (separately signed).
+- **ASAR integrity plus `onlyLoadAppFromAsar` are the tamper controls** that make
+  signing meaningful after install.
+
+* * *
+
+## When Not to Use Electron
+
+Electron’s cost is a Chromium and Node runtime per app: roughly 100–200MB installed
+depending on platform and compression, and a memory floor well above a native app.
+You are buying one rendering engine that behaves identically everywhere, the full web
+ecosystem, and a deep well of documentation and hiring.
+
+Consider alternatives when bundle size or memory is a hard product constraint, or when
+the app is small enough that the runtime dominates it.
+The main tradeoff you are accepting in exchange is **webview fragmentation**:
+system-webview frameworks render on WebView2 on Windows, WKWebView on macOS, and
+WebKitGTK on Linux, so you write once and debug three times.
+
+A detailed comparison of Tauri, Electrobun, Wails, and Neutralino is deliberately out of
+scope here and is tracked as separate research; this document stays focused on Electron.
+
+* * *
+
+## Best Practices
+
+**Architecture**
+
+- [ ] Renderer is an ordinary web app with no Node access.
+- [ ] Preload exposes named capabilities, never a generic `invoke`.
+- [ ] IPC types live in a type-only shared module used by both sides.
+- [ ] Every `ipcMain` handler validates its sender and its payload.
+- [ ] Long-running or CPU-bound work is in a `utilityProcess` or a sidecar, not in main.
+- [ ] Backend processes are spawned from main, supervised, and killed on quit.
+
+**Security**
+
+- [ ] `sandbox`, `contextIsolation`, and `nodeIntegration` left at their defaults.
+- [ ] CSP set via response header, with no `unsafe-inline` or `unsafe-eval`.
+- [ ] `setWindowOpenHandler` denies by default.
+- [ ] `will-navigate` pins the app to its own origin.
+- [ ] Permission request handler denies by default.
+- [ ] `shell.openExternal` allowlists the scheme.
+- [ ] Fuses flipped: `runAsNode`, `nodeCliInspect`, `nodeOptions`, and
+  `grantFileProtocolExtraPrivileges` disabled; ASAR integrity and `onlyLoadAppFromAsar`
+  enabled.
+- [ ] Electron version inside the three-major support window.
+
+**Build and release**
+
+- [ ] Main, preload, and renderer have separate build configs.
+- [ ] Preload emits a single CJS file.
+- [ ] macOS: hardened runtime, minimal entitlements, every nested Mach-O signed,
+  notarized and stapled.
+- [ ] Windows: cloud-based signing; no expectation of instant SmartScreen bypass.
+- [ ] Sidecars are `chmod +x` at build time and their path resolves through
+  `process.resourcesPath` when packaged.
+- [ ] Auto-update configured, and the app is signed so updates can apply.
+- [ ] Playwright test launches the packaged app and exercises at least one IPC round
+  trip.
+
+* * *
+
+## Open Research Questions
+
+1. **Do Mach-O sidecars under `Contents/Resources` reliably pass notarization?** Apple’s
+   TN2206 designates `Resources` for scripts and non-Mach-O executables, yet signed
+   binaries placed there by `extraResources` are widely shipped.
+   Resolving this needs a controlled test: notarize one build with a Mach-O sidecar in
+   `Resources` and another with it relocated to `Contents/Helpers`, and compare.
+
+2. **Is `node:sqlite` at full stability in the Node embedded in Electron 43?** It
+   reached release-candidate status in Node and stabilized in later Node versions than
+   Electron 43 embeds. Confirm before recommending it without qualification for
+   production data.
+
+3. **When does the Bun `--compile` macOS 27 signature defect
+   ([bun#32159](https://github.com/oven-sh/bun/issues/32159)) land a fix?** This gates
+   Bun-compiled sidecars on the newest macOS.
+
+4. **Will electron-builder 27 ship, and on what timeline?** The alpha has been in
+   progress for a while.
+   Its ESM migration and consolidated signing config are worth adopting, but not before
+   it is stable.
+
+5. **Does Electron Forge 8 close the gap with electron-builder** on Linux targets and
+   differential updates?
+   If so, the default recommendation here should move to the officially supported tool.
+
+* * *
+
+## Recommendations
+
+### Default Stack
+
+For a new standalone desktop app with a TypeScript UI and a Node backend:
+
+```
+Electron 43 + Node 24 (host toolchain) + pnpm 11
+├── electron-vite          # three-target build, HMR, hot restart
+├── Vite 8 (Rolldown)      # renderer
+├── TypeScript             # project references, three tsconfigs
+├── utilityProcess         # backend
+├── electron-builder       # packaging, signing, differential updates
+├── electron-updater       # auto-update on all three platforms
+├── @electron/fuses        # hardening at package time
+├── Playwright             # end-to-end against the built app
+└── node:sqlite            # persistence, when its API suffices
+```
+
+### Minimal Stack
+
+When the app is genuinely small and you want the fewest moving parts: Electron plus
+esbuild for main and preload, Vite for the renderer, and `@electron/packager` behind a
+short script. Accept that you own the dev loop.
+
+### Polyglot Backend Stack
+
+When the backend is Python or another language, keep everything above and add: a sidecar
+built with python-build-standalone plus `uv` (or a compiled Go/Rust binary), stdio
+JSON-RPC as the transport, `extraResources` for placement, an `afterPack` hook that
+signs every nested Mach-O, and explicit lifecycle supervision with a Job Object on
+Windows.
+
+### What to Avoid
+
+- Driving the Electron **build** through Bun.
+  Install with it if you like; package with Node.
+- Binding a loopback HTTP port when stdio would work.
+- Adding entitlements speculatively.
+- Starting a Python sidecar on PyOxidizer.
+- Relying on an Electron major outside the three-version support window.
+
+* * *
+
+## References
+
+### Official Documentation
+
+- [Electron Documentation](https://www.electronjs.org/docs/latest/)
+- [Electron Security Checklist](https://www.electronjs.org/docs/latest/tutorial/security)
+- [Electron Process Model](https://www.electronjs.org/docs/latest/tutorial/process-model)
+- [Electron ESM Support](https://www.electronjs.org/docs/latest/tutorial/esm)
+- [utilityProcess API](https://www.electronjs.org/docs/latest/api/utility-process)
+- [Electron Fuses](https://www.electronjs.org/docs/latest/tutorial/fuses)
+- [ASAR Integrity](https://www.electronjs.org/docs/latest/tutorial/asar-integrity)
+- [Code Signing](https://www.electronjs.org/docs/latest/tutorial/code-signing)
+- [Updating Applications](https://www.electronjs.org/docs/latest/tutorial/updates)
+- [Breaking Changes](https://www.electronjs.org/docs/latest/breaking-changes)
+- [Electron Release Timelines](https://www.electronjs.org/docs/latest/tutorial/electron-timelines)
+- [Native Node Modules](https://www.electronjs.org/docs/latest/tutorial/using-native-node-modules)
+
+### Build and Packaging Tools
+
+- [electron-vite](https://electron-vite.org/)
+- [vite-plugin-electron](https://github.com/electron-vite/vite-plugin-electron)
+- [Electron Forge](https://www.electronforge.io/)
+- [electron-builder](https://www.electron.build/)
+- [electron-builder v27 migration](https://www.electron.build/docs/migration/v27-breaking-changes/)
+- [Vite 8 announcement](https://vite.dev/blog/announcing-vite8)
+- [Playwright Electron support](https://playwright.dev/docs/api/class-electron)
+
+### Signing, Notarization, and Distribution
+
+- [Apple TN2206: macOS Code Signing In Depth](https://developer.apple.com/library/archive/technotes/tn2206/_index.html)
+- [Electron Forge macOS signing guide](https://www.electronforge.io/guides/code-signing/code-signing-macos)
+- [Microsoft: code signing options](https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/code-signing-options)
+- [Mac App Store submission guide](https://www.electronjs.org/docs/latest/tutorial/mac-app-store-submission-guide)
+- [update.electronjs.org](https://github.com/electron/update.electronjs.org)
+
+### Backend Runtimes
+
+- [Node.js Single Executable Applications](https://nodejs.org/api/single-executable-applications.html)
+- [Node.js `node:sqlite`](https://nodejs.org/api/sqlite.html)
+- [Bun standalone executables](https://bun.com/docs/bundler/executables)
+- [python-build-standalone](https://github.com/astral-sh/python-build-standalone)
+- [uv](https://docs.astral.sh/uv/)
+- [PyInstaller](https://pyinstaller.org/en/stable/)
+- [Nuitka](https://nuitka.net/)
+
+### Security Background
+
+- [GitHub: localhost dangers, CORS and DNS rebinding](https://github.blog/security/application-security/localhost-dangers-cors-and-dns-rebinding/)
+
+### Production Apps Surveyed
+
+Read directly from their build configuration for
+[§8](#8-what-shipping-apps-actually-do).
+
+- [microsoft/vscode](https://github.com/microsoft/vscode)—typed IPC channels in
+  [`src/vs/base/parts/ipc/`](https://github.com/microsoft/vscode/tree/main/src/vs/base/parts/ipc),
+  `utilityProcess` wrapper in
+  [`src/vs/platform/utilityProcess/electron-main/utilityProcess.ts`](https://github.com/microsoft/vscode/blob/main/src/vs/platform/utilityProcess/electron-main/utilityProcess.ts)
+- [signalapp/Signal-Desktop](https://github.com/signalapp/Signal-Desktop)—multi-target
+  build in
+  [`rolldown.config.ts`](https://github.com/signalapp/Signal-Desktop/blob/main/rolldown.config.ts)
+- [bitwarden/clients](https://github.com/bitwarden/clients)—fuse configuration in
+  [`apps/desktop/scripts/after-pack.js`](https://github.com/bitwarden/clients/blob/main/apps/desktop/scripts/after-pack.js),
+  preload in
+  [`apps/desktop/src/preload.ts`](https://github.com/bitwarden/clients/blob/main/apps/desktop/src/preload.ts)
+- [element-hq/element-desktop](https://github.com/element-hq/element-desktop)—fuses via
+  `electronFuses` in
+  [`electron-builder.ts`](https://github.com/element-hq/element-desktop/blob/develop/electron-builder.ts)
+- [laurent22/joplin](https://github.com/laurent22/joplin),
+  [mattermost/desktop](https://github.com/mattermost/desktop),
+  [logseq/logseq](https://github.com/logseq/logseq)
+- [electron-vite/electron-vite-react](https://github.com/electron-vite/electron-vite-react)—the
+  most current starter template found
+
+### Issue Reports Cited
+
+- [bun#9895: electron-builder `rebuild` script not found](https://github.com/oven-sh/bun/issues/9895)—open
+- [bun#18249: segfault during electron-builder build](https://github.com/oven-sh/bun/issues/18249)—closed
+- [bun#1588: Electron failed to install correctly](https://github.com/oven-sh/bun/issues/1588)—closed
+- [bun#32159: `--compile` binaries fail signature validation on macOS 27](https://github.com/oven-sh/bun/issues/32159)—open
+- [forge#3906: Bun package manager support](https://github.com/electron/forge/issues/3906)—open
+- [electron-builder#1790: executable permissions lost in packaging](https://github.com/electron-userland/electron-builder/issues/1790)
+
+* * *
+
+## Appendices
+
+### Appendix A: electron.vite.config.ts
+
+```ts
+import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
+import { resolve } from 'node:path';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  main: {
+    plugins: [externalizeDepsPlugin()],
+    build: {
+      lib: { entry: resolve(__dirname, 'src/main/index.ts'), formats: ['cjs'] },
+      sourcemap: true,
+    },
+  },
+  preload: {
+    plugins: [externalizeDepsPlugin()],
+    build: {
+      // Sandboxed preloads cannot be ESM and cannot be code-split. One CJS file.
+      lib: { entry: resolve(__dirname, 'src/preload/index.ts'), formats: ['cjs'] },
+      sourcemap: true,
+    },
+  },
+  renderer: {
+    root: resolve(__dirname, 'src/renderer'),
+    resolve: {
+      alias: { '@shared': resolve(__dirname, 'src/shared') },
+    },
+    plugins: [react()],
+    build: {
+      rollupOptions: { input: resolve(__dirname, 'src/renderer/index.html') },
+    },
+  },
+});
+```
+
+Notes on why this is short:
+
+- electron-vite already externalizes `electron` and every Node built-in, so you do not
+  list them. `externalizeDepsPlugin()` additionally keeps everything in `dependencies`
+  out of the main and preload bundles, which is what you want for native modules.
+  Anything that should be bundled belongs in `devDependencies`.
+- `build.lib.formats: ['cjs']` is the supported way to pin the output format; the
+  default is CJS or ESM depending on your `package.json` `type`, and being explicit
+  avoids a surprise if that changes.
+- `rollupOptions` remains the option name on Vite 8 even though Rolldown is the bundler
+  underneath.
+
+### Appendix B: electron-builder.yml
+
+```yaml
+appId: com.example.myapp
+productName: My App
+directories:
+  output: release
+  buildResources: build
+
+files:
+  - out/**/*
+  - package.json
+
+# Sidecars cannot execute from inside the ASAR archive.
+extraResources:
+  - from: resources/bin/${os}/${arch}
+    to: bin
+    filter: ['**/*']
+
+asar: true
+asarUnpack:
+  - '**/*.node' # native modules must be real files on disk
+
+mac:
+  category: public.app-category.productivity
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.plist
+  notarize: true
+  target:
+    - target: dmg
+      arch: [x64, arm64]
+    - target: zip # required for Squirrel.Mac auto-update
+      arch: [x64, arm64]
+
+win:
+  target:
+    - target: nsis
+      arch: [x64, arm64]
+  # Windows cannot sign from a .pfx file since June 2023; use a cloud signing service.
+
+linux:
+  category: Utility
+  target:
+    - target: deb
+      arch: [x64, arm64]
+    - target: flatpak
+      arch: [x64]
+
+publish:
+  provider: github
+
+afterPack: ./scripts/after-pack.js # sign nested binaries, restore +x
+afterSign: ./scripts/notarize.js # @electron/notarize
+```
+
+Matching `entitlements.mac.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key><true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+  <!-- Add only if a sidecar or native module actually requires it: -->
+  <!-- <key>com.apple.security.cs.disable-library-validation</key><true/> -->
+</dict>
+</plist>
+```
+
+### Appendix C: Main Process Entry Point
+
+```ts
+import { app, BrowserWindow, session, shell, ipcMain } from 'electron';
+import path from 'node:path';
+
+const APP_ORIGIN = 'app://-';
+const isDev = !app.isPackaged;
+
+function applySecurityPolicy(ses: Electron.Session): void {
+  ses.webRequest.onHeadersReceived((details, callback) => {
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': [
+          "default-src 'self'; script-src 'self'; style-src 'self'; " +
+            "img-src 'self' data:; connect-src 'self'; object-src 'none'; " +
+            "base-uri 'none'; frame-ancestors 'none'",
+        ],
+      },
+    });
+  });
+
+  // Deny every permission that has not been deliberately enabled.
+  ses.setPermissionRequestHandler((_wc, _permission, callback) => callback(false));
+}
+
+function createWindow(): BrowserWindow {
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    show: false,
+    webPreferences: {
+      preload: path.join(__dirname, '../preload/index.cjs'),
+      // These three are already the defaults. They are written out because a reviewer
+      // should see an explicit, deliberate value here rather than an absence.
+      sandbox: true,
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  win.once('ready-to-show', () => win.show());
+
+  // Never let the app itself navigate away from its own origin.
+  win.webContents.on('will-navigate', (event, url) => {
+    if (new URL(url).origin !== APP_ORIGIN) event.preventDefault();
+  });
+
+  // Open external links in the real browser; never in an app window.
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    const { protocol } = new URL(url);
+    if (protocol === 'https:') void shell.openExternal(url);
+    return { action: 'deny' };
+  });
+
+  if (isDev && process.env.ELECTRON_RENDERER_URL) {
+    void win.loadURL(process.env.ELECTRON_RENDERER_URL);
+  } else {
+    void win.loadFile(path.join(__dirname, '../renderer/index.html'));
+  }
+  return win;
+}
+
+app.whenReady().then(() => {
+  applySecurityPolicy(session.defaultSession);
+  registerIpcHandlers(ipcMain);
+  startBackend(); // utilityProcess or sidecar; see Appendix E
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});
+
+app.on('before-quit', () => {
+  stopBackend(); // never leave an orphan
+});
+```
+
+### Appendix D: Preload and Typed IPC
+
+```ts
+// src/shared/contract.ts — types only. Imported by main and renderer.
+export const Channels = {
+  openProject: 'project:open',
+  saveNote: 'note:save',
+  progress: 'backend:progress',
+} as const;
+
+export type Api = {
+  openProject: (id: string) => Promise<Project>;
+  saveNote: (note: NoteInput) => Promise<void>;
+  onProgress: (cb: (p: Progress) => void) => () => void;
+};
+```
+
+```ts
+// src/preload/index.ts — compiled to a single CJS file.
+import { contextBridge, ipcRenderer } from 'electron';
+import { Channels, type Api, type Progress } from '../shared/contract';
+
+const api: Api = {
+  // One named method per capability. No generic channel pass-through.
+  openProject: (id) => ipcRenderer.invoke(Channels.openProject, id),
+  saveNote: (note) => ipcRenderer.invoke(Channels.saveNote, note),
+
+  onProgress: (cb) => {
+    const listener = (_e: unknown, p: Progress) => cb(p);
+    ipcRenderer.on(Channels.progress, listener);
+    return () => ipcRenderer.off(Channels.progress, listener);
+  },
+};
+
+contextBridge.exposeInMainWorld('api', api);
+```
+
+```ts
+// src/renderer/env.d.ts — makes window.api typed in the renderer.
+import type { Api } from '../shared/contract';
+declare global {
+  interface Window {
+    api: Api;
+  }
+}
+```
+
+```ts
+// src/main/ipc.ts — validate the sender and the payload, every time.
+import { z } from 'zod';
+import { Channels } from '../shared/contract';
+
+const ProjectId = z.string().uuid();
+
+export function registerIpcHandlers(ipcMain: Electron.IpcMain): void {
+  ipcMain.handle(Channels.openProject, async (event, raw) => {
+    assertTrustedSender(event); // checklist item 17
+    const id = ProjectId.parse(raw); // reject anything unexpected
+    return openProject(id);
+  });
+}
+
+function assertTrustedSender(event: Electron.IpcMainInvokeEvent): void {
+  const url = new URL(event.senderFrame?.url ?? '');
+  if (url.origin !== APP_ORIGIN) throw new Error('untrusted IPC sender');
+}
+```
+
+### Appendix E: Python Sidecar End to End
+
+**1. Build the interpreter tree** (at build time, not install time):
+
+```bash
+# Fetch a relocatable CPython and assemble a locked environment beside it.
+uv python install 3.13
+uv venv --python 3.13 resources/bin/${OS}/${ARCH}/pyenv
+uv pip sync --python resources/bin/${OS}/${ARCH}/pyenv/bin/python requirements.lock
+```
+
+**2. Speak newline-delimited JSON over stdio** — no port, no auth, dies with the parent:
+
+```python
+# backend/main.py
+import json, sys
+
+for line in sys.stdin:
+    req = json.loads(line)
+    result = handle(req)
+    sys.stdout.write(json.dumps({"id": req["id"], "result": result}) + "\n")
+    sys.stdout.flush()   # without this, the parent waits forever
+```
+
+**3. Supervise it from the main process:**
+
+```ts
+import { spawn, type ChildProcess } from 'node:child_process';
+
+let backend: ChildProcess | undefined;
+
+export function startBackend(): void {
+  const root = app.isPackaged
+    ? path.join(process.resourcesPath, 'bin')
+    : path.join(__dirname, '../../resources/bin', process.platform, process.arch);
+  const python = path.join(root, 'pyenv', 'bin', 'python');
+
+  if (process.platform !== 'win32') fs.chmodSync(python, 0o755); // +x is not reliably preserved
+
+  backend = spawn(python, [path.join(root, 'main.py')], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    detached: process.platform !== 'win32', // own process group, so we can kill the tree
+  });
+  backend.on('exit', (code) => scheduleRestartWithBackoff(code));
+}
+
+export function stopBackend(): void {
+  if (!backend?.pid) return;
+  if (process.platform === 'win32') {
+    spawn('taskkill', ['/pid', String(backend.pid), '/f', '/t']);
+  } else {
+    process.kill(-backend.pid, 'SIGTERM'); // negative pid kills the group
+  }
+  backend = undefined;
+}
+```
+
+On Windows, prefer a Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` over
+`taskkill` if you can add a native dependency: it is the only approach that also cleans
+up when the main process crashes.
+
+**4. Sign every Mach-O in the tree** in `afterPack`, before the outer app is signed:
+
+```js
+// scripts/after-pack.js
+const { execFileSync } = require('node:child_process');
+const { globSync } = require('glob');
+
+exports.default = async function afterPack(context) {
+  if (context.electronPlatformName !== 'darwin') return;
+  const resources = `${context.appOutDir}/${context.packager.appInfo.productFilename}.app/Contents/Resources`;
+  // The interpreter, every .so extension module, and every bundled .dylib.
+  for (const file of globSync(`${resources}/bin/**/*(*.so|*.dylib|python*)`, { nodir: true })) {
+    execFileSync('codesign', [
+      '--force', '--options', 'runtime', '--timestamp',
+      '--entitlements', 'build/entitlements.mac.plist',
+      '--sign', process.env.CSC_NAME, file,
+    ]);
+  }
+};
+```
+
+### Appendix F: GitHub Actions Release Workflow
+
+```yaml
+name: Release
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+          - os: windows-latest
+          - os: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      # The Electron binary download is the largest cost in a cold build.
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/electron
+          key: electron-${{ matrix.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+
+      - name: Build and publish
+        run: pnpm exec electron-builder --publish always
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # macOS: certificate and notarization credentials.
+          CSC_LINK: ${{ secrets.MAC_CERT_P12 }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CERT_PASSWORD }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          # Windows: a cloud signing service. Key material cannot live in a file.
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+```
+
+Notarize on tags only.
+Pull request builds should package without signing, which is fast and needs no secrets.
 
 ## Related Guidelines
 
 - For monorepo setup with pnpm, see `tbd guidelines pnpm-monorepo-patterns`
 - For monorepo setup with Bun, see `tbd guidelines bun-monorepo-patterns`
-
-## References
-
-### Primary Sources (Directly Analyzed)
-
-- [craft-agents-oss source](https://github.com/lukilabs/craft-agents-oss)
-- [Electrobun source](https://github.com/blackboardsh/electrobun)
-
-### Official Documentation
-
-- [Electron Documentation](https://electronjs.org/docs)
-- [electron-builder Documentation](https://electron.build)
-- [electron-builder Common Configuration](https://www.electron.build/configuration.html)
-- [Bun Documentation](https://bun.sh/docs)
-- [pnpm Documentation](https://pnpm.io)
-- [Electrobun Documentation](https://electrobun.dev)
-- [Neutralino.js Documentation](https://neutralino.js.org)
-- [Buntralino Documentation](https://buntralino.github.io)
-- [Tauri Documentation](https://tauri.app)
-
-### GitHub Issue Reports (Bun + Electron)
-
-- [Bun #18249: Segfault during electron-builder build phase](https://github.com/oven-sh/bun/issues/18249)
-  (March 2025)
-- [Bun #9895: Does not work with electron-builder](https://github.com/oven-sh/bun/issues/9895)
-  (April 2024)
-- [Bun #1588: Electron failed to install correctly](https://github.com/oven-sh/bun/issues/1588)
-- [electron-forge #3906: Use bun when bunx is used](https://github.com/electron/forge/issues/3906)
-  (April 2025)
-- [Quasar #17085: Electron build error with Bun and pnpm](https://github.com/quasarframework/quasar/issues/17085)—Fixed
-  in Quasar v1.8.5, v2.0.0-beta.11, v3.12.8, v4.0.0-beta.12
-
-### GitHub Issue Reports (Electrobun)
-
-- [Bun #24876: Crash on MacBook Pro M2 Pro](https://github.com/oven-sh/bun/issues/24876)
-  (November 2025)—Closed as duplicate; resolved in Electrobun 0.1.21-beta.0+
-
-### GitHub Discussions
-
-- [Bun #790: Desktop support (Electron replacement)](https://github.com/oven-sh/bun/discussions/790)—Community
-  discussion on Bun desktop app support
-
-### Community Resources (Stack Overflow)
-
-- [How to run Electron.js with Bun?](https://stackoverflow.com/questions/77295981/how-run-electron-js-with-bun)
-- [Error when building my Electron app](https://stackoverflow.com/questions/46868107/error-when-building-my-electron-app)
-- [electron-builder not working for production due to path](https://stackoverflow.com/questions/53422717/electron-builder-not-working-for-production-due-to-path)
-
-### Community Resources (Reddit)
-
-- [Electron app works in dev but fails after build](https://www.reddit.com/r/electronjs/comments/1gnm7g5/help_needed_electron_app_works_in_dev_but_fails/)
-- [Why everyone does not just use Bun in 2025](https://www.reddit.com/r/bun/comments/1m69ui2/why_everyone_does_not_just_using_bun_in_2025/)
-- [Electron app reference architecture](https://www.reddit.com/r/node/comments/vkffcq/basic1_electron_app_reference_architecture/)
-
-### Blog Posts and News (Third-Party Opinions)
-
-- [Why We Ditched Node for Bun in 2026](https://dev.to/rayenmabrouk/why-we-ditched-node-for-bun-in-2026-and-why-you-should-too-48kg)—Opinion
-  piece
-- [Electrobun on Hacker News](https://news.ycombinator.com/item?id=42199486)
-- [Electrobun on Brian Lovin’s HN](https://brianlovin.com/hn/42199486)
-
-### Anthropic/Bun Acquisition (Primary Sources)
-
-- [Anthropic acquires Bun as Claude Code reaches $1B milestone](https://www.anthropic.com/news/anthropic-acquires-bun-as-claude-code-reaches-usd1b-milestone)—Official
-  Anthropic announcement (December 3, 2025)
-- [Bun is joining Anthropic](https://bun.com/blog/bun-joins-anthropic)—Bun’s
-  announcement (December 2, 2025)
-
-### Other Bug Reports
-
-- [Launchpad #1944468: Electron applications all crash upon launch](https://bugs.launchpad.net/bugs/1944468)—Ubuntu-specific
-  Electron issues
+- For dependency policy, see `tbd guidelines supply-chain-hardening`
+- For TypeScript conventions, see `tbd guidelines typescript-rules`
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/packages/tbd/docs/guidelines/electron-app-development-patterns.md
+++ b/packages/tbd/docs/guidelines/electron-app-development-patterns.md
@@ -95,7 +95,7 @@ This document is a reference for building a **clean, minimal, standalone Electro
 desktop app** with a modern build system and a backend written in whatever language
 suits the problem—Node.js, Bun, Python, Go, or a combination.
 
-The recommended default: **Electron 43 + electron-vite + TypeScript +
+The recommended default: **Electron 43 and electron-vite with TypeScript and
 electron-builder**, with the renderer as an ordinary Vite web app, the main process as a
 thin bundled CommonJS entry point, a CommonJS preload exposing a narrow typed API over
 `contextBridge`, and any substantial backend work pushed into a **`utilityProcess`**
@@ -1082,9 +1082,16 @@ the app is small enough that the runtime dominates it.
 The main tradeoff you are accepting in exchange is **webview fragmentation**:
 system-webview frameworks render on WebView2 on Windows, WKWebView on macOS, and
 WebKitGTK on Linux, so you write once and debug three times.
+That cost is concrete rather than
+theoretical—`tbd guidelines tauri-app-development-patterns` catalogues what actually
+breaks, and the Linux list is long.
 
-A detailed comparison of Tauri, Electrobun, Wails, and Neutralino is deliberately out of
-scope here and is tracked as separate research; this document stays focused on Electron.
+The two alternatives worth evaluating have their own guidelines: **Tauri**
+(`tbd guidelines tauri-app-development-patterns`) for a small, signed, auto-updating app
+if you can accept Rust in the build, and **Electrobun**
+(`tbd guidelines electrobun-app-development-patterns`) for internal or trusted-audience
+distribution only, since its updater verifies nothing.
+Wails and Neutralino are not covered.
 
 * * *
 

--- a/packages/tbd/docs/guidelines/electron-app-development-patterns.md
+++ b/packages/tbd/docs/guidelines/electron-app-development-patterns.md
@@ -2,7 +2,7 @@
 title: Electron App Development Patterns
 description: Building a clean, minimal, standalone Electron app—process model, modern Vite-based build system, attaching a Node/Bun/Python backend, security baseline, packaging, code signing, and auto-update
 author: Joshua Levy (github.com/jlevy) with LLM assistance
-category: electron
+category: desktop
 ---
 # Electron App Development Patterns
 

--- a/packages/tbd/docs/guidelines/electron-app-development-patterns.md
+++ b/packages/tbd/docs/guidelines/electron-app-development-patterns.md
@@ -35,9 +35,9 @@ given as the pin, per [Supply-Chain Mitigation](#supply-chain-mitigation).
 | Tool / Package | Version | Check For Updates |
 | --- | --- | --- |
 | **Electron** | ^43.2.0 (43.3.0/43.4.0 too recent) | [releases.electronjs.org](https://releases.electronjs.org/)—**43.4.0** (2026-08-11) is current stable: Chromium 150, Node 24.18.1, V8 15.0. Supported majors are **41, 42, 43**; **41 reaches EOL 2026-08-25**, so 42 is the practical floor. 44 is in beta and **drops macOS 12, 32-bit Windows (ia32), and linux-armv7l**. Security fixes ship on the supported line only—track the latest patch, not just the major. |
-| **Node.js (host toolchain)** | 24 (LTS “Krypton”) | [nodejs.org/releases](https://nodejs.org/en/about/previous-releases)—Node 24 Active LTS until Apr 2028; Node 26 Current (LTS Oct 2026); Node 22 in maintenance; **Node 20 EOL 2026-03-24**. Note the Node version *inside* Electron is set by Electron, not by your host Node. |
+| **Node.js (host toolchain)** | 24 (LTS “Krypton”) | [nodejs.org/releases](https://nodejs.org/en/about/previous-releases)—Node 24 Active LTS (EOL Apr 2028; moves to maintenance when Node 26 enters LTS in Oct 2026); Node 26 Current; Node 22 in maintenance; **Node 20 EOL 2026-03-24**. Note the Node version *inside* Electron is set by Electron, not by your host Node. |
 | **electron-vite** | ^5.0.0 | [electron-vite.org](https://electron-vite.org/)—5.0.0 (2025-12-07). Supports Vite 7 and 8. Added `build.isolatedEntries` for multi-entry isolation and stronger bytecode string protection. 6.0.0-beta.1 exists; not stable. |
-| **vite-plugin-electron** | ^1.1.1 | [github.com/electron-vite/vite-plugin-electron](https://github.com/electron-vite/vite-plugin-electron)—1.1.1 (2026-08-03). Same org as electron-vite, currently the more frequently released of the two. Auto-selects `rolldownOptions` on Vite 8+ and `rollupOptions` below. Use when you want a plugin inside a standard Vite project rather than a separate CLI. |
+| **vite-plugin-electron** | ^1.1.0 (1.1.1 too recent) | [github.com/electron-vite/vite-plugin-electron](https://github.com/electron-vite/vite-plugin-electron)—**Pinned to 1.1.0 (2026-06-24) per the 14-day rule**; 1.1.1 (2026-08-03) is 12 days old today. Same org as electron-vite, currently the more frequently released of the two. Auto-selects `rolldownOptions` on Vite 8+ and `rollupOptions` below. Use when you want a plugin inside a standard Vite project rather than a separate CLI. |
 | **Vite** | ^8.2.0 (8.2.1 too recent) | [vite.dev](https://vite.dev/blog/announcing-vite8)—Vite 8 (2026-03-12) ships **Rolldown as its sole bundler**, replacing the esbuild-for-dev / Rollup-for-prod split. Requires Node 20.19+ or 22.12+. |
 | **Rolldown** | ^1.2.1 (1.2.2+ too recent) | [rolldown.rs](https://rolldown.rs/)—1.0 stable May 2026; 1.2.4 (2026-08-12) newest. Adopted Rollup’s plugin API, so most Vite plugins work unmodified. Maintained by VoidZero, **acquired by Cloudflare 2026-06-04**; tools remain MIT. |
 | **esbuild** | ^0.28.1 (0.28.2 too recent) | [github.com/evanw/esbuild/releases](https://github.com/evanw/esbuild/releases)—still pre-1.0. No longer inside Vite’s production path, but still the simplest standalone choice for bundling a main process without adopting a framework. |
@@ -54,7 +54,7 @@ given as the pin, per [Supply-Chain Mitigation](#supply-chain-mitigation).
 | **update-electron-app** | ^3.3.0 | [github.com/electron/update-electron-app](https://github.com/electron/update-electron-app)—3.3.0 (2026-06-28). |
 | **Playwright** | ^1.62.1 | [playwright.dev](https://playwright.dev/docs/api/class-electron)—1.62.1 (2026-07-30). `_electron` is still an experimental namespace but is the standard way to drive a packaged app in tests. |
 | **better-sqlite3** | ^13.0.2 (13.0.3 too recent) | [npmjs.com/package/better-sqlite3](https://www.npmjs.com/package/better-sqlite3)—13.0.3 (2026-08-05) newest. Needs `@electron/rebuild`. Consider `node:sqlite` first (see [Native Modules](#native-modules)). |
-| **pnpm** | ^11.21.0 | [github.com/pnpm/pnpm/releases](https://github.com/pnpm/pnpm/releases)—pnpm 11 moved `nodeLinker` and `shamefullyHoist` out of `.npmrc` into `pnpm-workspace.yaml`, replaced `onlyBuiltDependencies` with `allowBuilds`, and made `strictDepBuilds` default to `true`. |
+| **pnpm** | ^11.19.0 (11.20+ too recent) | [github.com/pnpm/pnpm/releases](https://github.com/pnpm/pnpm/releases)—**Pinned to 11.19.0 (2026-07-31) per the 14-day rule**; 11.20.0 through 11.22.0 are all under 14 days old today. pnpm 11 moved `nodeLinker` and `shamefullyHoist` out of `.npmrc` into `pnpm-workspace.yaml`, replaced `onlyBuiltDependencies` with `allowBuilds`, and made `strictDepBuilds` default to `true`. |
 | **npm** | ^12.0.2 | [npmjs.com/package/npm](https://www.npmjs.com/package/npm)—npm 12 (2026-07-08) **disables dependency install scripts by default** (`allowScripts`); approve with `npm approve-scripts`. |
 | **Bun** | ^1.3.14 | [bun.com/blog](https://bun.com/blog)—1.3.14 (2026-05-13). Fine as a package manager and as a sidecar runtime; **not** a supported driver for Forge, and still unreliable through electron-builder’s script hooks. |
 
@@ -160,6 +160,10 @@ architecture early rather than as a later optimization.
 A rule that resolves most confusion: **there is no Node.js in the renderer, and there
 should never be.** If the renderer needs to read a file, call an API with a secret, or
 spawn a process, it asks the main process to do it through a named, validated channel.
+
+One API note for apps that embed more than one web view in a window: use
+`WebContentsView`. Its predecessor `BrowserView` has been deprecated since Electron 29,
+and the `<webview>` tag is disabled by default and discouraged by the Electron team.
 
 ### Module Format: The ESM Situation
 
@@ -301,7 +305,7 @@ The parts that matter:
 const win = new BrowserWindow({
   show: false, // avoid the white flash; show on 'ready-to-show'
   webPreferences: {
-    preload: path.join(__dirname, '../preload/index.cjs'),
+    preload: path.join(__dirname, '../preload/index.js'),
     // sandbox, contextIsolation, nodeIntegration are already correct by default.
     // They are listed in Appendix C explicitly, as documentation, not as a fix.
   },
@@ -460,7 +464,7 @@ best practice is not the one most tutorials describe.
 
 | Approach | Status (Aug 2026) | Notes |
 | --- | --- | --- |
-| **python-build-standalone + uv** (recommended) | Actively maintained by Astral since Dec 2024; release tag 20260610 ships CPython 3.13.14 and 3.14.6 | Relocatable CPython builds—statically linked, with the build system patched to use relative paths. Assemble the app environment at build time with `uv venv` and `uv pip sync` against a lockfile, then ship the tree. Most predictable and most debuggable. |
+| **python-build-standalone + uv** (recommended) | Actively maintained by Astral since Dec 2024; release tag 20260610 ships CPython 3.13.14 and 3.14.6 | Relocatable CPython builds—statically linked, with the build system patched to use relative paths. At build time, `uv pip sync` your lockfile **directly into the standalone tree** and ship that tree. Do not ship a venv: venv scripts and `pyvenv.cfg` hardcode build-machine paths, and the venv’s interpreter is a symlink back to wherever it was created. Most predictable and most debuggable. |
 | **PyInstaller** | 6.22.1, actively maintained, Python 3.8–3.15 | Mature and widely used. Sizes run ~28MB for a Flask app to ~180MB with PyTorch; startup ~2–3s, and onefile mode adds unpacking time that is worst on Windows. |
 | **Nuitka** | 4.x, actively maintained | Compiles to C. Faster execution, some IP protection. AGPLv3 with an exemption for compiled output; a commercial edition exists. Python 3.14 support is experimental. |
 | **Briefcase** (BeeWare) | Actively maintained | Whole-app packager rather than a backend packager. Cannot cross-build; you build on each target platform. |
@@ -654,11 +658,11 @@ restore.
 
 ### The Preload Boundary Is an RPC Boundary
 
-Covered in [Typed IPC](#typed-ipc-across-the-context-bridge); restated here because it
-is the single highest-value control.
 Most Electron security incidents are effectively **XSS to RCE**, and the escalation path
-runs through an over-broad preload API. Expose named capabilities, never a generic
-channel. Validate the sender and the payload in every handler.
+runs through an over-broad preload API. This is the single highest-value control.
+Expose named capabilities, never a generic channel, and validate the sender and the
+payload in every handler—the pattern and code are in
+[Typed IPC](#typed-ipc-across-the-context-bridge).
 
 ### Content Security Policy
 
@@ -692,9 +696,12 @@ contents.setWindowOpenHandler(({ url }) => {
   return { action: 'deny' };
 });
 
-// 2. Navigation: pin the app to its own origin.
+// 2. Navigation: allow only the URLs the app itself loads. With loadFile the
+//    renderer's origin is the opaque 'null', so compare against a URL prefix
+//    (dev server URL or the packaged renderer's file:// base), not an origin.
+//    A custom protocol gives you a real origin to compare instead.
 contents.on('will-navigate', (event, url) => {
-  if (new URL(url).origin !== APP_ORIGIN) event.preventDefault();
+  if (!url.startsWith(trustedRendererBase)) event.preventDefault();
 });
 
 // 3. Permissions: deny everything you have not deliberately enabled.
@@ -905,18 +912,17 @@ This requirement is documented in electron-builder’s issue tracker rather than
 its docs, and Electron Forge documents the equivalent requirement for its pnpm support
 added in 7.7.0.
 
-**On Bun specifically.** An older version of this document rated Bun’s Electron support
-“low” on the strength of four issue reports.
-Rechecking them in August 2026: the electron-builder segfault
-([bun#18249](https://github.com/oven-sh/bun/issues/18249)) is closed, the ancient
-install failure ([bun#1588](https://github.com/oven-sh/bun/issues/1588), filed against
-Bun 0.2.2 in 2022) is closed, and the Quasar lockfile mismatch is closed with a
-documented workaround.
-The two that remain open are the ones that matter: Forge does not support Bun, and
+**On Bun specifically.** Advice that Bun and Electron are broadly incompatible rests on
+issue reports from 2024–2025, most of which have since been resolved: the
+electron-builder segfault ([bun#18249](https://github.com/oven-sh/bun/issues/18249)) is
+closed, the install failure ([bun#1588](https://github.com/oven-sh/bun/issues/1588),
+filed against Bun 0.2.2 in 2022) is closed, and the Quasar lockfile mismatch is closed
+with a documented workaround.
+The two still open are the ones that matter: Forge does not support Bun, and
 electron-builder’s `rebuild` script lookup still fails under Bun.
-The accurate statement is narrower than the old one: **Bun is a fine package manager and
-sidecar runtime for an Electron project; it is not a supported driver for the Electron
-build step.** Install with Bun if you like, and invoke the packager through Node.
+So the accurate claim is narrow: **Bun is a fine package manager and sidecar runtime for
+an Electron project; it is not a supported driver for the Electron build step.** Install
+with Bun if you like, and invoke the packager through Node.
 
 * * *
 
@@ -971,12 +977,12 @@ actual build configuration on 2026-08-16.
 
 What generalizes, and what does not:
 
-- **electron-builder wins on adoption, decisively.** Every app here uses it except VS
-  Code, which runs a custom pipeline justified by its scale, and Logseq, whose packager
-  could not be confirmed.
-  **None use Electron Forge**, despite Forge being the officially supported tool.
-  This is the strongest empirical signal in the survey, and it is why electron-builder
-  is the recommendation here despite not being an official Electron project.
+- **electron-builder wins on adoption.** Every app here uses it except VS Code, which
+  runs a custom pipeline justified by its scale, and Logseq, whose packager could not be
+  confirmed. **None use Electron Forge**, despite Forge being the officially supported
+  tool. This is the strongest empirical signal in the survey, and it is why
+  electron-builder is the recommendation here despite not being an official Electron
+  project.
 
 - **CJS for main and preload is universal.** Every app in the survey emits CJS for the
   preload, and all but VS Code emit CJS for main.
@@ -1098,7 +1104,7 @@ scope here and is tracked as separate research; this document stays focused on E
 - [ ] `sandbox`, `contextIsolation`, and `nodeIntegration` left at their defaults.
 - [ ] CSP set via response header, with no `unsafe-inline` or `unsafe-eval`.
 - [ ] `setWindowOpenHandler` denies by default.
-- [ ] `will-navigate` pins the app to its own origin.
+- [ ] `will-navigate` blocks navigation outside the URLs the app itself loads.
 - [ ] Permission request handler denies by default.
 - [ ] `shell.openExternal` allowlists the scheme.
 - [ ] Fuses flipped: `runAsNode`, `nodeCliInspect`, `nodeOptions`, and
@@ -1167,6 +1173,12 @@ Electron 43 + Node 24 (host toolchain) + pnpm 11
 ├── Playwright             # end-to-end against the built app
 └── node:sqlite            # persistence, when its API suffices
 ```
+
+On the package manager: npm works with zero Electron-specific configuration and is an
+equally sound choice.
+pnpm appears here because it matches the companion monorepo guidelines; its
+`nodeLinker: hoisted` requirement is the one non-obvious step, covered in
+[§6](#6-package-managers-and-the-electron-toolchain).
 
 ### Minimal Stack
 
@@ -1327,6 +1339,9 @@ Notes on why this is short:
   avoids a surprise if that changes.
 - `rollupOptions` remains the option name on Vite 8 even though Rolldown is the bundler
   underneath.
+- Leave `package.json` without `"type": "module"`. The built main and preload are CJS
+  (emitted as `out/main/index.js` and `out/preload/index.js`), and a `"type": "module"`
+  declaration would make Node treat those `.js` files as ESM.
 
 ### Appendix B: electron-builder.yml
 
@@ -1406,9 +1421,15 @@ Matching `entitlements.mac.plist`:
 ```ts
 import { app, BrowserWindow, session, shell, ipcMain } from 'electron';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
-const APP_ORIGIN = 'app://-';
-const isDev = !app.isPackaged;
+// The URL prefix the renderer legitimately lives under: the dev server in
+// development, the packaged renderer directory in production. With loadFile
+// the page's origin is the opaque 'null', so trust is a URL prefix, not an
+// origin. (A custom app:// protocol would give you a real origin instead.)
+const trustedRendererBase =
+  process.env.ELECTRON_RENDERER_URL ??
+  pathToFileURL(path.join(__dirname, '../renderer/')).href;
 
 function applySecurityPolicy(ses: Electron.Session): void {
   ses.webRequest.onHeadersReceived((details, callback) => {
@@ -1434,7 +1455,7 @@ function createWindow(): BrowserWindow {
     height: 800,
     show: false,
     webPreferences: {
-      preload: path.join(__dirname, '../preload/index.cjs'),
+      preload: path.join(__dirname, '../preload/index.js'),
       // These three are already the defaults. They are written out because a reviewer
       // should see an explicit, deliberate value here rather than an absence.
       sandbox: true,
@@ -1445,9 +1466,9 @@ function createWindow(): BrowserWindow {
 
   win.once('ready-to-show', () => win.show());
 
-  // Never let the app itself navigate away from its own origin.
+  // Never let the app navigate outside the URLs it loads itself.
   win.webContents.on('will-navigate', (event, url) => {
-    if (new URL(url).origin !== APP_ORIGIN) event.preventDefault();
+    if (!url.startsWith(trustedRendererBase)) event.preventDefault();
   });
 
   // Open external links in the real browser; never in an app window.
@@ -1457,7 +1478,7 @@ function createWindow(): BrowserWindow {
     return { action: 'deny' };
   });
 
-  if (isDev && process.env.ELECTRON_RENDERER_URL) {
+  if (process.env.ELECTRON_RENDERER_URL) {
     void win.loadURL(process.env.ELECTRON_RENDERER_URL);
   } else {
     void win.loadFile(path.join(__dirname, '../renderer/index.html'));
@@ -1547,21 +1568,31 @@ export function registerIpcHandlers(ipcMain: Electron.IpcMain): void {
   });
 }
 
+// Same trustedRendererBase as the entry point (Appendix C): dev server URL in
+// development, the packaged renderer's file:// base in production.
 function assertTrustedSender(event: Electron.IpcMainInvokeEvent): void {
-  const url = new URL(event.senderFrame?.url ?? '');
-  if (url.origin !== APP_ORIGIN) throw new Error('untrusted IPC sender');
+  const url = event.senderFrame?.url ?? '';
+  if (!url.startsWith(trustedRendererBase)) throw new Error('untrusted IPC sender');
 }
 ```
 
 ### Appendix E: Python Sidecar End to End
 
-**1. Build the interpreter tree** (at build time, not install time):
+**1. Build the interpreter tree** (at build time, not install time).
+Unpack a python-build-standalone release for each target and install the locked
+dependencies **directly into that tree**—not into a venv, whose scripts and `pyvenv.cfg`
+hardcode build-machine paths and whose interpreter is a symlink back to wherever the
+venv was created:
 
 ```bash
-# Fetch a relocatable CPython and assemble a locked environment beside it.
-uv python install 3.13
-uv venv --python 3.13 resources/bin/${OS}/${ARCH}/pyenv
-uv pip sync --python resources/bin/${OS}/${ARCH}/pyenv/bin/python requirements.lock
+# One target shown; repeat per {os, arch}. Use the install_only variant.
+PBS=https://github.com/astral-sh/python-build-standalone/releases/download/20260610
+curl -LO $PBS/cpython-3.13.14+20260610-aarch64-apple-darwin-install_only.tar.gz
+mkdir -p resources/bin/darwin/arm64
+tar -xzf cpython-*.tar.gz -C resources/bin/darwin/arm64   # yields .../python/
+
+uv pip sync --python resources/bin/darwin/arm64/python/bin/python3 requirements.lock
+cp -r backend resources/bin/darwin/arm64/backend   # the app's own Python source
 ```
 
 **2. Speak newline-delimited JSON over stdio** — no port, no auth, dies with the parent:
@@ -1588,11 +1619,14 @@ export function startBackend(): void {
   const root = app.isPackaged
     ? path.join(process.resourcesPath, 'bin')
     : path.join(__dirname, '../../resources/bin', process.platform, process.arch);
-  const python = path.join(root, 'pyenv', 'bin', 'python');
+  const python =
+    process.platform === 'win32'
+      ? path.join(root, 'python', 'python.exe')
+      : path.join(root, 'python', 'bin', 'python3');
 
   if (process.platform !== 'win32') fs.chmodSync(python, 0o755); // +x is not reliably preserved
 
-  backend = spawn(python, [path.join(root, 'main.py')], {
+  backend = spawn(python, [path.join(root, 'backend', 'main.py')], {
     stdio: ['pipe', 'pipe', 'pipe'],
     detached: process.platform !== 'win32', // own process group, so we can kill the tree
   });
@@ -1625,7 +1659,11 @@ exports.default = async function afterPack(context) {
   if (context.electronPlatformName !== 'darwin') return;
   const resources = `${context.appOutDir}/${context.packager.appInfo.productFilename}.app/Contents/Resources`;
   // The interpreter, every .so extension module, and every bundled .dylib.
-  for (const file of globSync(`${resources}/bin/**/*(*.so|*.dylib|python*)`, { nodir: true })) {
+  const machO = globSync(
+    [`${resources}/bin/**/*.so`, `${resources}/bin/**/*.dylib`, `${resources}/bin/**/bin/python*`],
+    { nodir: true },
+  );
+  for (const file of machO) {
     execFileSync('codesign', [
       '--force', '--options', 'runtime', '--timestamp',
       '--entitlements', 'build/entitlements.mac.plist',
@@ -1653,6 +1691,10 @@ jobs:
           - os: windows-latest
           - os: ubuntu-latest
     runs-on: ${{ matrix.os }}
+    env:
+      # Pin the Electron download cache to one path so the cache step below is
+      # correct on all three runners (the OS-default location differs per OS).
+      ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
@@ -1664,25 +1706,38 @@ jobs:
       # The Electron binary download is the largest cost in a cold build.
       - uses: actions/cache@v4
         with:
-          path: ~/.cache/electron
+          path: ${{ github.workspace }}/.cache/electron
           key: electron-${{ matrix.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
 
+      # electron-builder's notarization wants APPLE_API_KEY as a file path.
+      - name: Write Apple API key
+        if: runner.os == 'macOS'
+        run: printf '%s' "$APPLE_API_KEY_P8" > "$RUNNER_TEMP/apple_api_key.p8"
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+
       - name: Build and publish
         run: pnpm exec electron-builder --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # macOS: certificate and notarization credentials.
+          # macOS: signing certificate plus notarization credentials.
           CSC_LINK: ${{ secrets.MAC_CERT_P12 }}
           CSC_KEY_PASSWORD: ${{ secrets.MAC_CERT_PASSWORD }}
+          APPLE_API_KEY: ${{ runner.temp }}/apple_api_key.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          # Windows: a cloud signing service. Key material cannot live in a file.
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          # Windows: cloud signing (Azure Artifact Signing); key material cannot
+          # live in a file. Also requires win.azureSignOptions in electron-builder.yml.
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 ```
+
+Environment variables that do not apply to a given OS are ignored, so one shared step
+works across the matrix.
 
 Notarize on tags only.
 Pull request builds should package without signing, which is fast and needs no secrets.

--- a/packages/tbd/docs/guidelines/tauri-app-development-patterns.md
+++ b/packages/tbd/docs/guidelines/tauri-app-development-patterns.md
@@ -1,0 +1,738 @@
+---
+title: Tauri App Development Patterns
+description: Building desktop apps with Tauri 2—the Rust core and system webview model, capabilities and permissions, typed commands and IPC, attaching Rust or non-Rust backends, packaging, signing, and the signed updater
+author: Joshua Levy (github.com/jlevy) with LLM assistance
+category: desktop
+---
+# Tauri App Development Patterns
+
+**Last Updated**: 2026-08-16
+
+**Related**:
+
+- [Tauri documentation](https://v2.tauri.app/)
+- [Tauri source](https://github.com/tauri-apps/tauri)
+- [awesome-tauri](https://github.com/tauri-apps/awesome-tauri)
+- [Companion: Electron App Development Patterns](https://github.com/jlevy/tbd/blob/main/packages/tbd/docs/guidelines/electron-app-development-patterns.md)
+- [Companion: Electrobun App Development Patterns](https://github.com/jlevy/tbd/blob/main/packages/tbd/docs/guidelines/electrobun-app-development-patterns.md)
+
+* * *
+
+## Updating This Document
+
+Tauri releases steadily and its 2.x line is stable, so the facts here age more slowly
+than in the Electrobun guideline.
+The parts most worth rechecking are the Linux webview situation and the Tauri 3.0
+roadmap, both of which are actively changing.
+
+### Last Researched Versions
+
+Observed 2026-08-16 by querying crates.io and the npm registry directly.
+Every pin below clears the 14-day cool-off in `tbd guidelines supply-chain-hardening` by
+at least 46 days.
+
+| Thing | Version | Check For Updates |
+| --- | --- | --- |
+| **tauri** (Rust crate) | 2.11.5 | [crates.io/crates/tauri](https://crates.io/crates/tauri)—published 2026-07-01. Still the 2.x line; **no v3 yet**. |
+| **tauri-build** | 2.6.3 | Versions on its own 2.6.x line, not in lockstep with the core crate. |
+| **tauri-cli / @tauri-apps/cli** | 2.11.4 | Published 2026-06-28. |
+| **@tauri-apps/api** | 2.11.1 | Published 2026-06-17. |
+| **tauri-plugin-updater / @tauri-apps/plugin-updater** | 2.10.1 | Rust crate and JS package share a version. |
+| **tauri-plugin-shell / @tauri-apps/plugin-shell** | 2.3.5 | Needed for sidecars. |
+| **Minimum version to pin** | **2.11.1** | 2.11.1 shipped security fixes: ACL enforcement for remote origins, and localhost suffix handling. Do not pin below it. |
+| **Linux webview** | webkit2gtk **4.1** | `4.0` was removed in Ubuntu 24 and Debian 13. Engine capability tracks the distro, not your build. |
+| **Windows webview** | WebView2 (Evergreen) | Preinstalled on Windows 11; bootstrapped on older versions. |
+
+A version-alignment note, because the obvious guess is wrong: **the ecosystem is
+near-lockstep but not uniform.** A plugin’s Rust crate and JS package share a version
+(`tauri-plugin-updater` 2.10.1 matches `@tauri-apps/plugin-updater` 2.10.1), but the
+core crates version independently—`tauri` at 2.11.5, the CLI at 2.11.4, `tauri-build` at
+2.6.3. Match plugin pairs; do not try to force the core crates to one number.
+
+### Reminders When Updating
+
+1. **Recheck the Linux webview story first.** It is the weakest part of Tauri and the
+   part changing fastest.
+   Tauri 3.0’s headline item is the GTK4 and WebKitGTK 6.0 migration, which addresses
+   much of [What Breaks on Linux](#6-what-actually-breaks-across-webviews).
+
+2. **Recheck the security advisories** and the minimum safe version.
+   The 2.11.1 fixes above are the current floor.
+
+3. **Recheck `webviewInstallMode` sizes.** The bootstrapper options change, and
+   `embedBootstrapper` currently costs roughly 190MB.
+
+4. **Re-measure bundle sizes** rather than repeating claims.
+   The numbers here come from real release assets and vary enormously with what you put
+   in the Rust half.
+
+5. **Recheck the deprecation list.** The signer environment variables were renamed
+   recently and the tray API is deprecated.
+
+* * *
+
+## Executive Summary
+
+Tauri builds desktop apps from a Rust core plus the operating system’s own webview.
+It ships no browser engine, which is where its small bundles come from, and it replaces
+Electron’s “secure it yourself” posture with a compile-time permission system that
+denies everything by default.
+
+Four things matter most when deciding:
+
+- **The updater verifies what it installs.** The downloaded payload is checked with
+  minisign against a public key compiled into your app, and the update aborts if
+  verification fails. This is a categorical difference from an updater that trusts its
+  host, and it is the single strongest reason to prefer Tauri over less mature
+  alternatives.
+
+- **The security model is genuinely two-sided.** `core:default` grants around 106 window
+  and menu permissions and *zero* filesystem, shell, or network access, so the deny-all
+  baseline is real. But there is no equivalent of Electron’s OS-level renderer sandbox,
+  CSP is off by default, and **the webview’s patch cycle belongs to the user’s operating
+  system, not to you**.
+
+- **Linux is the weak platform.** WebRTC is unavailable in distro WebKitGTK, media
+  served through Tauri’s own asset protocol does not play, and drag-and-drop is broken
+  across several open issues.
+  If Linux is a first-class target, read
+  [What Breaks](#6-what-actually-breaks-across-webviews) before committing.
+
+- **You pay in build time, not in bundle size.** Rust builds impose a real 3-5x CI
+  penalty against a JavaScript-only toolchain, and you cannot cross-compile.
+
+**Recommendation in one line:** the default choice when you want a small, signed,
+auto-updating desktop app and can accept Rust in the build and system webviews in the
+product—with Linux support verified early rather than assumed.
+
+**Research questions this document answers**:
+
+1. What runs where, and what is the actual security boundary?
+2. How do capabilities and permissions work, and how tightly do real apps scope them?
+3. How do you attach a backend—in Rust, or in Python, Node, Bun, or Go?
+4. What does it take to package, sign, and ship verified updates?
+
+* * *
+
+## 1. Architecture and the Process Model
+
+### The Layers
+
+| Layer | What it is | Role |
+| --- | --- | --- |
+| **Rust core** | Your `src-tauri` crate | Privileged process. Owns the filesystem, OS APIs, and command handlers. |
+| **TAO** | Windowing crate (0.36.0) | Windows, menus, tray, events. |
+| **WRY** | Webview abstraction (0.56.0) | Wraps each platform’s native webview. |
+| **Webview** | WebView2, WKWebView, WebKitGTK, Android System WebView | Your UI. No filesystem, no OS access. |
+
+The webview has no ambient privilege.
+Everything it can do passes through the IPC layer, and every IPC call is gated by
+permissions declared at compile time.
+
+**There is no preload script.** This is the sharpest structural difference from
+Electron, where the preload is the audited crossing point.
+In Tauri the frontend imports `@tauri-apps/api`, and the security boundary is the
+permission system rather than a script you write.
+The optional `withGlobalTauri` injects `window.__TAURI__` instead; it is **off by
+default**, and leaving it off is correct—it exposes the API surface to any third-party
+script on the page and defeats tree-shaking.
+
+### The IPC Model
+
+Tauri 2 moved from `postMessage` to a **custom protocol**: an HTTP-shaped request that
+never touches the network.
+Older WebKitGTK (below 2.36) falls back to `postMessage`.
+
+Four mechanisms, in the order you will reach for them:
+
+| Mechanism | Use it for |
+| --- | --- |
+| `#[tauri::command]` + `invoke()` | Ordinary request/response. JSON-serialized. |
+| `emit` / `listen` events | Broadcast notifications, main-to-frontend push. |
+| `Channel<T>` | Streaming a sequence of values, e.g. download progress. |
+| `ipc::Response` / `ipc::Request` | Raw binary, bypassing JSON. |
+
+The raw-binary path is worth knowing about before you need it: a 64KB binary round trip
+measures roughly **600µs through `ipc::Response` against about 6.7ms through standard
+JSON serialization**. If you move images, audio, or file contents across the boundary,
+this is a tenfold difference, not a micro-optimization.
+
+* * *
+
+## 2. Capabilities and Permissions
+
+This is the largest change in Tauri 2 and the part most worth understanding properly,
+because it is both the framework’s main security asset and its main source of confusion.
+
+### The Three Layers
+
+1. **Permissions** — per-command on/off switches, named `<plugin>:<identifier>`.
+2. **Scopes** — parameter validation that narrows what a permitted command may touch.
+3. **Capabilities** — bind a set of permissions and scopes to specific windows.
+
+A real `src-tauri/capabilities/default.json`:
+
+```json
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "main-capability",
+  "description": "Capability for the main window",
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "core:window:allow-set-title",
+    {
+      "identifier": "fs:allow-read-file",
+      "allow": [{ "path": "$APPDATA/**" }],
+      "deny": [{ "path": "$APPDATA/secrets/**" }]
+    }
+  ]
+}
+```
+
+Naming follows `<name>:default`, `<name>:allow-<command>`, and `<name>:deny-<command>`.
+Scopes accept glob patterns and variables such as `$HOME`, `$APPDATA`, and `$DESKTOP`,
+and **deny always beats allow**.
+
+### What You Get by Default
+
+`core:default` grants roughly **106 window permissions, 42 menu, 24 tray, and 24 app
+permissions—and no filesystem, shell, HTTP, or plugin access whatsoever.** That is the
+fact to internalize: the default is a fully usable UI with no reach into the machine.
+Every capability beyond drawing a window is something you deliberately added.
+
+### What Real Apps Actually Do
+
+Surveying fourteen serious open-source Tauri apps shows the system is used well by some
+and loosely by others, and the pattern is instructive.
+
+**Tightly scoped, worth imitating:**
+
+- **Modrinth** splits capabilities across three files, scopes HTTP by URL and the
+  filesystem by path.
+- **Spacedrive** is the only app in the survey that scopes to **specific window names**
+  rather than `windows: ["*"]`.
+- **Yaak** and **Hoppscotch** confine the filesystem to `$APPDATA` and `$APPCONFIG`.
+
+**Broad, and worth understanding why:**
+
+- **Clash Verge Rev** carries an `fs:scope` of `"**"` plus shell execute, spawn, and
+  kill.
+- **Cap** grants `fs:write-all`, `fs:read-all`, and HTTP to `http://*` and `https://*`.
+
+The single biggest source of over-broad permissions is **the v1 migration**, which dumps
+the old allowlist into a `migrated.json` capability.
+If you are migrating from Tauri 1, rewrite your capabilities by hand.
+Shipping the migration output means shipping v1’s coarse permissions into a system
+designed for fine ones.
+
+* * *
+
+## 3. Attaching a Backend
+
+### Rust Commands: The Default Path
+
+```rust
+#[tauri::command]
+async fn open_project(id: String, state: tauri::State<'_, AppState>) -> Result<Project, Error> {
+    state.db.load(&id).await
+}
+
+fn main() {
+    tauri::Builder::default()
+        .manage(AppState::new())
+        .invoke_handler(tauri::generate_handler![open_project])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}
+```
+
+The most common friction point is not the borrow checker—it is that **your error type
+must implement serde’s `Serialize`** to cross the boundary.
+Plan for a single app-wide error enum with a `Serialize` implementation early.
+
+### How Much Rust Do You Actually Need?
+
+Honestly: for a frontend-driven app using official plugins, close to none.
+The scaffold’s `main.rs` often stays untouched, because the filesystem, dialog, HTTP,
+store, and shell plugins already expose what a typical app needs.
+Rust starts to matter when you write custom commands, and the friction is concentrated
+in serde derives, serializable error types, and `State<'_, T>` inside async functions
+rather than in lifetimes or ownership.
+
+If your team genuinely will not write Rust, sidecars are the sanctioned escape
+hatch—paid for in bundle size and process lifecycle complexity.
+
+### Sidecars
+
+Declare external binaries in `tauri.conf.json`:
+
+```json
+{
+  "bundle": {
+    "externalBin": ["binaries/my-sidecar"]
+  }
+}
+```
+
+**The target-triple naming convention is the most common failure point in all of
+Tauri.** A binary declared as `binaries/my-sidecar` must exist on disk with the Rust
+target triple appended:
+
+```
+src-tauri/binaries/my-sidecar-x86_64-apple-darwin
+src-tauri/binaries/my-sidecar-aarch64-apple-darwin
+src-tauri/binaries/my-sidecar-x86_64-unknown-linux-gnu
+src-tauri/binaries/my-sidecar-x86_64-pc-windows-msvc.exe
+```
+
+Get the current triple with `rustc --print host-tuple` (Rust 1.84 and later).
+Your build script must produce correctly suffixed copies for every target you ship.
+
+A second gotcha, easy to lose an hour to: **the Rust and JavaScript APIs take different
+arguments.** `Command::sidecar()` in Rust takes the **filename only**, while
+`Command.sidecar()` in JavaScript takes the **full `externalBin` path**.
+
+Spawning a sidecar requires permissions, each with a scope marking it as a sidecar:
+
+```json
+{
+  "identifier": "shell:allow-spawn",
+  "allow": [{ "name": "binaries/my-sidecar", "sidecar": true }]
+}
+```
+
+You will typically also need `shell:allow-kill` and, if you write to the process,
+`shell:allow-stdin-write`.
+
+### Non-Rust Backends
+
+| Language | Approach | Cost |
+| --- | --- | --- |
+| **Go** | Compile a static binary. No extra tooling. | Smallest and simplest. |
+| **Bun** | `bun build --compile` produces a single executable. | **~29MB added to a .dmg**, against ~5MB for pure Rust. |
+| **Node** | The official docs use `@yao-pkg/pkg`. No real Node SEA examples were found in the wild. | Comparable to Bun. |
+| **Python** | PyInstaller sidecar, or PyTauri with python-build-standalone. | Largest; see below. |
+
+For **Python**, the PyInstaller route is the well-trodden one and has a working
+reference implementation, but two problems recur: one-file mode (`-F`) unpacks on every
+launch and is slow, and shutdown is unreliable because the PyInstaller bootloader’s PID
+differs from the Python process’s PID, so killing the PID you spawned may leave the
+interpreter alive.
+PyTauri with python-build-standalone is better integrated but drags in
+PyO3 and platform-specific rpath and linker configuration.
+The tradeoffs mirror those in `tbd guidelines electron-app-development-patterns`, which
+covers Python packaging in more depth; the analysis is framework-independent.
+
+### Process Lifecycle
+
+Sidecars spawned through the shell plugin **are** tracked and killed when the app exits.
+Orphans still occur in three edge cases worth guarding against: `prevent_exit()`
+combined with `AppHandle::exit()` on Windows, the macOS `MenuItem::Quit` bypassing
+`RunEvent` handlers, and grandchild processes that escape the process group.
+
+The reliable pattern is to build explicitly and handle exit:
+
+```rust
+tauri::Builder::default()
+    .build(tauri::generate_context!())?
+    .run(|app_handle, event| {
+        if let tauri::RunEvent::Exit = event {
+            // kill children held in managed state
+        }
+    });
+```
+
+### Sidecars Versus Plugins
+
+|  | Plugin | Sidecar |
+| --- | --- | --- |
+| Process | In-process | Separate process |
+| IPC cost | Low | Serialization plus process boundary |
+| Language | Rust | Any |
+| Crash isolation | No | Yes |
+| **Mobile** | **Works** | **Not supported** |
+
+That last row decides it for mobile apps: if you target iOS or Android, backend logic
+has to be a plugin or Rust code, not a sidecar.
+
+Real apps use sidecars readily—five of the fourteen surveyed.
+Clash Verge Rev ships a Go proxy engine, Spacedrive a Rust daemon, Cap a media pipeline,
+GitButler git binaries.
+**Yaak** is the instructive variant: it bundles a whole Node.js runtime as a
+**resource** rather than an `externalBin`, which is the right move when you need an
+interpreter rather than a single triple-named executable.
+
+* * *
+
+## 4. Security Baseline
+
+### Where Tauri Is Stronger Than Electron
+
+- **Deny-all by default.** Permissions are additive and enforced at compile time.
+- **Memory safety** in the privileged process.
+- **No bundled engine** to carry known vulnerabilities.
+- **The Isolation pattern**, an optional sandboxed iframe that intercepts every IPC
+  message before it reaches Rust, encrypting it with AES-GCM under a key regenerated
+  each startup. Its real purpose is defending against a **compromised frontend
+  dependency**: a malicious npm package cannot make raw IPC calls without passing your
+  hook.
+- Tauri 2.0 was **externally audited** by Radically Open Security, funded by NLNet/NGI.
+
+### Where Tauri Is Weaker, Stated Plainly
+
+- **There is no equivalent of Electron’s renderer sandbox.** Electron’s sandbox
+  restricts renderer syscalls at the OS level.
+  Tauri has no such layer.
+- **CSP is not enabled by default.** It works well once configured, with compile-time
+  nonce and hash injection, but you must opt in.
+- **`security.freezePrototype` defaults to `false`**, so prototype pollution defenses
+  are off unless you enable them.
+- **You do not control the webview’s patch cycle.** This is the flip side of shipping no
+  engine: a user on an old OS runs an old, potentially vulnerable webview, and you
+  cannot ship a fix. Electron’s bundled Chromium is a larger attack surface that *you*
+  can patch.
+- **`remote.urls`** in a capability grants remote origins access to commands.
+  It is more granular than v1’s `dangerousRemoteDomainIpcAccess`, but still
+  dangerous—and **on Linux and Android, iframes from remote origins cannot be
+  distinguished from main-window requests**.
+
+### CSP: What the Docs Say and What Apps Do
+
+The documentation recommends a real CSP. The ecosystem largely does not follow it, and a
+guideline that ignored this would read as theoretical.
+Of the fourteen apps surveyed:
+
+| Approach | Count |
+| --- | --- |
+| CSP disabled outright (`null`) | 5 |
+| Permissive (wildcards or `unsafe-eval`) | 3 |
+| Moderate (per-domain, `unsafe-inline`) | 4 |
+| **Strict (SHA-256 script hashes)** | **1** |
+
+Only Wealthfolio does what the documentation actually recommends.
+Apps that wrap external web content essentially cannot set a strict policy.
+
+The advice stands regardless: **set a CSP, and prefer script hashes to
+`unsafe-inline`.** Tauri injects nonces and hashes at compile time for bundled code, so
+a strict policy is more achievable here than the survey numbers suggest.
+Configure it under `app.security.csp`, with `devCsp` for development.
+
+* * *
+
+## 5. Packaging, Signing, and Updates
+
+### Bundle Targets
+
+Seven targets: `app`, `dmg`, `nsis`, `msi`, `deb`, `rpm`, `appimage`. Flatpak and Snap
+are external tooling—Flatpak community-maintained with a known D-Bus naming issue, Snap
+officially documented.
+
+### Bundle Size, Measured
+
+Real release assets, not marketing figures:
+
+| App | Artifact | Size |
+| --- | --- | --- |
+| Pake 3.15.6 (thin wrapper) | MSI | **3.5MB** |
+| Pake 3.15.6 | deb | 4.5MB |
+| Pake 3.15.6 | DMG | 9.4MB |
+| Pake 3.15.6 | **AppImage** | **75.5MB** |
+| Spacedrive 0.4.3 (heavy Rust) | DMG | ~80-86MB |
+| Clash Verge Rev 2.5.0 (~50MB sidecar) | Windows x64 | 47MB |
+
+Three honest conclusions.
+The small-bundle claim is **true for `.msi` and `.deb` with a thin frontend**. It is
+**false for AppImage**, which is always 70MB or more because it bundles WebKitGTK. And
+it **collapses entirely once you add a sidecar or a substantial Rust backend**—at which
+point your binary, not the framework, is the size.
+
+The best like-for-like data point available: the Hoppscotch team reported going from
+**165MB on Electron to 8MB on Tauri** for a pure web frontend.
+
+### The Updater, and Why It Is the Headline Feature
+
+Tauri’s updater verifies the payload before applying it.
+From `plugins/updater/src/updater.rs`:
+
+```rust
+fn verify_signature(data: &[u8], release_signature: &str, pub_key: &str) -> Result<()> {
+    let pub_key_decoded = base64_to_string(pub_key)?;
+    let public_key = PublicKey::decode(&pub_key_decoded)?;
+    let signature_base64_decoded = base64_to_string(release_signature)?;
+    let signature = Signature::decode(&signature_base64_decoded)?;
+
+    // Validate signature or bail out
+    public_key.verify(data, &signature, true)?;
+    Ok(())
+}
+```
+
+The verification uses **minisign**, runs against the **downloaded bytes**, checks them
+with a **public key compiled into your application**, and **aborts the update on
+failure**.
+
+Why this matters more than it sounds: the private key never touches the update server,
+so **compromising your update host is not sufficient to ship code to your users**.
+Integrity comes from the key, not from trusting the host.
+Generate the keypair with `tauri signer generate`, keep the private key in CI secrets as
+**`TAURI_SIGNING_PRIVATE_KEY`** (renamed from `TAURI_PRIVATE_KEY`; the old name still
+works), and put the public key in your config.
+
+This is near-universal practice, not just documentation: **ten of the surveyed apps ship
+the official updater, and every one of them ships a pubkey.**
+
+### Code Signing
+
+**macOS.** Sign with a Developer ID certificate and notarize, supplying either Apple ID
+credentials or App Store Connect API key credentials through the standard environment
+variables.
+
+One point worth stating because it is widely assumed otherwise: **Tauri does not need
+JIT entitlements.** Electron requires `com.apple.security.cs.allow-jit` and
+`allow-unsigned-executable-memory` because it signs its own Chromium helper processes,
+in which V8 JIT-compiles.
+Tauri’s web content runs in Apple’s own out-of-process `com.apple.WebKit.WebContent`,
+which carries Apple’s entitlements.
+Tauri’s signing documentation does not mention entitlements at all, and Spacedrive,
+GitButler, and Modrinth ship no `Entitlements.plist` and notarize successfully.
+Add entitlements for features you actually use—**Cap** ships them for camera,
+microphone, USB, and library validation because it is a screen recorder loading its own
+media sidecars, not because the webview demands it.
+
+**Windows.** Authenticode has required a hardware security module since June 2023, so a
+local `.pfx` is no longer viable.
+Use `signCommand` with Azure Key Vault or Azure Trusted Signing.
+
+Then choose how WebView2 reaches the user via `webviewInstallMode`:
+
+| Mode | Tradeoff |
+| --- | --- |
+| `downloadBootstrapper` (default) | Smallest installer; needs network at install time. |
+| `embedBootstrapper` | No network needed; **adds roughly 190MB**. |
+| `offlineInstaller` | Fully offline; largest. |
+| `fixedVersion` | Pins an engine version; you own its security updates. |
+| `skip` | Assumes it is present; the app will not launch if it is not. |
+
+**Linux.** No signing story comparable to the other platforms; distribution goes through
+deb, rpm, and AppImage.
+
+### CI
+
+You **cannot cross-compile**—build on each target OS. A realistic matrix is five
+entries: macOS arm64, macOS x64, Ubuntu x64, Ubuntu arm64, and Windows.
+Note that surveyed apps pin **`ubuntu-22.04` rather than a newer image**, because of
+WebKit dependencies.
+macOS universal binaries are an option but double the file size.
+
+**Budget for Rust build time honestly.** A clean build runs 3-8 minutes locally and 5-15
+in CI. With `swatinem/rust-cache@v2` that drops to 2-5 minutes.
+macOS notarization adds another 2-5 minutes and cannot be cached.
+A parallel five-runner release lands around 15 minutes wall-clock.
+Against a JavaScript-only pipeline this is a real **3-5x penalty**, and it is the cost
+that most surprises teams arriving from Electron.
+Locally, switching to the LLD linker is the single biggest win, taking one measured
+incremental build from 14.8s to 3.7s.
+
+* * *
+
+## 6. What Actually Breaks Across Webviews
+
+Shipping no engine means inheriting whatever engine the user has.
+This section exists because “system webviews vary” is too vague to plan around.
+
+### Linux Is the Weak Platform
+
+Every item below is an open or documented issue, not speculation:
+
+- **WebRTC is unavailable** in WebKitGTK as shipped by most distributions.
+  It works on Windows and macOS. If your app does video calling, Linux is not a target
+  today.
+- **Audio and video served through custom protocols do not play.** Files delivered via
+  `convertFileSrc` or the asset protocol fail with `NotSupportedError`. This is
+  Linux-specific and affects the ordinary way Tauri apps serve local media.
+- **Drag-and-drop is broken** across several issues: the drop event never fires, and
+  file drops can navigate the webview to the file instead.
+- **Wayland rendering glitches**: maximizing produces duplicated “shadow” DOM over real
+  content, reproducible on a vanilla scaffold.
+- **Performance degrades** until devtools is opened, and CSS animations blur the app.
+- Child webviews require X11.
+
+Engine capability tracks the distribution: Ubuntu 22.04 ships WebKitGTK 2.36 (roughly
+Safari 16), Ubuntu 20.04 ships 2.28-2.32. Your users’ CSS and JavaScript support is set
+by their OS, not your build.
+
+**Tauri 3.0’s headline item is the GTK4 and WebKitGTK 6.0 migration**, which addresses
+much of this. It is a milestone in progress, not a shipped fix.
+
+### Windows and macOS
+
+- **Windows**: on machines without WebView2, the installer triggers a UAC prompt to
+  install “Windows Edge Update,” which looks alarming to users; declining leaves an app
+  that cannot launch. Apps also fail to start under Windows Administrator Protection.
+- **macOS**: enabling devtools uses private WebKit APIs and **makes the app ineligible
+  for the App Store**. WKWebView restricts media autoplay, and `convertFileSrc` fails on
+  very large files.
+- **Fonts render differently on every platform** (DirectWrite, CoreText, FreeType).
+  Bundle your own fonts if visual consistency matters.
+
+* * *
+
+## 7. What Shipping Apps Actually Do
+
+Fourteen serious open-source apps, read from their configuration rather than their
+READMEs.
+
+| App | What it demonstrates |
+| --- | --- |
+| [Modrinth](https://github.com/modrinth/code) | **Best capability architecture**: three capability files, URL-scoped HTTP, path-scoped fs. |
+| [Spacedrive](https://github.com/spacedriveapp/spacedrive) | Window-name-scoped capabilities; a Rust `sd-daemon` sidecar. |
+| [GitButler](https://github.com/gitbutlerapp/gitbutler) | Custom CI pipeline; `createUpdaterArtifacts: "v1Compatible"` for existing installs. |
+| [Cap](https://github.com/CapSoftware/Cap) | Media sidecar pipeline; `tauri-specta` for type-safe IPC bindings. |
+| [Hoppscotch](https://github.com/hoppscotch/hoppscotch) | Reported 165MB → 8MB moving off Electron. |
+| [Yaak](https://github.com/mountain-loop/yaak) | Bundles a **Node.js runtime as a resource** for its plugin system. |
+| [Wealthfolio](https://github.com/afadil/wealthfolio) | **The only app with a strict CSP** (SHA-256 script hashes); ships mobile. |
+| [Clash Verge Rev](https://github.com/clash-verge-rev/clash-verge-rev) | Go proxy sidecar; multiple updater endpoints with mirrors. Also the broadest permissions. |
+
+Patterns appearing in three or more apps, which is the bar for putting something in a
+guideline:
+
+- **The official updater with a minisign pubkey** (10 apps—the strongest consensus in
+  the dataset).
+- **Plugins**: `deep-link` (7), `window-state` (7), `single-instance` (6).
+- **`fs:scope` confined to `$APPDATA/**`** as the minimum viable filesystem scope.
+- **Cargo features** `devtools` and `protocol-asset` (6 apps each).
+- **`macOSPrivateApi: true`** for vibrancy and transparency (4 apps).
+- **Custom title bars** via `titleBarStyle: "Overlay"` or `hiddenTitle` (4 apps).
+- **Vite** as the bundler, near-universally.
+
+**No frontend framework dominates**: React and Next.js account for five apps, Vue three,
+Svelte and Solid one each.
+Framework choice is team preference, not a Tauri constraint.
+
+**Mobile remains the exception**—only two of fourteen ship it, despite Tauri 2
+supporting iOS and Android since 2024.
+
+**The v2 migration is effectively complete.** Twelve of fourteen are on v2, and both v1
+holdouts show reduced maintenance.
+
+* * *
+
+## Best Practices
+
+- [ ] Pin at least **2.11.1** for the ACL and localhost security fixes.
+- [ ] Match plugin crate and JS package versions; do not force core crates to one
+  number.
+- [ ] Keep `withGlobalTauri` off and import `@tauri-apps/api` instead.
+- [ ] Scope capabilities to specific windows where you can, and to `$APPDATA` at minimum
+  for the filesystem.
+- [ ] **Rewrite capabilities by hand when migrating from v1**; never ship
+  `migrated.json`.
+- [ ] Set a CSP with script hashes, and `devCsp` separately for development.
+- [ ] Enable `security.freezePrototype` unless a dependency breaks under it.
+- [ ] Use the Isolation pattern if your frontend has a large dependency tree.
+- [ ] Ship the official updater with a minisign key; keep the private key in CI secrets
+  only.
+- [ ] Use `ipc::Response` or `Channel<T>` for binary and streaming payloads.
+- [ ] Suffix sidecar binaries with the correct target triple, and remember the Rust and
+  JS APIs take different path arguments.
+- [ ] Handle `RunEvent::Exit` to kill sidecars; do not assume automatic cleanup covers
+  every path.
+- [ ] Pin `ubuntu-22.04` in CI for WebKit compatibility.
+- [ ] Cache Rust builds with `swatinem/rust-cache`; expect notarization to stay
+  uncached.
+- [ ] Test on real Linux hardware early if Linux matters.
+
+* * *
+
+## Open Research Questions
+
+1. **When does Tauri 3.0’s GTK4 and WebKitGTK 6.0 migration land, and does it resolve
+   the Linux media and drag-and-drop problems?** This is the single largest open
+   question for anyone targeting Linux.
+
+2. **What is the practical exposure from the unpatched-webview problem?** Users on old
+   operating systems run old engines, and no data was found quantifying how often that
+   matters in the field.
+
+3. **Is the Isolation pattern’s overhead acceptable for high-frequency IPC?** The
+   documentation says most apps will not notice; no benchmark was found.
+
+4. **Why do so few apps set a strict CSP?** The survey shows the gap clearly but not
+   whether the cause is difficulty, tooling friction, or inattention.
+
+5. **Does `fixedVersion` WebView2 make sense for enterprise deployment**, given it moves
+   engine security updates onto you?
+
+* * *
+
+## Recommendations
+
+### When Tauri Is the Right Choice
+
+- You want a small, signed, auto-updating desktop app and can accept Rust in the build.
+- **Update integrity matters.** The signed updater is the strongest reason to choose
+  Tauri over less mature small-bundle frameworks.
+- Your team is comfortable with a permission model that must be configured deliberately.
+- You are Windows-first or macOS-first, with Linux as a secondary target you will test.
+- You want mobile from the same codebase, accepting that backend logic must be plugins
+  or Rust rather than sidecars.
+
+### When to Choose Something Else
+
+- **Your app depends on WebRTC, media playback through local protocols, or drag-and-drop
+  on Linux.** Verify before committing.
+- **You need a guaranteed rendering engine across platforms.** Electron ships one; Tauri
+  inherits whatever is installed.
+- **Your CI budget cannot absorb a 3-5x build-time increase.**
+- **You need an OS-level renderer sandbox**, which Electron provides and Tauri does not.
+- **Your team will write no Rust and your backend cannot be a sidecar**—for example
+  because you need mobile support.
+
+Choose **Electron** for maximum maturity, a controlled engine, the richest ecosystem,
+and a real renderer sandbox; see `tbd guidelines electron-app-development-patterns`.
+Choose **Electrobun** only for internal or trusted-audience distribution; see
+`tbd guidelines electrobun-app-development-patterns`, and note its updater performs no
+verification.
+
+### If You Adopt It
+
+Pin 2.11.1 or later, scope capabilities deliberately rather than accepting the migration
+output, ship the signed updater from day one, budget for Rust build times in CI, and put
+a real Linux machine in your test matrix before you promise Linux support.
+
+* * *
+
+## References
+
+### Official
+
+- [Tauri 2 documentation](https://v2.tauri.app/)
+- [Security and capabilities](https://v2.tauri.app/security/capabilities/)
+- [Permissions reference](https://v2.tauri.app/security/permissions/)
+- [Isolation pattern](https://v2.tauri.app/concept/inter-process-communication/isolation/)
+- [Updater plugin](https://v2.tauri.app/plugin/updater/)
+- [Embedding external binaries](https://v2.tauri.app/develop/sidecar/)
+- [macOS signing](https://v2.tauri.app/distribute/sign/macos/)
+- [Webview versions](https://v2.tauri.app/reference/webview-versions/)
+- [awesome-tauri](https://github.com/tauri-apps/awesome-tauri)
+
+### Issues Cited
+
+- [WebRTC unavailable on Linux (wry#85)](https://github.com/tauri-apps/wry/issues/85)
+- [Media via custom protocol fails on Linux (#3725)](https://github.com/tauri-apps/tauri/issues/3725)
+- [Drag-and-drop on Linux (#9725)](https://github.com/tauri-apps/tauri/issues/9725)
+- [Wayland shadow DOM duplication (#13157)](https://github.com/tauri-apps/tauri/issues/13157)
+- [WebView2 install UX (#4389)](https://github.com/tauri-apps/tauri/issues/4389)
+- [Windows Administrator Protection (#13926)](https://github.com/tauri-apps/tauri/issues/13926)
+
+## Related Guidelines
+
+- For Electron, see `tbd guidelines electron-app-development-patterns`
+- For Electrobun, see `tbd guidelines electrobun-app-development-patterns`
+- For dependency policy, see `tbd guidelines supply-chain-hardening`
+- For TypeScript conventions, see `tbd guidelines typescript-rules`
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/packages/tbd/docs/guidelines/tauri-app-development-patterns.md
+++ b/packages/tbd/docs/guidelines/tauri-app-development-patterns.md
@@ -436,6 +436,8 @@ GitButler git binaries.
 **Yaak** is the instructive variant: it bundles a whole Node.js runtime as a
 **resource** rather than an `externalBin`, which is the right move when you need an
 interpreter rather than a single triple-named executable.
+A python-build-standalone tree ships the same way: as a resource directory, spawned by
+path, with the target-triple convention reserved for single-file binaries.
 
 * * *
 

--- a/packages/tbd/docs/guidelines/tauri-app-development-patterns.md
+++ b/packages/tbd/docs/guidelines/tauri-app-development-patterns.md
@@ -86,11 +86,12 @@ Four things matter most when deciding:
   host, and it is the single strongest reason to prefer Tauri over less mature
   alternatives.
 
-- **The security model is genuinely two-sided.** `core:default` grants around 106 window
-  and menu permissions and *zero* filesystem, shell, or network access, so the deny-all
-  baseline is real. But there is no equivalent of Electron’s OS-level renderer sandbox,
-  CSP is off by default, and **the webview’s patch cycle belongs to the user’s operating
-  system, not to you**.
+- **The security model is genuinely two-sided.** `core:default` grants the default sets
+  of the nine core UI modules and *zero* filesystem, shell, or network access, so the
+  deny-all baseline is real.
+  But there is no equivalent of Electron’s OS-level renderer sandbox, CSP is off by
+  default, and **the webview’s patch cycle belongs to the user’s operating system, not
+  to you**.
 
 - **Linux is the weak platform.** WebRTC is unavailable in distro WebKitGTK, media
   served through Tauri’s own asset protocol does not play, and drag-and-drop is broken
@@ -152,10 +153,82 @@ Four mechanisms, in the order you will reach for them:
 | `Channel<T>` | Streaming a sequence of values, e.g. download progress. |
 | `ipc::Response` / `ipc::Request` | Raw binary, bypassing JSON. |
 
-The raw-binary path is worth knowing about before you need it: a 64KB binary round trip
-measures roughly **600µs through `ipc::Response` against about 6.7ms through standard
-JSON serialization**. If you move images, audio, or file contents across the boundary,
-this is a tenfold difference, not a micro-optimization.
+The raw-binary path is worth knowing about before you need it: in one third-party
+benchmark, a 64KB binary round trip measured roughly **600µs through `ipc::Response`
+against about 6.7ms through standard JSON serialization**. If you move images, audio, or
+file contents across the boundary, this is a tenfold difference, not a
+micro-optimization.
+
+### Project Layout
+
+Scaffold with `create-tauri-app`, which produces the shape every surveyed app follows:
+an ordinary frontend project with a Rust crate beside it.
+
+```
+my-app/
+├── src/                        # frontend—any framework; Vite is the near-universal bundler
+├── package.json
+└── src-tauri/
+    ├── Cargo.toml              # tauri = "2.11.1"+, plugins as crates
+    ├── tauri.conf.json
+    ├── capabilities/
+    │   └── default.json        # permission grants (see §2)
+    ├── binaries/               # sidecars, target-triple suffixed (see §3)
+    ├── icons/
+    └── src/
+        ├── main.rs             # thin entry; calls into lib.rs
+        └── lib.rs              # commands, state, plugin registration
+```
+
+The frontend never imports from `src-tauri`; the crate never imports from `src/`. The
+only contract between them is the command names, the event names, and the capability
+files.
+
+### Configuration and the Dev Loop
+
+A minimal complete `tauri.conf.json`, with the four keys that wire in your frontend
+toolchain:
+
+```json
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "my-app",
+  "version": "0.1.0",
+  "identifier": "com.example.my-app",
+  "build": {
+    "beforeDevCommand": "pnpm dev",
+    "devUrl": "http://localhost:5173",
+    "beforeBuildCommand": "pnpm build",
+    "frontendDist": "../dist"
+  },
+  "app": {
+    "windows": [{ "title": "my-app", "width": 1200, "height": 800 }],
+    "security": {
+      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost"
+    }
+  },
+  "bundle": {
+    "active": true,
+    "targets": "all",
+    "icon": ["icons/icon.icns", "icons/icon.ico", "icons/icon.png"]
+  }
+}
+```
+
+Two details in that file repay attention.
+The `identifier` is the reverse-DNS bundle identifier and is painful to change after
+shipping, because it keys installation paths, update identity, and macOS signing.
+And the CSP’s `connect-src` must include `ipc: http://ipc.localhost`—that is the custom
+protocol IPC from the previous section, and a CSP that omits it silently breaks
+`invoke()` on Windows and Linux.
+
+The loop itself: `tauri dev` runs `beforeDevCommand` (your Vite dev server, with normal
+HMR), compiles the Rust crate, and launches the app pointing at `devUrl`. Frontend edits
+hot-reload instantly; **Rust edits trigger a recompile and relaunch, which takes
+seconds, not milliseconds**—structure your app so iteration happens on the frontend side
+and commands stay stable.
+`tauri build` runs `beforeBuildCommand`, embeds `frontendDist`, and produces the bundle
+targets.
 
 * * *
 
@@ -196,9 +269,10 @@ and **deny always beats allow**.
 
 ### What You Get by Default
 
-`core:default` grants roughly **106 window permissions, 42 menu, 24 tray, and 24 app
-permissions—and no filesystem, shell, HTTP, or plugin access whatsoever.** That is the
-fact to internalize: the default is a fully usable UI with no reach into the machine.
+`core:default` bundles the default permission sets of the nine core modules—window,
+menu, tray, app, event, image, path, resources, and webview—**and no filesystem, shell,
+HTTP, or plugin access whatsoever.** That is the fact to internalize: the default is a
+fully usable UI with no reach into the machine.
 Every capability beyond drawing a window is something you deliberately added.
 
 ### What Real Apps Actually Do
@@ -479,6 +553,48 @@ Generate the keypair with `tauri signer generate`, keep the private key in CI se
 **`TAURI_SIGNING_PRIVATE_KEY`** (renamed from `TAURI_PRIVATE_KEY`; the old name still
 works), and put the public key in your config.
 
+The wiring is three pieces.
+First, tell the bundler to produce signed update artifacts, and give the updater plugin
+your public key and endpoints:
+
+```json
+{
+  "bundle": { "createUpdaterArtifacts": true },
+  "plugins": {
+    "updater": {
+      "pubkey": "…base64 minisign public key from tauri signer generate…",
+      "endpoints": [
+        "https://releases.example.com/{{target}}/{{arch}}/{{current_version}}"
+      ]
+    }
+  }
+}
+```
+
+The `{{target}}`, `{{arch}}`, and `{{current_version}}` variables are substituted at
+request time, so one endpoint template serves every platform.
+
+Second, host a manifest at that endpoint—either a static JSON file or a dynamic server
+response:
+
+```json
+{
+  "version": "1.2.0",
+  "notes": "Release notes shown to the user",
+  "pub_date": "2026-08-01T00:00:00Z",
+  "platforms": {
+    "darwin-aarch64": { "signature": "…", "url": "https://…/my-app.app.tar.gz" },
+    "windows-x86_64": { "signature": "…", "url": "https://…/my-app-setup.exe" }
+  }
+}
+```
+
+The `signature` values are the contents of the `.sig` files the build emits beside each
+updater artifact; the verification above runs against exactly these.
+
+Third, call `check()` and `downloadAndInstall()` from `@tauri-apps/plugin-updater` when
+your app wants to update.
+
 This is near-universal practice, not just documentation: **ten of the surveyed apps ship
 the official updater, and every one of them ships a pubkey.**
 
@@ -631,8 +747,8 @@ holdouts show reduced maintenance.
 - [ ] Set a CSP with script hashes, and `devCsp` separately for development.
 - [ ] Enable `security.freezePrototype` unless a dependency breaks under it.
 - [ ] Use the Isolation pattern if your frontend has a large dependency tree.
-- [ ] Ship the official updater with a minisign key; keep the private key in CI secrets
-  only.
+- [ ] Ship the official updater with `bundle.createUpdaterArtifacts: true` and a
+  minisign key; keep the private key in CI secrets only.
 - [ ] Use `ipc::Response` or `Channel<T>` for binary and streaming payloads.
 - [ ] Suffix sidecar binaries with the correct target triple, and remember the Rust and
   JS APIs take different path arguments.

--- a/packages/tbd/docs/guidelines/tauri-app-development-patterns.md
+++ b/packages/tbd/docs/guidelines/tauri-app-development-patterns.md
@@ -166,9 +166,9 @@ because it is both the framework’s main security asset and its main source of 
 
 ### The Three Layers
 
-1. **Permissions** — per-command on/off switches, named `<plugin>:<identifier>`.
-2. **Scopes** — parameter validation that narrows what a permitted command may touch.
-3. **Capabilities** — bind a set of permissions and scopes to specific windows.
+1. **Permissions:** per-command on/off switches, named `<plugin>:<identifier>`.
+2. **Scopes:** parameter validation that narrows what a permitted command may touch.
+3. **Capabilities:** bind a set of permissions and scopes to specific windows.
 
 A real `src-tauri/capabilities/default.json`:
 

--- a/packages/tbd/docs/guidelines/typescript-lint-format-rules.md
+++ b/packages/tbd/docs/guidelines/typescript-lint-format-rules.md
@@ -163,6 +163,9 @@ type-only import is syntactically marked.
 Checked-JavaScript projects add `allowJs: true`, `checkJs: true`, and `noEmit: true`,
 scope `include` to the JavaScript they own (excluding vendored assets), and take types
 from JSDoc annotations and `.d.ts` files.
+The kpress and metabrowser repositories are probably the quickest worked examples to
+copy from; metabrowser also keeps a second `tsconfig.legacy.json`, which is a concrete
+instance of the ratchet described next.
 
 Existing projects adopt new flags through the legacy ratchet (floor rule 8): enable what
 passes today, and give each flag that still fails a tracked issue rather than leaving it

--- a/packages/tbd/docs/guidelines/typescript-lint-format-rules.md
+++ b/packages/tbd/docs/guidelines/typescript-lint-format-rules.md
@@ -163,7 +163,6 @@ type-only import is syntactically marked.
 Checked-JavaScript projects add `allowJs: true`, `checkJs: true`, and `noEmit: true`,
 scope `include` to the JavaScript they own (excluding vendored assets), and take types
 from JSDoc annotations and `.d.ts` files.
-Reference configs: the kpress and metabrowser repositories.
 
 Existing projects adopt new flags through the legacy ratchet (floor rule 8): enable what
 passes today, and give each flag that still fails a tracked issue rather than leaving it

--- a/packages/tbd/src/cli/commands/docs-fork.ts
+++ b/packages/tbd/src/cli/commands/docs-fork.ts
@@ -53,6 +53,7 @@ import {
 } from '../../file/doc-fork.js';
 import { updateOne, diffContents, type UpdateStrategy } from '../../file/fork-update.js';
 import { createDocMap, type DocMapEntry } from '../../docmap/index.js';
+import { DOC_CATEGORIES } from '../../lib/doc-categories.js';
 import { servedEntryFor, loadServeContext, effectiveServePaths } from '../lib/doc-serve.js';
 import { docCategory, parseCategoryOption } from '../../lib/doc-categories.js';
 
@@ -790,7 +791,7 @@ export function registerForkSubcommands(docs: Command): void {
     .option('--all', 'fork all available docs')
     .option(
       '--category <name>',
-      'fork all docs in a category (repeatable: general|typescript|python|convex|electron)',
+      `fork all docs in a category (repeatable: ${DOC_CATEGORIES.join('|')})`,
       (value: string, previous: string[] | undefined) => [...(previous ?? []), value],
     )
     .option('--force', 'overwrite an existing non-fork file')

--- a/packages/tbd/src/lib/doc-categories.ts
+++ b/packages/tbd/src/lib/doc-categories.ts
@@ -4,7 +4,7 @@
  * the old name-based inference is retired in favor of the declared field.
  */
 
-export const DOC_CATEGORIES = ['general', 'typescript', 'python', 'convex', 'electron'] as const;
+export const DOC_CATEGORIES = ['general', 'typescript', 'python', 'convex', 'desktop'] as const;
 
 export type DocCategory = (typeof DOC_CATEGORIES)[number];
 

--- a/packages/tbd/tests/doc-categories.test.ts
+++ b/packages/tbd/tests/doc-categories.test.ts
@@ -13,7 +13,7 @@ import { readFile, readdir } from 'node:fs/promises';
 import { join, dirname, extname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { docCategory } from '../src/lib/doc-categories.js';
+import { docCategory, parseCategoryOption } from '../src/lib/doc-categories.js';
 import { parseMarkdownMatter } from '../src/utils/gray-matter.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -93,5 +93,21 @@ describe('docCategory()', () => {
     expect(docCategory({ category: 'meta' })).toBeUndefined();
     expect(docCategory({})).toBeUndefined();
     expect(docCategory(undefined)).toBeUndefined();
+  });
+});
+
+describe('parseCategoryOption', () => {
+  it('accepts each valid category', () => {
+    expect(parseCategoryOption('desktop')).toBe('desktop');
+    expect(parseCategoryOption('general')).toBe('general');
+  });
+
+  it('fails fast on an unknown category, listing the valid ones', () => {
+    // The desktop rename retired 'electron' with no alias, per
+    // backward-compatibility-rules: the actionable error IS the compatibility
+    // surface, so pin its content.
+    expect(() => parseCategoryOption('electron')).toThrowError(
+      /Unknown category "electron"\. Valid categories: general, typescript, python, convex, desktop\./,
+    );
   });
 });

--- a/packages/tbd/tests/doc-categories.test.ts
+++ b/packages/tbd/tests/doc-categories.test.ts
@@ -30,7 +30,7 @@ export const GUIDELINE_CATEGORIES = [
   'typescript',
   'python',
   'convex',
-  'electron',
+  'desktop',
 ] as const;
 
 describe('guideline doc categories', () => {

--- a/packages/tbd/tests/golden-output.test.ts
+++ b/packages/tbd/tests/golden-output.test.ts
@@ -72,7 +72,7 @@ describe('golden output tests', { timeout: subprocessTestTimeout() }, () => {
 
           Hidden (default):  keep the cache as-is; zero repo footprint
           Curated:           tbd docs fork <name> [...]  fork chosen docs into docs/tbd/
-                             tbd docs fork --category=<name>  (general, typescript, python, convex, electron)
+                             tbd docs fork --category=<name>  (general, typescript, python, convex, desktop)
           Everything:        tbd docs fork --all         all docs, visible and editable
 
           Browse / read: tbd docs list / tbd docs show <name>
@@ -102,7 +102,7 @@ describe('golden output tests', { timeout: subprocessTestTimeout() }, () => {
           '  Guidelines are active from the cache. Three postures, all serving the same docs:',
           '  Hidden (default):  keep the cache as-is; zero repo footprint',
           '  Curated:           tbd docs fork <name> [...]  fork chosen docs into docs/tbd/',
-          '                     tbd docs fork --category=<name>  (general, typescript, python, convex, electron)',
+          '                     tbd docs fork --category=<name>  (general, typescript, python, convex, desktop)',
           '  Everything:        tbd docs fork --all         all docs, visible and editable',
           '  Browse / read: tbd docs list / tbd docs show <name>',
         ].join('\n'),

--- a/packages/tbd/tests/setup-flows.test.ts
+++ b/packages/tbd/tests/setup-flows.test.ts
@@ -428,7 +428,7 @@ describe('setup flows', { timeout: subprocessTestTimeout() }, () => {
       '  Guidelines are active from the cache. Three postures, all serving the same docs:',
       '  Hidden (default):  keep the cache as-is; zero repo footprint',
       '  Curated:           tbd docs fork <name> [...]  fork chosen docs into docs/tbd/',
-      '                     tbd docs fork --category=<name>  (general, typescript, python, convex, electron)',
+      '                     tbd docs fork --category=<name>  (general, typescript, python, convex, desktop)',
       '  Everything:        tbd docs fork --all         all docs, visible and editable',
       '  Browse / read: tbd docs list / tbd docs show <name>',
     ].join('\n');


### PR DESCRIPTION
## Summary

Full senior engineering review and rewrite of the Electron guideline, plus two new companion guidelines for Electrobun and Tauri, all under a renamed `desktop` category. Every load-bearing claim was verified against primary sources (repo clones, registry queries, updater source, and the actual config files of ~22 surveyed open-source apps) rather than documentation or blog posts, and each doc went through a second review pass that corrected example bugs and calibration errors.

## Changes

- **Electron guideline rewritten** as a pure-Electron reference: removed a false headline claim (the "Electron 39 broken on macOS 14" finding was a misdiagnosis of documented `require('electron')` behavior under plain Node), refreshed all versions to the Electron 43 era, added reference architecture, backend attachment (utilityProcess vs sidecars, Node/Bun/Python), security baseline, packaging/signing/updates, a production-app survey (VS Code, Signal, Bitwarden, Element, Joplin, Mattermost, Logseq, Standard Notes), and six appendices with complete configs.
- **New `electrobun-app-development-patterns`**: verified firsthand that the updater applies updates with no signature or digest verification; documents that sandbox and RPC are mutually exclusive, there is no contextIsolation equivalent, and `mainProcess` now defaults to `cottontail` (Electrobun's own JSC runtime, not Bun). Recommendation scoped to internal/trusted distribution with the updater disabled.
- **New `tauri-app-development-patterns`**: anchored on the minisign-verified updater (read from `updater.rs`); documents the two-sided security model, the Linux webview breakage with issue citations, sidecar target-triple and permission gotchas, the 3-5x Rust CI cost, and what 14 real apps actually configure. Corrected a plausible-but-wrong research claim (Tauri does not need macOS JIT entitlements).
- **Category rename** `electron` → `desktop` (applied `backward-compatibility-rules`: no named consumer, DO NOT MAINTAIN; `parseCategoryOption` already fails fast with the valid list). Removed a duplicated hardcoded category list.
- **Cross-cutting compliance pass**: style fixes per `common-doc-guidelines`, reciprocal cross-references among all three docs, README rows, docs-cache registration.
- **Verification-question resolution**: Electron 43.4.0 embeds Node 24.18.1 where `node:sqlite` is Stability 1.2 (release candidate since 24.15.0); Mach-O binaries under `Contents/Resources` pass notarization by universal field practice (`app.asar.unpacked`). Both folded into the doc; open questions renumbered.

## Test Plan

Already validated (every push ran the full pre-push suite):

- [x] Full suite green: 138 test files / 2000+ tests, format, typecheck, lint, build
- [x] `doc-categories` and `doc-references` tests pass (every `tbd guidelines <name>` reference resolves; every guideline declares a valid category)
- [x] All intra-doc anchors resolve in all three guidelines (scripted check)
- [x] CLI end-to-end: `tbd guidelines --list --category=desktop` lists all three docs; `--category=electron` fails fast with the valid-category message; each doc loads via `tbd guidelines <name>`
- [x] Golden-output and setup-flows tests updated for the category rename and passing
- [x] Version pins audited against registries for the 14-day cool-off rule

For a reviewer to spot-check:

- [ ] `pnpm tbd guidelines electron-app-development-patterns` (and the other two) renders with correct frontmatter and content
- [ ] Skim each doc's Last Researched Versions table; every claim carries an observation date of 2026-08-16
- [ ] The three docs' reciprocal claims are consistent (Tauri updater verifies via minisign; Electrobun updater verifies nothing; Electron/Squirrel refuses unsigned) — sources cited inline
- [ ] `rg "electron" packages/tbd/src --type ts` shows no stale category references

## Related Beads

- `tbd-xi90` (epic: Electron review) — closed
- `tbd-v0lb` (epic: Electrobun + Tauri reviews) — closed, all 14 children closed
- `tbd-bvg0` (review pass on the two new docs) — closed
- `tbd-j6mg`, `tbd-r8nc` (verification questions) — resolved from primary sources and closed
- `tbd-svtm`, `tbd-485b` (watch beads: Electrobun updater verification / Tauri 3.0 Linux fixes) — open by design

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcqXCVuzxYZzGnPntbN2wq

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcqXCVuzxYZzGnPntbN2wq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation and CLI copy/category constants with test updates; no runtime product logic beyond clearer validation for unknown fork categories.
> 
> **Overview**
> This PR turns the desktop-app guidance into a **three-doc set** under a shared **`desktop`** category instead of a single Electron-focused doc in **`electron`**.
> 
> The **Electron** guideline is largely rewritten: Electron 43-era defaults (electron-vite, security, packaging/signing/updates), backend attachment patterns, production-app survey, and appendices with full configs. **New** guidelines cover **Electrobun** (updater verification gaps, sandbox vs RPC) and **Tauri 2** (capabilities, signed updater, Linux webview caveats). All three cross-reference each other and appear in README, `.tbd/config.yml`, and skill shortcut tables with updated descriptions.
> 
> **Category rename `electron` → `desktop`**: `DOC_CATEGORIES`, guideline frontmatter, `tbd docs fork --category` help text, golden/setup snapshots, and a test that **`electron`** is rejected with the new valid list. New guidelines are registered for fork/serve.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 906073c32e2637ed2079bfd736b27c008f07e4e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->