### PR TITLE
Provision projects, honor max_nesting, and contain batch failures in the Linear sync

### DIFF
--- a/packages/tbd/src/cli/lib/integration-runner.ts
+++ b/packages/tbd/src/cli/lib/integration-runner.ts
@@ -487,6 +487,13 @@ export async function runEnabledIntegrations(
       specUrl: (issue) => (issue.spec_path ? specLinks.get(issue.spec_path) : undefined),
       mirrorLabels: resolveProviderSettings(config.integrations?.linear ?? {}).mirrorLabels,
       originLabels: await resolveOriginLabels(tbdRoot, config),
+      // Resolved from config like everything else here. This was the one option
+      // the full sync did not forward, so the engine's fallback default (2)
+      // silently overrode any configured `max_nesting` — while the mirror-only
+      // `--push` path forwarded it correctly, making the two modes disagree
+      // about which beads even qualify. Found live: a repo set to 3 kept
+      // reporting `past max_nesting 2`.
+      maxNesting: entry.maxNesting,
       // Linear cannot represent P4 (its 4 covers P3 and P4); without this
       // equivalence every P4 bead would oscillate as a phantom pull.
       equivalences: {

--- a/packages/tbd/src/integrations/core/intents.ts
+++ b/packages/tbd/src/integrations/core/intents.ts
@@ -24,6 +24,7 @@ import { z } from 'zod';
 import type { ProviderNameType } from '../../lib/types.js';
 import { parseYamlWithConflictDetection, stringifyYaml } from '../../utils/yaml-utils.js';
 import { bridgeIntentsDir } from './bridge-state.js';
+import { isWorkspaceLimitError } from './types.js';
 import type { AttachmentSpec, CanonicalPatch, ConflictReport, TrackerAdapter } from './types.js';
 
 const CanonicalPatchSchema = z
@@ -268,13 +269,55 @@ export async function replayIntents(
     failures: [],
   };
 
+  // A workspace plan limit fails every issue create for the same reason, so the
+  // first such error stops further create attempts across ALL journaled runs —
+  // otherwise a large halted batch re-pays one doomed request per item on every
+  // sync until the limit is lifted (observed live: ~141 failing calls per run).
+  // Other op kinds keep replaying: comments and updates are not what the limit
+  // is counting, and holding them hostage would delay unrelated convergence.
+  let createHalt: string | undefined;
+  // External ids that provably do not exist: the client ids of creates that
+  // failed or were parked. An op journaled against one — the attachments or
+  // managed block of a never-created issue — is a guaranteed "Could not find
+  // referenced Issue" from the provider, so it parks locally instead. Observed
+  // live: 32 halted creates left 64 dependent ops burning a request each on
+  // every sync.
+  const deadExternalIds = new Set<string>();
+
   for (const file of await listIntentFiles(dataSyncDir, provider)) {
     report.replayedRuns += 1;
     let failed = false;
     const recoveredCreates: ReplayReport['recoveredCreates'] = [];
     const recoveredComments: ReplayReport['recoveredComments'] = [];
+    // Ops that must survive into the next replay. Everything else — succeeded,
+    // consumed by the safety filter, or discarded by the integrity guard — has
+    // no reason to run again: replaying a 200-op journal for its 3 failures
+    // costs a request per already-done op on every sync (observed live as ~90
+    // redundant requests per run against a halted batch).
+    const pendingOps: typeof file.ops = [];
 
     for (const op of file.ops) {
+      if (op.kind === 'create_issue' && createHalt !== undefined) {
+        failed = true;
+        pendingOps.push(op);
+        deadExternalIds.add(op.client_id);
+        report.failures.push({
+          runId: file.run_id,
+          op,
+          error: `not attempted: ${createHalt}`,
+        });
+        continue;
+      }
+      if (op.kind !== 'create_issue' && deadExternalIds.has(op.external_id)) {
+        failed = true;
+        pendingOps.push(op);
+        report.failures.push({
+          runId: file.run_id,
+          op,
+          error: 'not attempted: its issue was never created; retries with the create.',
+        });
+        continue;
+      }
       const blockedTarget = blockedReplayTarget(op, safety);
       if (blockedTarget) {
         // The durable bead remains the source for re-planning once the link
@@ -335,6 +378,13 @@ export async function replayIntents(
         report.replayedOps += 1;
       } catch (error) {
         failed = true;
+        pendingOps.push(op);
+        if (op.kind === 'create_issue') {
+          deadExternalIds.add(op.client_id);
+          if (isWorkspaceLimitError(error)) {
+            createHalt = error.message;
+          }
+        }
         report.failures.push({
           runId: file.run_id,
           op,
@@ -351,6 +401,12 @@ export async function replayIntents(
     }
     if (!failed) {
       await deleteIntentFile(dataSyncDir, provider, file.run_id);
+    } else if (pendingOps.length < file.ops.length) {
+      // Compact rather than keep verbatim: the next replay should pay only for
+      // what is actually pending. Written only after recordRecovery above, so
+      // a crash between the two leaves the fuller journal, which replays
+      // idempotently — the safe direction to fail in.
+      await writeIntentFile(dataSyncDir, { ...file, ops: pendingOps });
     }
   }
 

--- a/packages/tbd/src/integrations/core/sync-engine.ts
+++ b/packages/tbd/src/integrations/core/sync-engine.ts
@@ -71,7 +71,7 @@ import {
   type IntentOp,
   type IntentPatch,
 } from './intents.js';
-import { CONFLICT_COMMENT_MARKER } from './types.js';
+import { CONFLICT_COMMENT_MARKER, isWorkspaceLimitError } from './types.js';
 import type { ConflictReport, ExternalIssue, TrackerAdapter } from './types.js';
 
 /** Re-fetch this far behind the watermark; over-fetching costs nothing. */
@@ -1294,8 +1294,45 @@ export async function runSync(options: SyncEngineOptions): Promise<SyncRunReport
   }
 
   // 7a. Outbound-new creates.
+  //
+  // Two batch-level failure modes are handled above the per-item try/catch.
+  // A parent whose create failed leaves its children pointing at a client id
+  // that never came to exist, so attempting them is a guaranteed provider
+  // rejection ("parentId … could not be found" — observed live); they are
+  // reported without an API call and their intents stay journaled. And a
+  // workspace plan limit dooms every remaining create for the same reason it
+  // failed the first, so the batch halts at the first such error rather than
+  // paying a request per doomed item.
+  const failedCreateClientIds = new Set<string>();
+  let workspaceLimitHalt: string | undefined;
   for (const issue of outboundNew) {
     const displayId = options.displayId(issue.id);
+    const haltClientId = outboundClientIds.get(issue.id);
+    const haltParentId = outboundParentIds.get(issue.id);
+    if (workspaceLimitHalt !== undefined) {
+      journalDirty = true;
+      if (haltClientId) {
+        failedCreateClientIds.add(haltClientId);
+      }
+      report.failures.push({
+        beadId: displayId,
+        error: `not attempted: ${workspaceLimitHalt}`,
+      });
+      continue;
+    }
+    if (haltParentId && failedCreateClientIds.has(haltParentId)) {
+      journalDirty = true;
+      if (haltClientId) {
+        failedCreateClientIds.add(haltClientId);
+      }
+      report.failures.push({
+        beadId: displayId,
+        error:
+          'not attempted: its parent failed to create in this run. ' +
+          'Both stay journaled and converge on a later sync.',
+      });
+      continue;
+    }
     try {
       const clientId = outboundClientIds.get(issue.id);
       const parentExternalId = outboundParentIds.get(issue.id);
@@ -1365,6 +1402,12 @@ export async function runSync(options: SyncEngineOptions): Promise<SyncRunReport
       report.createdOutbound.push(displayId);
     } catch (error) {
       journalDirty = true;
+      if (haltClientId) {
+        failedCreateClientIds.add(haltClientId);
+      }
+      if (isWorkspaceLimitError(error)) {
+        workspaceLimitHalt = error.message;
+      }
       report.failures.push({
         beadId: displayId,
         error: error instanceof Error ? error.message : String(error),

--- a/packages/tbd/src/integrations/core/types.ts
+++ b/packages/tbd/src/integrations/core/types.ts
@@ -193,7 +193,6 @@ export interface TrackerAdapter {
   /** Create an external item and return its ref. */
   createIssue(patch: CanonicalPatch, clientId?: string): Promise<ExternalRef>;
 
-  /** Apply a patch, returning the provider's new updatedAt for echo suppression. */
   /**
    * Apply a patch. Returns the post-write timestamp, which is what suppresses
    * the echo on the next pull, plus the item's human identifier and URL when the
@@ -262,10 +261,24 @@ export interface ProvisionOptions {
   apply: boolean;
 }
 
+/**
+ * Whether an error means the WORKSPACE is refusing writes — a billing or plan
+ * limit — rather than one item failing.
+ *
+ * A duck-typed marker (`workspaceLimit: true` on the error) instead of an
+ * `instanceof`, because the class lives with the provider that threw it and
+ * this core layer must not import provider modules. Batch loops use this to
+ * stop after the first such failure: every later create is doomed for the same
+ * reason, and attempting them anyway burns a request per item on every sync.
+ */
+export function isWorkspaceLimitError(error: unknown): error is Error {
+  return error instanceof Error && (error as { workspaceLimit?: unknown }).workspaceLimit === true;
+}
+
 /** One piece of tracker-side scaffolding and its state. */
 export interface ProvisionItem {
-  /** What the thing is, for the operator: `label` or `label group`. */
-  kind: 'label' | 'label group';
+  /** What the thing is, for the operator: `label`, `label group`, or `project`. */
+  kind: 'label' | 'label group' | 'project';
   /** The name tbd refers to it by. */
   name: string;
   /** `present` needed nothing; `created` was made now; `missing` is an unapplied gap. */

--- a/packages/tbd/src/integrations/linear/adapter.ts
+++ b/packages/tbd/src/integrations/linear/adapter.ts
@@ -41,6 +41,7 @@ import {
   ISSUE_LABELS_QUERY,
   ISSUE_UPDATE_MUTATION,
   LABEL_CREATE_MUTATION,
+  PROJECT_CREATE_MUTATION,
   PROJECT_QUERY,
   TEAM_META_QUERY,
   TEAM_LABELS_QUERY,
@@ -162,6 +163,29 @@ export class LinearAdapter implements TrackerAdapter {
       return this.projectId ?? undefined;
     }
 
+    const { match, available } = await this.findProject();
+    if (!match) {
+      throw new Error(
+        `Linear project not found: ${this.project}. Available: ${available || 'none'}. ` +
+          `Run \`tbd integration setup\` to create it.`,
+      );
+    }
+    this.projectId = match.id;
+    return match.id;
+  }
+
+  /**
+   * Look the configured project up without deciding what absence means.
+   *
+   * Split from {@link resolveProjectId} because the two callers disagree about
+   * a missing project: the sync path treats it as an error (filing issues into
+   * "no project" because of a typo is the failure the throw prevents), while
+   * `provision` treats it as work to do.
+   */
+  private async findProject(): Promise<{
+    match?: { id: string; name: string; slugId: string };
+    available: string;
+  }> {
     const projects: { id: string; name: string; slugId: string }[] = [];
     let after: string | undefined;
     do {
@@ -177,18 +201,13 @@ export class LinearAdapter implements TrackerAdapter {
         : undefined;
     } while (after);
 
-    const wanted = this.project.toLowerCase();
-    const match = projects.find(
-      (node) => node.slugId.toLowerCase() === wanted || node.name.toLowerCase() === wanted,
-    );
-    if (!match) {
-      const available = projects.map((node) => `${node.name} (${node.slugId})`).join(', ');
-      throw new Error(
-        `Linear project not found: ${this.project}. Available: ${available || 'none'}`,
-      );
-    }
-    this.projectId = match.id;
-    return match.id;
+    const wanted = (this.project ?? '').toLowerCase();
+    return {
+      match: projects.find(
+        (node) => node.slugId.toLowerCase() === wanted || node.name.toLowerCase() === wanted,
+      ),
+      available: projects.map((node) => `${node.name} (${node.slugId})`).join(', '),
+    };
   }
 
   /**
@@ -827,17 +846,63 @@ export class LinearAdapter implements TrackerAdapter {
   }
 
   /**
-   * Inspect, and optionally create, the label scaffolding this mirror needs.
+   * Inspect, and optionally create, the tracker scaffolding this mirror needs.
    *
    * Idempotent by construction: everything is find-or-create against the qualified-name
    * index, so running it twice creates nothing the second time. The group is reported as
    * its own item because it is a distinct object in Linear with its own failure mode —
    * a plain label already sitting on the group's name blocks the child, and an operator
    * needs to be told that rather than watching the label quietly not appear.
+   *
+   * The configured project is scaffolding too: `resolveProjectId` fails a sync outright
+   * when `target.project` names nothing, so a setup that provisioned only labels walked
+   * the operator into a guaranteed first-sync error. Found live wiring the second
+   * repository of a multi-repo team, where per-repo projects are the intended shape.
    */
   async provision(options: ProvisionOptions): Promise<ProvisionReport> {
     const index = await this.ensureLabelIndex();
     const items: ProvisionItem[] = [];
+
+    if (this.project) {
+      const { match } = await this.findProject();
+      if (match) {
+        items.push({ kind: 'project', name: this.project, state: 'present' });
+      } else if (!options.apply) {
+        items.push({ kind: 'project', name: this.project, state: 'missing' });
+      } else {
+        try {
+          const data = await this.client.request<{
+            projectCreate: {
+              success: boolean;
+              project: { id: string; name: string; slugId: string } | null;
+            };
+          }>(PROJECT_CREATE_MUTATION, {
+            input: { name: this.project, teamIds: [await this.resolveTeamId()] },
+          });
+          const created = data.projectCreate.project;
+          if (!data.projectCreate.success || !created) {
+            items.push({
+              kind: 'project',
+              name: this.project,
+              state: 'blocked',
+              reason: 'Linear declined to create the project',
+            });
+          } else {
+            // Cache the id so the sync that typically follows setup does not
+            // re-list every project just to find the one this run created.
+            this.projectId = created.id;
+            items.push({ kind: 'project', name: this.project, state: 'created' });
+          }
+        } catch (error) {
+          items.push({
+            kind: 'project',
+            name: this.project,
+            state: 'blocked',
+            reason: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
 
     /**
      * Where each leaf name is already taken, keyed by the bare leaf.

--- a/packages/tbd/src/integrations/linear/client.ts
+++ b/packages/tbd/src/integrations/linear/client.ts
@@ -45,6 +45,26 @@ export class LinearDuplicateIdError extends LinearApiError {
   }
 }
 
+/**
+ * Raised when the workspace refuses a write for plan/billing reasons — e.g.
+ * "You've exceeded the free issue limit for this workspace."
+ *
+ * Distinct from a per-item failure because it is a property of the WORKSPACE:
+ * once one create hits it, every later create in the run will too. Callers use
+ * that to halt a batch instead of burning a request per doomed item — observed
+ * live as a 77-create sync that kept re-attempting its whole backlog on every
+ * run, ~141 failing API calls each time, against a 2,500/hr budget.
+ */
+export class LinearWorkspaceLimitError extends LinearApiError {
+  /** Duck-typed marker consumed by `isWorkspaceLimitError` in the core layer. */
+  readonly workspaceLimit = true;
+
+  constructor(message: string) {
+    super(message, 'INPUT_ERROR', false);
+    this.name = 'LinearWorkspaceLimitError';
+  }
+}
+
 export interface LinearClientOptions {
   apiKey: string;
   /** Overridable so tests can point at a local mock server. */
@@ -209,6 +229,12 @@ export class LinearClient {
       const haystack = `${firstError.message} ${presentable ?? ''}`;
       if (/already exists/i.test(haystack) || /conflict on insert/i.test(haystack)) {
         throw new LinearDuplicateIdError(detail);
+      }
+      // Matched on "exceeded … limit for this workspace" rather than any
+      // mention of upgrading, so an unrelated message that happens to suggest a
+      // plan change does not halt a batch.
+      if (/exceeded .* limit for this workspace/i.test(haystack)) {
+        throw new LinearWorkspaceLimitError(detail);
       }
       throw new LinearApiError(detail, code, false, response.status);
     }

--- a/packages/tbd/src/integrations/linear/queries.ts
+++ b/packages/tbd/src/integrations/linear/queries.ts
@@ -19,6 +19,19 @@ export const PROJECT_QUERY = `query Projects($first: Int!, $after: String) {
   }
 }`;
 
+/**
+ * Create the configured project during `tbd integration setup`.
+ *
+ * Verified against Linear's published schema: `name` and `teamIds` are the two
+ * required fields of `ProjectCreateInput`.
+ */
+export const PROJECT_CREATE_MUTATION = `mutation ProjectCreate($input: ProjectCreateInput!) {
+  projectCreate(input: $input) {
+    success
+    project { id name slugId url }
+  }
+}`;
+
 /** Resolve a team key (e.g. `FIN`) to its UUID plus states and labels. */
 export const TEAM_META_QUERY = `query TeamMeta($key: String!) {
   teams(filter: { key: { eq: $key } }, first: 1) {

--- a/packages/tbd/tests/helpers/linear-mock-server.ts
+++ b/packages/tbd/tests/helpers/linear-mock-server.ts
@@ -70,10 +70,14 @@ export class LinearMockServer {
     { id: 'user-1', name: 'Josh', displayName: 'Josh', email: 'josh@example.com' },
     { id: 'user-2', name: 'Test User', displayName: 'Test User', email: 'test@example.com' },
   ];
-  readonly projects: { id: string; name: string; slugId: string }[] = [];
+  readonly projects: { id: string; name: string; slugId: string; url?: string }[] = [];
 
   /** Number of requests to fail with RATELIMITED before succeeding. */
   rateLimitFailures = 0;
+  /** Refuse issue creates once `issues.size` reaches this, like the free tier. */
+  freeIssueLimit?: number;
+  /** Hard-fail creates with these titles: a per-item rejection, unlike the limit. */
+  readonly failCreateTitles = new Set<string>();
   /** Number of requests to fail with a 500 before succeeding. */
   serverFailures = 0;
   /** Number of attachment upserts to reject without retry. */
@@ -264,6 +268,31 @@ export class LinearMockServer {
       };
     }
 
+    if (query.includes('mutation ProjectCreate')) {
+      const input = variables.input as { name: string; teamIds: string[] };
+      // Linear rejects a project create naming an unknown team; without this the
+      // mock would accept a provisioning bug the real API refuses.
+      if (!input.teamIds?.length || input.teamIds.some((id) => id !== 'team-1')) {
+        return {
+          status: 200,
+          payload: {
+            errors: [{ message: `Unknown team in teamIds: ${input.teamIds?.join(',')}` }],
+          },
+        };
+      }
+      const project = {
+        id: this.nextId('project'),
+        name: input.name,
+        slugId: `${input.name.toLowerCase().replace(/[^a-z0-9]+/g, '')}${this.projects.length}`,
+        url: `https://linear.app/acme/project/${input.name.toLowerCase()}`,
+      };
+      this.projects.push(project);
+      return {
+        status: 200,
+        payload: { data: { projectCreate: { success: true, project } } },
+      };
+    }
+
     if (query.includes('query Projects')) {
       const first = variables.first as number;
       const offset = Number(variables.after ?? 0);
@@ -371,7 +400,42 @@ export class LinearMockServer {
 
     if (query.includes('mutation IssueCreate')) {
       const input = variables.input as Record<string, unknown>;
+      if (this.failCreateTitles.has(input.title as string)) {
+        return {
+          status: 200,
+          payload: {
+            errors: [{ message: `create rejected by test for title: ${input.title as string}` }],
+          },
+        };
+      }
       const clientId = input.id as string | undefined;
+      // Order matters, and is taken from live behavior: a replayed create whose
+      // client id already exists gets the DUPLICATE error even when the
+      // workspace is over its issue limit — observed as a full backlog of
+      // already-created issues recovering while new creates were being
+      // refused. Duplicate detection first, then the limit.
+      if (this.freeIssueLimit !== undefined && this.issues.size >= this.freeIssueLimit) {
+        if (!(clientId && this.issues.has(clientId))) {
+          return {
+            status: 200,
+            payload: {
+              errors: [
+                {
+                  message: 'issue limit exceeded',
+                  extensions: {
+                    type: 'invalid input',
+                    code: 'INPUT_ERROR',
+                    statusCode: 400,
+                    userError: true,
+                    userPresentableMessage:
+                      "You've exceeded the free issue limit for this workspace. Please upgrade or contact sales@linear.app for a free trial.",
+                  },
+                },
+              ],
+            },
+          };
+        }
+      }
       if (clientId && this.issues.has(clientId)) {
         // Matches the real API: a duplicate client id is a hard error, so a
         // retried create must treat this as success rather than failure.
@@ -392,6 +456,18 @@ export class LinearMockServer {
         };
       }
       const id = clientId ?? this.nextId('issue');
+      // Linear rejects a create naming a parent that does not exist; silently
+      // storing `parent: null` instead let the suite bless orphan creates that
+      // the real API refuses — observed live when a parent's create failed and
+      // its children were attempted against the never-created client id.
+      if (typeof input.parentId === 'string' && !this.issues.has(input.parentId)) {
+        return {
+          status: 200,
+          payload: {
+            errors: [{ message: 'parentId contained an entry that could not be found.' }],
+          },
+        };
+      }
       const identifier = `FIN-${this.issues.size + 1}`;
       const issue = this.addIssue({
         id,

--- a/packages/tbd/tests/integration-nesting-config.e2e.test.ts
+++ b/packages/tbd/tests/integration-nesting-config.e2e.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Config-driven `max_nesting`, through the real CLI.
+ *
+ * The engine honored its `maxNesting` option and the mirror-only `--push` path
+ * forwarded it, but the full synchronization never passed it — so the engine's
+ * fallback default (2) silently overrode any configured value, and the two
+ * modes disagreed about which beads even qualify. A unit test on the engine
+ * cannot see that: the defect was one missing property at the call site, which
+ * only a run through the CLI exercises. Found live on a repo set to 3 that kept
+ * reporting `past max_nesting 2`.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { LinearMockServer } from './helpers/linear-mock-server.js';
+
+const execFileAsync = promisify(execFile);
+const BIN = join(import.meta.dirname, '..', 'dist', 'bin.mjs');
+
+describe('config-driven max_nesting via the CLI', () => {
+  let dir: string;
+  let remoteDir: string;
+  let server: LinearMockServer;
+
+  async function cli(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+    try {
+      const { stdout, stderr } = await execFileAsync(process.execPath, [BIN, ...args], {
+        cwd: dir,
+        env: {
+          ...process.env,
+          LINEAR_API_KEY: 'lin_api_test',
+          LINEAR_API_URL: server.endpoint,
+        },
+      });
+      return { stdout, stderr, code: 0 };
+    } catch (error) {
+      const failed = error as { stdout?: string; stderr?: string; code?: number };
+      return { stdout: failed.stdout ?? '', stderr: failed.stderr ?? '', code: failed.code ?? 1 };
+    }
+  }
+
+  beforeAll(async () => {
+    server = new LinearMockServer();
+    await server.start();
+
+    dir = await mkdtemp(join(tmpdir(), 'tbd-nesting-e2e-'));
+    remoteDir = await mkdtemp(join(tmpdir(), 'tbd-nesting-e2e-origin-'));
+    const sh = async (cmd: string, args: string[]): Promise<void> => {
+      await execFileAsync(cmd, args, { cwd: dir });
+    };
+    await execFileAsync('git', ['init', '--bare', '-q', remoteDir]);
+    await sh('git', ['init', '-q', '--initial-branch=main']);
+    await sh('git', ['config', 'user.email', 't@e.com']);
+    await sh('git', ['config', 'user.name', 'T']);
+    await sh('git', ['config', 'commit.gpgsign', 'false']);
+    await writeFile(join(dir, 'README.md'), '# t\n');
+    await writeFile(join(dir, '.gitignore'), '.env\n');
+    await sh('git', ['add', '-A']);
+    await sh('git', ['commit', '-q', '-m', 'init']);
+    await sh('git', ['remote', 'add', 'origin', remoteDir]);
+    await sh('git', ['push', '-q', '-u', 'origin', 'main']);
+
+    const init = await cli(['init', '--prefix=nst', '--force']);
+    expect(init.code).toBe(0);
+
+    // The grouped f08 form, exactly as a configured repo carries it. The value
+    // under test: max_nesting 3, one past the engine's fallback default.
+    const config = await readFile(join(dir, '.tbd', 'config.yml'), 'utf8');
+    await writeFile(
+      join(dir, '.tbd', 'config.yml'),
+      `${config}
+integrations:
+  on_tbd_sync: 'off'
+  linear:
+    enabled: true
+    target:
+      team_key: FIN
+    policy:
+      outbound:
+        kinds: [epic, task]
+        statuses: [open]
+        max_nesting: 3
+`,
+    );
+
+    // A three-level chain: epic > task > task. Depth 3 is exactly what the
+    // default would exclude and the configured value must include.
+    const root = await cli(['create', 'Root epic', '-t', 'epic']);
+    expect(root.code).toBe(0);
+    const rootId = /Created (\S+):/.exec(root.stdout)![1]!;
+    const mid = await cli(['create', 'Mid task', '-t', 'task', '--parent', rootId]);
+    expect(mid.code).toBe(0);
+    const midId = /Created (\S+):/.exec(mid.stdout)![1]!;
+    const leaf = await cli(['create', 'Leaf task', '-t', 'task', '--parent', midId]);
+    expect(leaf.code).toBe(0);
+  }, 60_000);
+
+  afterAll(async () => {
+    await server.stop();
+    await rm(dir, { recursive: true, force: true });
+    await rm(remoteDir, { recursive: true, force: true });
+  });
+
+  it('the full sync honors configured max_nesting instead of the engine default', async () => {
+    const result = await cli(['integration', 'sync', '--dry-run']);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('would create 3');
+    expect(result.stdout).not.toContain('past max_nesting');
+  });
+});

--- a/packages/tbd/tests/integrations-provision-project.test.ts
+++ b/packages/tbd/tests/integrations-provision-project.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Project provisioning in `tbd integration setup`.
+ *
+ * `resolveProjectId` fails a sync outright when `target.project` names nothing,
+ * so a setup that provisioned only labels walked the operator into a guaranteed
+ * first-sync error: setup printed success, the very next `tbd integration sync`
+ * died with `Linear project not found`. Found live while wiring the second
+ * repository of a multi-repo team, where one project per repository is the
+ * intended shape.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { LinearAdapter } from '../src/integrations/linear/adapter.js';
+import { LinearClient } from '../src/integrations/linear/client.js';
+import { LinearMockServer } from './helpers/linear-mock-server.js';
+
+describe('project provisioning', () => {
+  let server: LinearMockServer;
+  let adapter: LinearAdapter;
+
+  beforeEach(async () => {
+    server = new LinearMockServer();
+    const endpoint = await server.start();
+    adapter = new LinearAdapter({
+      client: new LinearClient({ apiKey: 'k', endpoint, sleep: () => Promise.resolve() }),
+      teamKey: 'FIN',
+      project: 'metaproc',
+    });
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it('reports a missing project on a dry run, creating nothing', async () => {
+    const report = await adapter.provision({ originLabels: [], apply: false });
+
+    expect(report.items).toContainEqual(
+      expect.objectContaining({ kind: 'project', name: 'metaproc', state: 'missing' }),
+    );
+    expect(server.projects).toHaveLength(0);
+  });
+
+  it('creates the missing project on apply, and is idempotent', async () => {
+    const first = await adapter.provision({ originLabels: [], apply: true });
+    expect(first.items).toContainEqual(
+      expect.objectContaining({ kind: 'project', name: 'metaproc', state: 'created' }),
+    );
+    expect(server.projects.map((p) => p.name)).toEqual(['metaproc']);
+
+    // A fresh adapter, as a re-run of setup would construct: the project now
+    // exists, so nothing is created and nothing is duplicated.
+    const again = new LinearAdapter({
+      client: new LinearClient({
+        apiKey: 'k',
+        endpoint: server.endpoint,
+        sleep: () => Promise.resolve(),
+      }),
+      teamKey: 'FIN',
+      project: 'metaproc',
+    });
+    const second = await again.provision({ originLabels: [], apply: true });
+    expect(second.items).toContainEqual(
+      expect.objectContaining({ kind: 'project', name: 'metaproc', state: 'present' }),
+    );
+    expect(server.projects).toHaveLength(1);
+  });
+
+  it('matches an existing project by name or slug, case-insensitively', async () => {
+    server.projects.push({ id: 'project-9', name: 'Metaproc', slugId: 'abc123' });
+
+    const report = await adapter.provision({ originLabels: [], apply: true });
+
+    expect(report.items).toContainEqual(
+      expect.objectContaining({ kind: 'project', name: 'metaproc', state: 'present' }),
+    );
+    expect(server.projects).toHaveLength(1);
+  });
+
+  it('reports nothing about projects when none is configured', async () => {
+    const bare = new LinearAdapter({
+      client: new LinearClient({
+        apiKey: 'k',
+        endpoint: server.endpoint,
+        sleep: () => Promise.resolve(),
+      }),
+      teamKey: 'FIN',
+    });
+
+    const report = await bare.provision({ originLabels: [], apply: true });
+
+    expect(report.items.filter((item) => item.kind === 'project')).toHaveLength(0);
+  });
+
+  it('a create straight after provisioning files into the project setup just made', async () => {
+    // The failure this feature exists to prevent, end to end: before it, setup
+    // printed success and the very next outbound write died with `Linear
+    // project not found`. createIssue exercises resolveProjectId on the same
+    // adapter, which must find the project — via the cached id, not a re-list.
+    await adapter.provision({ originLabels: [], apply: true });
+    const requestsAfterProvision = server.requests.length;
+
+    const ref = await adapter.createIssue({
+      title: 'First bead of the newly integrated repo',
+      status: 'open',
+      priority: 2,
+    });
+
+    const stored = server.issues.get(ref.id);
+    expect(stored?.projectId).toBe(server.projects[0]!.id);
+    // No `query Projects` after provisioning: the created id was cached.
+    const later = server.requests.slice(requestsAfterProvision);
+    expect(later.filter((request) => request.query.includes('query Projects'))).toHaveLength(0);
+  });
+});

--- a/packages/tbd/tests/integrations-sync-engine.test.ts
+++ b/packages/tbd/tests/integrations-sync-engine.test.ts
@@ -390,6 +390,127 @@ describe('the sync engine', () => {
     expect(store.get(id)!.extensions?.linear).not.toHaveProperty('key');
   });
 
+  describe('batch failure containment on outbound creates', () => {
+    const createAttempts = () =>
+      server.requests.filter((request) => request.query.includes('mutation IssueCreate'));
+
+    it('halts remaining creates at the first workspace-limit rejection', async () => {
+      // The limit is a property of the workspace, so once one create hits it,
+      // every later one in the batch is doomed for the same reason. Observed
+      // live: a 77-create sync burned a request per doomed item, then its
+      // replay backlog did it again on every subsequent sync.
+      const ids = [
+        'is-01hx5zzkbkactav9wevgemmc01',
+        'is-01hx5zzkbkactav9wevgemmc02',
+        'is-01hx5zzkbkactav9wevgemmc03',
+        'is-01hx5zzkbkactav9wevgemmc04',
+      ];
+      for (const id of ids) {
+        store.set(id, bead(id, { title: `Epic ${id.slice(-3)}` }));
+      }
+      server.freeIssueLimit = 1;
+
+      const result = await run([...store.values()]);
+
+      expect(result.createdOutbound).toHaveLength(1);
+      expect(result.failures).toHaveLength(3);
+      // One success, one limit rejection — the two remaining were never sent.
+      expect(createAttempts()).toHaveLength(2);
+      const notAttempted = result.failures.filter((failure) =>
+        failure.error.startsWith('not attempted:'),
+      );
+      expect(notAttempted).toHaveLength(2);
+    });
+
+    it('does not attempt a child whose parent failed to create in this run', async () => {
+      // The child's parentId is the parent's pre-assigned client id, which
+      // never came to exist — Linear rejects it with "parentId contained an
+      // entry that could not be found" (observed live). Skipping locally keeps
+      // both journaled, and a later replay creates parent then child in order.
+      const parentId = 'is-01hx5zzkbkactav9wevgemmd01';
+      const childId = 'is-01hx5zzkbkactav9wevgemmd02';
+      store.set(parentId, bead(parentId, { title: 'Doomed parent' }));
+      store.set(childId, bead(childId, { title: 'Orphan child', parent_id: parentId }));
+      server.failCreateTitles.add('Doomed parent');
+
+      const result = await run([...store.values()]);
+
+      expect(result.createdOutbound).toHaveLength(0);
+      expect(result.failures).toHaveLength(2);
+      const childFailure = result.failures.find((failure) => failure.beadId === 'md02');
+      expect(childFailure?.error).toContain('parent failed to create');
+      // Only the parent's create reached the provider.
+      expect(createAttempts()).toHaveLength(1);
+    });
+
+    it('replays a halted backlog without re-paying a request per doomed item', async () => {
+      const ids = [
+        'is-01hx5zzkbkactav9wevgemme01',
+        'is-01hx5zzkbkactav9wevgemme02',
+        'is-01hx5zzkbkactav9wevgemme03',
+      ];
+      for (const id of ids) {
+        store.set(id, bead(id, { title: `Epic ${id.slice(-3)}` }));
+      }
+      server.freeIssueLimit = 0;
+      await run([...store.values()]); // journals 3 creates, halts after the first rejection
+
+      const before = createAttempts().length;
+      const second = await run([...store.values()]);
+
+      // One probe rediscovers the limit; the rest of the backlog stays parked.
+      expect(createAttempts().length - before).toBe(1);
+      expect(second.createdOutbound).toHaveLength(0);
+
+      // And the backlog is a backlog, not a graveyard: lift the limit and the
+      // next sync converges everything.
+      server.freeIssueLimit = undefined;
+      const recovered = await run([...store.values()]);
+      expect(recovered.failures).toEqual([]);
+      expect(server.issues.size).toBe(3);
+    });
+
+    it('compacts a partially-failed journal so replay pays only for pending ops', async () => {
+      // File-granular retention meant a 200-op journal replayed its succeeded
+      // ops on every sync until the last one cleared — observed live as ~90
+      // redundant requests per run. After a partial pass, the journal keeps
+      // only what is still pending.
+      const ids = [
+        'is-01hx5zzkbkactav9wevgemmf01',
+        'is-01hx5zzkbkactav9wevgemmf02',
+        'is-01hx5zzkbkactav9wevgemmf03',
+      ];
+      for (const id of ids) {
+        store.set(id, bead(id, { title: `Epic ${id.slice(-3)}` }));
+      }
+      server.freeIssueLimit = 2; // two fit, the third trips the limit
+      await run([...store.values()]); // journals everything, applies partially
+
+      // The first sync keeps its own journal whole — the engine does not track
+      // per-op completion. The NEXT sync's replay pass recovers the succeeded
+      // ops (idempotently) and it is that pass which compacts.
+      const [before] = await listIntentFiles(dir, 'linear');
+      expect(before!.ops.filter((op) => op.kind === 'create_issue')).toHaveLength(3);
+
+      await run([...store.values()]); // replay recovers 2, re-fails 1, compacts
+
+      const [journal] = await listIntentFiles(dir, 'linear');
+      expect(journal).toBeDefined();
+      // Only the doomed create's ops remain; every recovered op is gone, so a
+      // third sync pays one probe rather than one request per completed op.
+      expect(
+        journal!.ops.filter((op) => op.kind === 'create_issue').map((op) => op.bead_id),
+      ).toEqual(['is-01hx5zzkbkactav9wevgemmf03']);
+
+      // The compacted journal converges once the limit lifts.
+      server.freeIssueLimit = undefined;
+      const recovered = await run([...store.values()]);
+      expect(recovered.failures).toEqual([]);
+      expect(await listIntentFiles(dir, 'linear')).toEqual([]);
+      expect(server.issues.size).toBe(3);
+    });
+  });
+
   it('backfills and preserves the managed block on a pre-existing linked item', async () => {
     server.addIssue({
       id: 'linked-item',


### PR DESCRIPTION
Wiring two sibling repositories (metaproc, metabrowser) into one Linear team as separate projects — the multi-repo shape the f08 label design was built for — surfaced four defects. Each was verified live and each carries a regression test confirmed to fail without its fix.

## Setup now provisions the configured project

`resolveProjectId` fails a sync outright when `target.project` names nothing (deliberately — filing issues into "no project" over a typo is worse). But `integration setup` provisioned only labels, so it printed success and walked the operator into a guaranteed first-sync error:

```
$ tbd integration setup        ->  "Already provisioned; ready to sync."
$ tbd integration sync         ->  Error: Linear project not found: metaproc
```

The project is scaffolding exactly like the labels: dry-run reports it, apply creates it (verified against Linear's schema — `ProjectCreateInput` requires `name` + `teamIds`), re-run is idempotent, and the created id is cached so the sync that follows does not re-list projects.

## The full sync now honors configured `max_nesting`

The engine took the option, the mirror-only `--push` forwarded it — and the full sync never passed it, so the engine default (2) silently overrode any configured value. One missing property at one call site, which is why the regression test drives the real CLI rather than the engine: a unit test cannot see a call-site omission.

## Batch failures are contained instead of amplified

The metabrowser sync hit the workspace's **free-issue limit** 45 creates into 77. The aftermath cost more than the failure:

- children of failed parents burned a request each on a guaranteed rejection ("parentId contained an entry that could not be found")
- every subsequent sync replayed the entire journaled backlog: the doomed creates, their dependent attachment/description ops, and the ~90 ops that had **already succeeded**

Measured: ~405 requests for the failing run, then ~146 per sync forever, against a 2,500/hr budget.

Now, in order:
1. A workspace-limit rejection is **typed** (duck-typed marker, so the provider-agnostic core imports nothing from the Linear layer) and **halts remaining creates** in the batch; replays probe once and park the rest.
2. A child whose parent failed to create is parked without an API call.
3. Ops targeting a never-created issue park with their create.
4. A partially-failed journal is **compacted** after each replay pass, so completed ops are never re-paid.

Everything parked stays journaled, and the backlog converges on the first sync after the limit lifts — that recovery path is asserted in the tests. Live measurement on the halted repository: **405 → 146 → 50 requests per sync**, the remainder being the documented `comments=two_way` per-pair cost.

## The mock got the missing realities

Same theme as the f08 PR: each of these survived CI because the mock was kinder than Linear. It now enforces the free-issue limit — after duplicate-id detection, matching live evidence that a replayed duplicate create recovers even over the limit — rejects creates naming a nonexistent parent, and supports `projectCreate`.

## Verification

- 145 test files, 2,207 tests, 1,101 golden assertions green
- Each fix's test confirmed to fail with the fix reverted
- Live: metaproc provisioned end to end (project + labels created, 5 issues synced, second sync `nothing to do`); metabrowser converged to the parked steady state above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core sync, intent replay, and outbound create paths—behavior changes under failure and limits—but changes are guarded with tests and preserve journaled convergence when limits lift.
> 
> **Overview**
> Fixes **Linear multi-repo setup and sync behavior** where full sync ignored policy, setup could not create projects, and halted batches kept hammering the API.
> 
> **Configured `max_nesting` on full sync** — `runEnabledIntegrations` now passes `maxNesting` into `runSync`, matching mirror-only `--push`. Previously the engine default (2) overrode config (e.g. `3`), so depth-3 beads were wrongly skipped.
> 
> **Project provisioning in setup** — `integration setup` can report and create the configured Linear project (`PROJECT_CREATE_MUTATION`), with id cached for the following sync. Avoids “setup succeeded” then sync failing with project not found.
> 
> **Batch failure containment** — Workspace plan limits are classified via `LinearWorkspaceLimitError` / `isWorkspaceLimitError`; outbound create loops and intent replay **halt further creates** after the first limit error, **skip children** whose parent never created, **skip dependent ops** on dead client ids, and **compact** intent journals to pending ops only so replays do not re-pay succeeded work.
> 
> **Linear mock** — Enforces free-issue limits (after duplicate-id), rejects invalid `parentId`, and supports `projectCreate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d226362603da2a513b74877ff960b3f31fe1f56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->