### PR TITLE
Mirror the bead's own dates, and make archive ownership a policy

### DIFF
--- a/.tbd/config.yml
+++ b/.tbd/config.yml
@@ -136,11 +136,12 @@ docs_cache:
     references/agent-skill-distribution.md: internal:references/agent-skill-distribution.md
     references/docmap-format.md: internal:references/docmap-format.md
     references/docref-format.md: internal:references/docref-format.md
+    references/linear-integration-design.md: internal:references/linear-integration-design.md
   lookup_path:
     - .tbd/docs/shortcuts/system
     - .tbd/docs/shortcuts/standard
 integrations:
-  on_tbd_sync: 'off'
+  on_tbd_sync: off
   linear:
     target:
       team_key: OS

--- a/TODO.archive.md
+++ b/TODO.archive.md
@@ -1,0 +1,93 @@
+# TODO archive
+
+Completed and superseded items moved out of [TODO.md](./TODO.md), newest first.
+Kept because the reasoning is often more useful than the outcome, and because several of
+these were found the expensive way.
+
+Beads hold the authoritative record: `tbd show <id>` for any id below.
+
+## 2026-08 — Linear integration, f08 era
+
+### Multi-repo rollout (metaproc, metabrowser, tbd into one Linear team)
+
+Three repositories now mirror into team `OS`, each as its own project, sharing one label
+group.
+Wiring the second and third repositories is what surfaced most of what follows — a
+single-repo integration hid all of it.
+
+- `tbd-cuwr` — **spec permalinks named the branch that ran the sync.** Every link would
+  404 once the branch was deleted after merge, and because the link sits inside the
+  managed block, syncing from any other branch rewrote the entire mirror.
+  Now resolves durable-trunk-first
+- Project provisioning — `integration setup` provisioned labels but not the configured
+  project, so it printed success and walked the operator into a guaranteed
+  `Linear project not found` on the first sync
+- `max_nesting` was read by the mirror and ignored by the full sync — one missing
+  property at one call site, so the engine default silently overrode configuration
+- Batch-failure containment — a workspace issue-limit rejection used to burn a request
+  per doomed item and then replay the whole backlog on every subsequent sync.
+  Measured 405 → 146 → 50 requests per sync after halting, parking dependent ops, and
+  compacting partially-failed journals
+
+### Identity, dates, and the archive lifecycle
+
+- `tbd-3lfc` — **mirrored issues carried sync-time dates instead of the bead’s own.**
+  Onboarding three repositories produced 99 issues “completed” within one week,
+  including beads genuinely closed seven months earlier.
+  Linear’s auto-archive counts from `completedAt`, so this also filled the issue quota.
+  Fixed on the create path, which is the only surface Linear allows it on — and, not
+  coincidentally, the only one where it matters
+- `tbd-o0sj` — **archive ownership became a policy**, `policy.archive`, defaulting to
+  `manual`. Archiving is a filing decision about what a human sees; a repository’s
+  automation is a poor judge of when someone is done looking.
+  `on_close` hands tbd the lifecycle, with both halves together so reopened work is
+  never stranded
+- `tbd-0t6r` — reopening a bead under an archived issue used to stop syncing silently,
+  forever, once Linear’s default 6-month auto-archive ran.
+  Now either revived (`on_close`) or reported with the remedy (`manual`)
+- `tbd-ktji` — mirror-only `--push` maintained no bridge record, so it never refreshed
+  identifiers. Fixed at zero request cost: the update mutation already returned them and
+  the adapter was discarding them
+- The tracker identifier moved off the bead entirely.
+  Renaming team `TBD` → `OS` mid-session left every bead carrying a stale `TBD-nnn` in a
+  file committed to git, while the UUID links survived untouched — the whole argument
+  for keeping identity and display in different tiers
+
+### Proven, not assumed
+
+- `tbd-majw` — creating a Linear comment **does** advance the issue’s `updatedAt`
+  (02:11:54 → 02:30:58 live), which was the plan’s stated precondition for the
+  delta-gated comment fetch.
+  Worth remembering: the issue’s `updatedAt` landed 21ms *earlier* than the comment’s
+  `createdAt`, so nothing should assume the reverse ordering
+- Linear enforces **label-name uniqueness across a whole team**, and a label group does
+  not scope it. This is why the origin marker is `tbd:sync` rather than a bare `tbd`:
+  repository label names are sanitized to `[a-z0-9._-]` and cannot contain a colon, so
+  the namespaces are disjoint by construction.
+  Before this, mirroring a repository named `tbd` was impossible
+- **Linear rewrites markdown on store.** A link written `[a](url)` reads back
+  `[a](<url>)`. Comparing the managed block as a raw string therefore found a difference
+  on every sync and rewrote 109 of 205 issues forever — the third distinct write loop
+  found in this feature, and the one no other check could see, because the base hash
+  strips the managed block before comparing
+
+### Test infrastructure
+
+The recurring theme: **the mock server was kinder than Linear**, so the suite kept
+blessing shapes the real API refuses.
+It now models team-wide label uniqueness, markdown round-tripping, the free-issue limit,
+unknown-parent rejection, create-date rules, and both archive mutations.
+
+- `tbd-z70i` — `testTimeout` was the 5s default while `hookTimeout` was already
+  Windows-aware. A git-heavy test failed CI at 5472ms and passed on rerun
+
+### Superseded
+
+- `tbd-zo62` — “stamp this repo to `f07` after v0.6.0 publishes.”
+  Obsolete: the repository is stamped `f08`
+
+## Earlier
+
+Work before 2026-08 lives in bead history and in the plan specs under
+[docs/project/specs/](./docs/project/specs/). `tbd list --status closed` is the full
+record — 1,599 closed beads as of this writing.

--- a/TODO.archive.md
+++ b/TODO.archive.md
@@ -61,10 +61,12 @@ single-repo integration hid all of it.
   Worth remembering: the issue’s `updatedAt` landed 21ms *earlier* than the comment’s
   `createdAt`, so nothing should assume the reverse ordering
 - Linear enforces **label-name uniqueness across a whole team**, and a label group does
-  not scope it. This is why the origin marker is `tbd:sync` rather than a bare `tbd`:
-  repository label names are sanitized to `[a-z0-9._-]` and cannot contain a colon, so
-  the namespaces are disjoint by construction.
-  Before this, mirroring a repository named `tbd` was impossible
+  not scope it. A `repo` group with bare children therefore put `repo/tbd` and a root
+  `tbd` in direct conflict, and mirroring this very repository was impossible.
+  Resolved by prefixing the REPOSITORY labels (`repo:<name>`) rather than the marker:
+  segments are sanitized to `[a-z0-9._-]` and cannot contain a colon, so a prefixed name
+  can never equal a bare one — leaving the most-seen label in the workspace as plain
+  `tbd`
 - **Linear rewrites markdown on store.** A link written `[a](url)` reads back
   `[a](<url>)`. Comparing the managed block as a raw string therefore found a difference
   on every sync and rewrote 109 of 205 issues forever — the third distinct write loop

--- a/TODO.md
+++ b/TODO.md
@@ -66,7 +66,7 @@ Real, tracked, and not blocking the release.
 | `tbd-iqgm` | Comment fetching is not delta-gated, so cost is `2+N` per sync rather than `2+changed` |
 | `tbd-fbr6` | `repoUrl` and `prUrls` are rendering code with no data behind them |
 | `tbd-1emr` | Sync’s duplicate-link failure names a UUID where doctor names the issue key |
-| `tbd-t9hi` | Research and active-plan docs still say `label is not tbd`; the marker is `tbd:sync`. In-code references were corrected |
+| `tbd-t9hi` | Research and active-plan docs describe the pre-f08 label scheme. The shipped shape is a bare `tbd` marker plus `repo:<name>`; in-code and reference docs are current |
 | `tbd-j3q1` | Flaky tryscript: `cli-edge-cases` “Non-existent short ID” collides with did-you-mean suggestions |
 
 ## Open epics

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,108 @@
+# TODO
+
+Top-level state: what ships next, what is blocked on a decision, and the epics and specs
+in flight. Everything actionable lives in beads; this file is the map, not the backlog.
+Historical detail moves to [TODO.archive.md](./TODO.archive.md).
+
+Beads are the source of truth.
+`tbd list --status open`, `tbd show <id>`. Last reviewed: 2026-08-16.
+
+## Shipping next: get-tbd 0.7.0 (the f08 release)
+
+Plan:
+[plan-2026-08-15-f08-release-rollout.md](./docs/project/specs/active/plan-2026-08-15-f08-release-rollout.md).
+That document owns the mechanics; this is the status.
+
+**Ready.** The format bump, the integration work, and the multi-repo rollout are merged
+or in review. CI is green on `main`.
+
+Blocking the tag:
+
+- [ ] Land [#236](https://github.com/jlevy/tbd/pull/236) (honest import dates, archive
+  ownership policy, the Linear design reference)
+- [ ] `tbd-62a5` — flip the two goldens this release *un*-breaks.
+  They will “fail” on success: the doctor’s `Launcher fallback` warning disappears once
+  the tagged version can read f08, and `validate-upgrade-package.mjs` regains a genuine
+  same-format baseline that no published version can supply today
+- [ ] Release notes lead with the two operational facts: pre-0.7.0 clients refuse
+  upgraded repositories, and `tbd setup --auto` is a **required** upgrade step
+- [ ] Note that repositories pinning `get-tbd` in CI or hygiene tests must bump those
+  pins — metabrowser’s own suite pins `0.4.2` and currently blocks its branch
+
+Order matters: **publish 0.7.0 first, upgrade repositories second.** The reverse strands
+anyone whose launcher needs the registry fallback.
+
+## Waiting on a human decision
+
+These cannot be closed by writing code.
+
+- **The Linear workspace is over its Free-plan cap.** 250 issues, non-archived; the
+  workspace sits at about 275. metabrowser’s remaining 32 issues are journaled and
+  converge on the first sync after the cap clears — that recovery path is tested.
+  Options: upgrade to Basic (about $30/mo for 3 users, and it likely doubles the API
+  rate limit from the undocumented 2,500/hr the Free tier actually enforces), archive
+  the completed issues, or narrow what gets mirrored.
+  Honest import dates (#236) make this largely self-correcting going forward, but do not
+  retroactively re-date the 99 issues already mirrored with sync-time stamps.
+- **Re-date those 99 issues, or leave them.** Cleanest fix is unlink and re-mirror once
+  #236 lands, so they get correct `createdAt`. Costs a batch of creates against the cap.
+- **`tbd-b7cy`** — whether to create the shared “filter out agent traffic” Linear view,
+  and whether labels should be workspace-scoped rather than team-scoped.
+  Both are decisions about someone’s workspace, not gaps in the code.
+- **`tbd-klgh`** — `identity.user_map` is empty, so assignee sync is skipped and every
+  sync ends with two warnings.
+  Either map the Linear users or decide assignee stays local-only and downgrade the
+  message.
+
+## Known loose ends
+
+Real, tracked, and not blocking the release.
+
+| Bead |  |
+| --- | --- |
+| `tbd-3m0j` | **Half-shipped.** Origin labels landed; the origin-scoped inbound scan did not. `isForeignRepoLabel` exists, is documented as the inbound guard, and is called from nowhere. Latent only because project scoping currently hides it |
+| `tbd-7q6v` | The suite is load-sensitive well past the timing assertions. Worse: `test:coverage` is `vitest run --coverage && tryscript run …`, so any vitest flake **silently skips all 1,101 goldens**. Fix the `&&` independently of the budgets |
+| `tbd-sjil` | Verify orphaned pairs really cost zero requests per sync. Both archive policies assume quiescent pairs are free; if they still cost a fetch, the lifecycle saves nothing |
+| `tbd-iqgm` | Comment fetching is not delta-gated, so cost is `2+N` per sync rather than `2+changed` |
+| `tbd-fbr6` | `repoUrl` and `prUrls` are rendering code with no data behind them |
+| `tbd-1emr` | Sync’s duplicate-link failure names a UUID where doctor names the issue key |
+| `tbd-t9hi` | Research and active-plan docs still say `label is not tbd`; the marker is `tbd:sync`. In-code references were corrected |
+| `tbd-j3q1` | Flaky tryscript: `cli-edge-cases` “Non-existent short ID” collides with did-you-mean suggestions |
+
+## Open epics
+
+Thirteen open. The ones with active work:
+
+- **`tbd-dzme`** — External sync and traceability (prime, claim, checkpoint, Linear
+  visibility). Phases 1–2 shipped; phase 3 is the current front
+- **`tbd-gvju`** — External tracker integrations (Linear first, GitHub next)
+- **`tbd-g9x7`** — Modernize multi-agent skills and hooks setup
+- **`tbd-6h1r`** — Agent CLI ergonomics (bulk ops, output contract, sync clarity)
+- **`tbd-up8l`** / **`tbd-70dj`** / **`tbd-lizx`** / **`tbd-29vf`** / **`tbd-j89q`** —
+  the docs-config redesign arc, phases 1–3 plus the categories decision
+- **`tbd-df33`** — Transactional mode and agent registration
+- **`tbd-d7za`**, **`tbd-mgnn`**, **`tbd-de2w`** — CLI output consistency, sub-agents
+  research review, post-merge ID mapping polish
+
+`tbd list --type epic --status open` for the full set.
+
+## Active plan specs
+
+Eighteen under [docs/project/specs/active/](./docs/project/specs/active/). The ones
+governing current work:
+
+- `plan-2026-08-15-f08-release-rollout.md` — the release above
+- `plan-2026-08-14-external-sync-and-traceability.md` — the four-phase Linear plan
+- `plan-2026-08-10-external-tracker-integrations.md` — the integration design it feeds
+- `plan-2026-06-13-agent-cli-ergonomics.md` — bulk ops and the output contract
+
+Specs archived out of `active/` stop being mirrored to Linear, which is the intended
+signal that they are done.
+
+## Reference
+
+- **[Linear integration design](./packages/tbd/docs/references/linear-integration-design.md)**
+  — read before changing sync behavior.
+  Every rule is paired with the Linear behavior that forces it
+- `tbd docs show setup-linear` — connecting a repository
+- [docs/publishing.md](./docs/publishing.md) — release mechanics

--- a/packages/tbd/docs/references/linear-integration-design.md
+++ b/packages/tbd/docs/references/linear-integration-design.md
@@ -1,0 +1,241 @@
+---
+title: Linear Integration Design
+description: How tbd's model maps onto Linear's, and why each design decision follows from a specific Linear behavior—identity, labels, the managed block, import dates, the archive lifecycle, and what a sync costs
+author: Joshua Levy (github.com/jlevy) with LLM assistance
+---
+# Linear Integration Design
+
+This is the *why*. For connecting a repository, see the `setup-linear` shortcut; for the
+config keys, see the schema.
+This document exists because the same class of bug kept reaching a live workspace: every
+one of them came from a Linear behavior that was known to whoever hit it and written
+down nowhere a reader would find it.
+
+Every rule below is paired with the Linear behavior that forces it.
+A rule without that pairing is one somebody will “clean up” later.
+
+## The governing idea
+
+**The bead is the system of record.
+Linear is a projection.**
+
+Everything else follows.
+A projection may be rebuilt, may lag, and may be edited by a human on the far side—but
+it must never become the only place a fact lives, and it must never rewrite the history
+it is projecting.
+
+The corollary that keeps costing money if forgotten: a projection has to reach a
+**steady size**. A quiet sync costs roughly `2 + N` requests for `N` mirrored pairs, so
+if pairs accumulate forever, sync cost grows without bound.
+Every “retire a settled pair” mechanism here is really about that.
+
+## Identity: the UUID, never the identifier
+
+Linear gives every issue two names: an immutable UUID, and a human identifier like
+`OS-77` that is **team-scoped and mutable**. Renaming a team rewrites the identifier of
+every issue in it. Moving an issue between teams renumbers it.
+
+So the bead stores the UUID and nothing else that Linear can invalidate:
+
+```yaml
+extensions:
+  linear:
+    id: f53df50f-cbd8-4069-bb90-8d27b86cc51e   # the link
+    linked_at: 2026-08-10T19:35:26.513Z
+```
+
+The human identifier and URL live on the **bridge record**, which every sync rewrites
+and which therefore repairs itself.
+They were once stored on the bead; renaming this workspace’s team from `TBD` to `OS`
+left every bead carrying a stale `TBD-nnn` in a file committed to git.
+The links themselves survived untouched, which is the whole argument for keeping
+identity and display in different tiers.
+
+**Rule:** anything Linear can change without tbd’s involvement belongs on the bridge
+record, not the bead.
+
+## Labels: a flat namespace with no scoping
+
+The single most surprising Linear behavior in this integration:
+
+> **Label names must be unique across an entire team, and a label group does not scope
+> them.**
+
+A grouped label stores only its leaf in `name`, with the group in `parent`. So
+`repo/tbd` and a root label named `tbd` are a genuine collision, and Linear rejects the
+second with `duplicate label name`.
+
+That is why the origin marker is **`tbd:sync`** and not a bare `tbd`. Repository label
+names are sanitized to `[a-z0-9._-]`, which cannot contain a colon—so everything in the
+`tbd:` namespace is collision-proof against every possible repository name **by
+construction** rather than by luck.
+Before this, mirroring a repository named `tbd` was impossible, and one named `docs`
+would have collided with an ordinary `docs` label.
+
+The scheme:
+
+| Label | Purpose |
+| --- | --- |
+| `tbd:sync` | Every mirrored item. `label is not tbd:sync` gives a human their board back |
+| `repo/<name>` | Which repository. A Linear group allows one label per issue, which is one-repo-per-bead enforced structurally |
+| `tbd:*` | tbd’s own carriers (`tbd:blocked`, and mirrored labels under `mirror: prefixed`) |
+
+**Rule:** every label tbd creates for itself lives under `tbd:`. Repository labels live
+in the `repo` group.
+The two namespaces cannot collide, and neither can collide with a name a human chose.
+
+## The managed block, and markdown round-tripping
+
+tbd owns a delimited region of each issue description and leaves the rest to humans.
+
+The trap: **Linear rewrites markdown when it stores it.** A link written as
+`[name](url)` is read back as `[name](<url>)`. CommonMark renders those identically, so
+it is invisible to a person and lethal to a string comparison—the block differed from
+itself on every sync, rewriting 109 of 205 issues forever.
+
+The base description hash could never have caught it, because hashing strips the managed
+block first: that region had no check at all.
+
+Known rewrites, all normalized before any comparison:
+
+- link destinations wrapped in angle brackets
+- bare URLs and emails auto-linkified (`a@b.com` → `[a@b.com](mailto:a@b.com)`),
+  including inside fenced code blocks
+- list bullets normalized (`-` → `*`)
+- leading indentation of one to three spaces dropped (insignificant per CommonMark; four
+  or more open a code block and are preserved)
+- blank-line runs collapsed, tight lists loosened
+
+**Rule:** never compare tracker prose as a raw string.
+Normalize both sides.
+When a normalization changes, bump `DESCRIPTION_HASH_PREFIX` so stale hashes read as “no
+recorded base” rather than faking a both-sides-changed conflict.
+
+## Import semantics: dates belong to the bead
+
+Linear accepts `createdAt` and `completedAt` on issue **create**—self-described as “e.g.
+if importing from another system,” which is exactly what a mirror is—and accepts neither
+on **update**.
+
+That asymmetry is the correct shape, not a limitation to route around.
+In steady state a bead closes and the next sync pushes the transition within minutes, so
+a provider-stamped time is already honest.
+The distortion is an **onboarding artifact**: backfilling an existing repository mirrors
+months of history in one afternoon, and onboarding goes through create.
+
+Getting this wrong is not cosmetic.
+Linear’s auto-archive counts from `completedAt`, so a backfilled repository stamped
+“today” keeps years of closed work in the active view—and, on a capped plan, in the
+issue quota—for the entire archive period.
+Observed live: 99 issues stamped completed within one week, including beads genuinely
+closed seven months earlier.
+
+Linear enforces three rules, and violating any fails the **whole create** rather than
+dropping the field, so tbd clamps rather than trusts:
+
+1. Both must be in the past.
+   Clock skew is enough to make “now” land in the future, so anything at or after now is
+   dropped.
+2. `completedAt` must be after `createdAt`. A bead opened and closed in the same
+   second—routine for scripted work—is nudged forward a millisecond.
+3. `completedAt` requires a completed-type state.
+   Only tbd’s `closed` maps to one, so any other status omits it even when the bead
+   carries a `closed_at`.
+
+**Rule:** the projection carries the bead’s dates, never the sync’s.
+
+## The archive lifecycle, and who owns it
+
+Archiving is how a settled pair stops costing anything: an archived issue leaves the
+active view, leaves the issue quota, and stays searchable and restorable.
+
+But **archiving is a filing decision**—it governs what a human sees in their own
+views—and a repository’s automation is a poor judge of when someone is finished looking
+at something. So ownership is a policy, and the default gives it to the human:
+
+```yaml
+policy:
+  archive: manual    # default
+```
+
+**`manual`** — tbd never archives or unarchives.
+An archived item is treated as a settled pair and the sync goes quiet on it.
+A bead reopened under an archived item is **reported with the remedy**, not acted on and
+not silently ignored.
+Linear’s own team-level `autoArchivePeriod` keeps working underneath, which is exactly
+where that policy belongs.
+
+**`on_close`** — tbd owns the lifecycle: closing a bead archives its item, reopening
+restores it. Both halves together on purpose, because an integration that archived but
+never restored would strand reopened work in a tracker nobody is looking at.
+Archiving runs **last** among a pair’s writes, since Linear rejects edits to an archived
+issue.
+
+Two behaviors hold under either policy:
+
+- An archived item is **never re-created**. The bead keeps its link, so the pair is
+  quiescent rather than duplicated.
+- A **trashed** item is never revived.
+  Linear purges trash after 30 days, so reviving one races a deletion that would strand
+  the link again.
+
+The enum rather than a boolean is the extension point: `on_close_after: <duration>` fits
+here without another format bump.
+
+## Multi-repo shape
+
+One team, one project per repository, one shared label group:
+
+```
+team OS ── project tbd          ── repo/tbd        ─┐
+        ├─ project metaproc     ── repo/metaproc   ─┼─ all carry tbd:sync
+        └─ project metabrowser  ── repo/metabrowser ┘
+```
+
+`tbd integration setup` provisions all of it—including the **project**, because
+`resolveProjectId` fails a sync outright when `target.project` names nothing, so
+provisioning only labels would print success and walk the operator into a guaranteed
+first-sync error.
+
+Inbound scanning is project-scoped, so sibling repositories in the same team stay
+invisible to each other rather than importing each other’s work.
+
+## What a sync costs
+
+A quiet sync is `2 + N` requests.
+With the free tier’s 2,500/hour (the documented 5,000 applies to paid plans; the halving
+is not documented) a 200-pair mirror is affordable continuously, and that arithmetic is
+why the steady-size property matters.
+
+Failures are contained rather than amplified:
+
+- A **workspace limit** rejection halts remaining creates in the batch—it is a property
+  of the workspace, so every later create is doomed identically.
+- A **child of a failed parent** is skipped without an API call: its parent id names
+  something that was never created.
+- A partially-failed **journal is compacted** after each replay, so completed operations
+  are never re-paid.
+
+Everything parked stays journaled and converges on the first sync after the blocker
+clears. Measured on a mirror halted by the free-tier cap: 405 → 146 → 50 requests per
+sync.
+
+## What tbd deliberately does not do
+
+Each of these is a judgment about whose workspace it is:
+
+- **Auto-provision on sync.** Creating label groups restructures a shared workspace;
+  `tbd integration setup` is the command you run on purpose.
+- **Create shared views.** `customViewCreate` would work, but a saved view is more
+  invasive than a label.
+- **Set `autoArchivePeriod`.** It is team-wide and governs human-authored issues too.
+  tbd reports it; a human sets it.
+- **Mass-create labels from bead labels.** `mirror: none` is the default; a repository
+  can carry a hundred labels and a team namespace is shared.
+- **Delete anything.** Unlink severs a pair; the tracker item is left for a human.
+
+* * *
+
+*This document is part of the tbd documentation.
+See also: the `setup-linear` shortcut for connecting a repository, and
+`docs/project/specs/` for the plans this design came from.*

--- a/packages/tbd/docs/references/linear-integration-design.md
+++ b/packages/tbd/docs/references/linear-integration-design.md
@@ -65,24 +65,38 @@ A grouped label stores only its leaf in `name`, with the group in `parent`. So
 `repo/tbd` and a root label named `tbd` are a genuine collision, and Linear rejects the
 second with `duplicate label name`.
 
-That is why the origin marker is **`tbd:sync`** and not a bare `tbd`. Repository label
-names are sanitized to `[a-z0-9._-]`, which cannot contain a colon—so everything in the
-`tbd:` namespace is collision-proof against every possible repository name **by
+That collision is why the **repository** labels carry a prefix: `repo:tbd`,
+`repo:metaproc`. Repository segments are sanitized to `[a-z0-9._-]` and can never
+contain a colon, so a prefixed name cannot equal a bare one—collision-proof **by
 construction** rather than by luck.
-Before this, mirroring a repository named `tbd` was impossible, and one named `docs`
-would have collided with an ordinary `docs` label.
+
+Prefixing the repository side rather than the marker is deliberate.
+The marker is the single most-seen label in the workspace and the one the documented
+filter names, so it stays plain `tbd`; the prefix goes on the supporting detail.
+An earlier shape did the reverse (`tbd` beside a `repo` group) and read worse for no
+benefit.
+
+The cost is Linear’s one-label-per-group guarantee, which the group form gave free.
+It is small: tbd asserts exactly one repository label per item, so the invariant already
+holds from this side, and “show me everything from any tbd repository” is what the `tbd`
+marker is for.
 
 The scheme:
 
 | Label | Purpose |
 | --- | --- |
-| `tbd:sync` | Every mirrored item. `label is not tbd:sync` gives a human their board back |
+| `tbd` | Every mirrored item. `label is not tbd` gives a human their board back |
 | `repo/<name>` | Which repository. A Linear group allows one label per issue, which is one-repo-per-bead enforced structurally |
 | `tbd:*` | tbd’s own carriers (`tbd:blocked`, and mirrored labels under `mirror: prefixed`) |
 
-**Rule:** every label tbd creates for itself lives under `tbd:`. Repository labels live
-in the `repo` group.
-The two namespaces cannot collide, and neither can collide with a name a human chose.
+tbd sets a color when it *creates* one of its own labels—indigo for the marker, slate
+for repository labels, red and amber for the blocked and deferred carriers—and never on
+update. Colour is presentation, and once a label exists it belongs to the workspace.
+
+**Rule:** the marker is bare; everything else tbd creates is prefixed, `tbd:` for its
+own carriers and `repo:` for repository identity.
+No prefixed name can collide with a bare one, so none of the three can collide with each
+other or with a name a human chose.
 
 ## The managed block, and markdown round-tripping
 
@@ -184,12 +198,12 @@ here without another format bump.
 
 ## Multi-repo shape
 
-One team, one project per repository, one shared label group:
+One team, one project per repository, one flat label namespace:
 
 ```
-team OS ── project tbd          ── repo/tbd        ─┐
-        ├─ project metaproc     ── repo/metaproc   ─┼─ all carry tbd:sync
-        └─ project metabrowser  ── repo/metabrowser ┘
+team OS ── project tbd          ── repo:tbd         ─┐
+        ├─ project metaproc     ── repo:metaproc    ─┼─ all carry `tbd`
+        └─ project metabrowser  ── repo:metabrowser ─┘
 ```
 
 `tbd integration setup` provisions all of it—including the **project**, because
@@ -224,7 +238,7 @@ sync.
 
 Each of these is a judgment about whose workspace it is:
 
-- **Auto-provision on sync.** Creating label groups restructures a shared workspace;
+- **Auto-provision on sync.** Creating labels restructures a shared workspace;
   `tbd integration setup` is the command you run on purpose.
 - **Create shared views.** `customViewCreate` would work, but a saved view is more
   invasive than a label.

--- a/packages/tbd/docs/shortcuts/standard/setup-linear.md
+++ b/packages/tbd/docs/shortcuts/standard/setup-linear.md
@@ -256,9 +256,10 @@ session-end `tbd sync` keeps Linear current with no extra command.
 Full reference: the External Tracker Integrations section of `tbd docs`.
 
 For the design behind all of this—why the link stores a UUID, why the origin label is
-`tbd:sync`, why prose is normalized before comparison, and who owns the archive—see
-`tbd docs show linear-integration-design`. Read that before changing sync behavior: each
-rule there is paired with the Linear behavior that forces it.
+`tbd` and repository labels `repo:<name>`, why prose is normalized before comparison,
+and who owns the archive—see `tbd docs show linear-integration-design`. Read that before
+changing sync behavior: each rule there is paired with the Linear behavior that forces
+it.
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/packages/tbd/docs/shortcuts/standard/setup-linear.md
+++ b/packages/tbd/docs/shortcuts/standard/setup-linear.md
@@ -250,7 +250,15 @@ session-end `tbd sync` keeps Linear current with no extra command.
 | Sync says `nothing to do` but Linear looks stale | The policy does not select those beads | Check `policy.outbound` against what the user expects; `--dry-run integration sync --push` lists the selected set |
 | A bead reports malformed managed-block markers | A human edited inside the `⟦tbd⟧` … `⟦/tbd⟧` region in Linear | Repair the region in Linear (one `⟦tbd⟧` and one `⟦/tbd⟧`, in that order) or delete it entirely; the next sync rewrites it |
 
+| A reopened bead stops syncing, warning that its item is archived | Under the default `policy.archive: manual` the tracker’s archive is yours to manage | Restore the issue in Linear, or set `policy.archive: on_close` to let tbd own the lifecycle |
+| Newly mirrored issues all show today’s dates | A tbd older than 0.7.0 stamped them at sync time instead of sending the bead’s own | Upgrade; dates are sent on create, so already-mirrored issues keep their original stamps |
+
 Full reference: the External Tracker Integrations section of `tbd docs`.
+
+For the design behind all of this—why the link stores a UUID, why the origin label is
+`tbd:sync`, why prose is normalized before comparison, and who owns the archive—see
+`tbd docs show linear-integration-design`. Read that before changing sync behavior: each
+rule there is paired with the Linear behavior that forces it.
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/packages/tbd/src/cli/lib/integration-runner.ts
+++ b/packages/tbd/src/cli/lib/integration-runner.ts
@@ -487,6 +487,13 @@ export async function runEnabledIntegrations(
       specUrl: (issue) => (issue.spec_path ? specLinks.get(issue.spec_path) : undefined),
       mirrorLabels: resolveProviderSettings(config.integrations?.linear ?? {}).mirrorLabels,
       originLabels: await resolveOriginLabels(tbdRoot, config),
+      // Resolved from config like everything else here. This was the one option
+      // the full sync did not forward, so the engine's fallback default (2)
+      // silently overrode any configured `max_nesting` — while the mirror-only
+      // `--push` path forwarded it correctly, making the two modes disagree
+      // about which beads even qualify. Found live: a repo set to 3 kept
+      // reporting `past max_nesting 2`.
+      maxNesting: entry.maxNesting,
       // Linear cannot represent P4 (its 4 covers P3 and P4); without this
       // equivalence every P4 bead would oscillate as a phantom pull.
       equivalences: {

--- a/packages/tbd/src/integrations/core/intents.ts
+++ b/packages/tbd/src/integrations/core/intents.ts
@@ -24,6 +24,7 @@ import { z } from 'zod';
 import type { ProviderNameType } from '../../lib/types.js';
 import { parseYamlWithConflictDetection, stringifyYaml } from '../../utils/yaml-utils.js';
 import { bridgeIntentsDir } from './bridge-state.js';
+import { isWorkspaceLimitError } from './types.js';
 import type { AttachmentSpec, CanonicalPatch, ConflictReport, TrackerAdapter } from './types.js';
 
 const CanonicalPatchSchema = z
@@ -268,13 +269,55 @@ export async function replayIntents(
     failures: [],
   };
 
+  // A workspace plan limit fails every issue create for the same reason, so the
+  // first such error stops further create attempts across ALL journaled runs —
+  // otherwise a large halted batch re-pays one doomed request per item on every
+  // sync until the limit is lifted (observed live: ~141 failing calls per run).
+  // Other op kinds keep replaying: comments and updates are not what the limit
+  // is counting, and holding them hostage would delay unrelated convergence.
+  let createHalt: string | undefined;
+  // External ids that provably do not exist: the client ids of creates that
+  // failed or were parked. An op journaled against one — the attachments or
+  // managed block of a never-created issue — is a guaranteed "Could not find
+  // referenced Issue" from the provider, so it parks locally instead. Observed
+  // live: 32 halted creates left 64 dependent ops burning a request each on
+  // every sync.
+  const deadExternalIds = new Set<string>();
+
   for (const file of await listIntentFiles(dataSyncDir, provider)) {
     report.replayedRuns += 1;
     let failed = false;
     const recoveredCreates: ReplayReport['recoveredCreates'] = [];
     const recoveredComments: ReplayReport['recoveredComments'] = [];
+    // Ops that must survive into the next replay. Everything else — succeeded,
+    // consumed by the safety filter, or discarded by the integrity guard — has
+    // no reason to run again: replaying a 200-op journal for its 3 failures
+    // costs a request per already-done op on every sync (observed live as ~90
+    // redundant requests per run against a halted batch).
+    const pendingOps: typeof file.ops = [];
 
     for (const op of file.ops) {
+      if (op.kind === 'create_issue' && createHalt !== undefined) {
+        failed = true;
+        pendingOps.push(op);
+        deadExternalIds.add(op.client_id);
+        report.failures.push({
+          runId: file.run_id,
+          op,
+          error: `not attempted: ${createHalt}`,
+        });
+        continue;
+      }
+      if (op.kind !== 'create_issue' && deadExternalIds.has(op.external_id)) {
+        failed = true;
+        pendingOps.push(op);
+        report.failures.push({
+          runId: file.run_id,
+          op,
+          error: 'not attempted: its issue was never created; retries with the create.',
+        });
+        continue;
+      }
       const blockedTarget = blockedReplayTarget(op, safety);
       if (blockedTarget) {
         // The durable bead remains the source for re-planning once the link
@@ -335,6 +378,13 @@ export async function replayIntents(
         report.replayedOps += 1;
       } catch (error) {
         failed = true;
+        pendingOps.push(op);
+        if (op.kind === 'create_issue') {
+          deadExternalIds.add(op.client_id);
+          if (isWorkspaceLimitError(error)) {
+            createHalt = error.message;
+          }
+        }
         report.failures.push({
           runId: file.run_id,
           op,
@@ -351,6 +401,12 @@ export async function replayIntents(
     }
     if (!failed) {
       await deleteIntentFile(dataSyncDir, provider, file.run_id);
+    } else if (pendingOps.length < file.ops.length) {
+      // Compact rather than keep verbatim: the next replay should pay only for
+      // what is actually pending. Written only after recordRecovery above, so
+      // a crash between the two leaves the fuller journal, which replays
+      // idempotently — the safe direction to fail in.
+      await writeIntentFile(dataSyncDir, { ...file, ops: pendingOps });
     }
   }
 

--- a/packages/tbd/src/integrations/core/mirror.ts
+++ b/packages/tbd/src/integrations/core/mirror.ts
@@ -251,6 +251,11 @@ export function planMirror(context: MirrorContext): MirrorPlan {
       title: issue.title,
       status: issue.status,
       priority: issue.priority,
+      // Carried on every action, consumed only by the create path: the adapter's
+      // update surface ignores these, and the provider does not accept them there
+      // either. See CanonicalPatch.sourceCreatedAt.
+      sourceCreatedAt: issue.created_at,
+      sourceCompletedAt: issue.closed_at ?? null,
       ...(!linkedBeyondMaxNesting ? { parentId: parentLink?.id ?? null } : {}),
       // Omitting `labels` entirely leaves the tracker's labels alone except for
       // the status carriers the adapter adds. Sending [] would strip labels a

--- a/packages/tbd/src/integrations/core/origin-labels.ts
+++ b/packages/tbd/src/integrations/core/origin-labels.ts
@@ -1,59 +1,101 @@
 /**
  * Origin labels: the marks that make a shared tracker legible.
  *
- * Every mirrored item carries a `tbd:sync` label and a per-repository label in a group
- * named `repo`. Two things follow, and both are the point:
+ * Every mirrored item carries a `tbd` label and a `repo:<name>` label. Two things
+ * follow, and both are the point:
  *
  * - **A human can filter agent traffic out.** Linear views support "is not", so
- *   `label is not tbd:sync` gives a person their own board back in a workspace that
- *   agents also write to. Without a uniform marker there is no such filter.
- * - **Many repositories can report into one surface.** The `repo` group answers "where
- *   did this come from", which is the question that otherwise makes a shared team or
- *   project unusable past the second repository.
+ *   `label is not tbd` gives a person their own board back in a workspace that agents
+ *   also write to. Without a uniform marker there is no such filter.
+ * - **Many repositories can report into one surface.** `repo:<name>` answers "where did
+ *   this come from", which is the question that otherwise makes a shared team or project
+ *   unusable past the second repository.
  *
  * They apply in **every** integration mode, by default. A single-repo setup pays nothing
  * for them and becomes consolidation-ready for free; a repository that genuinely does not
  * want them sets `labels.origin: false`.
  *
- * The group form (`repo/<name>`) is Linear's native namespace convention, and a Linear
- * label group allows only one of its labels per issue — which matches one-repo-per-bead
- * structurally rather than by a rule this code has to enforce.
+ * ## Why both are flat, and why the marker is bare
  *
- * A group does **not**, however, scope the label's name: Linear stores only the leaf and
- * enforces uniqueness across the entire team, so `repo/tbd` and a root `tbd` are a
- * genuine conflict that Linear rejects outright. That is why tbd's own markers live
- * behind {@link TBD_LABEL_PREFIX}, which repository names provably cannot reach. A repo
- * name can still collide with a label a human already made; that is a real conflict and
- * `tbd integration setup` reports it rather than half-applying.
+ * A Linear label name must be unique across the **entire team**, and a label group does
+ * *not* scope it: Linear stores only the leaf name and rejects a duplicate outright. So
+ * an earlier shape — a `repo` group whose children were bare repository names — put the
+ * marker and the label for a repository named `tbd` in direct conflict, and Linear
+ * refused to create the second. Mirroring this very repository was impossible.
+ *
+ * Prefixing the *repository* labels instead of the marker resolves it in the direction
+ * that reads better. {@link sanitizeRepoLabel} emits only `[a-z0-9._-]`, so a repository
+ * segment can never contain a colon — which makes `repo:<name>` unable to collide with
+ * the bare marker, with another repository's label, or with a plain name a human chose.
+ * Disjoint by construction rather than by luck, exactly as before, but now the common
+ * label on every bead is simply `tbd`.
+ *
+ * The cost is Linear's one-label-per-group guarantee, which the group form gave for
+ * free. It is a small loss: tbd asserts exactly one repository label per item, so the
+ * invariant already holds from this side, and the group's other use — "show me
+ * everything from any tbd repository" — is what the `tbd` marker is for.
+ *
+ * {@link TBD_LABEL_PREFIX} remains for tbd's occasional purposeful carriers
+ * (`tbd:blocked`, `tbd:deferred`). Those are deliberately uncommon; the label on *every*
+ * mirrored item is the bare marker.
  */
 
 import type { ProviderSettings, RepoLabelSetting } from './provider-settings.js';
 import { parseRepoSlug } from './permalink.js';
 
 /**
- * Namespace for every root-level label tbd creates for itself.
+ * Namespace for tbd's own purposeful carriers — `tbd:blocked`, `tbd:deferred`.
  *
- * A Linear label name must be unique across the whole team — a label group does *not*
- * scope it, which is the constraint the rest of this file is shaped around. Since
- * {@link sanitizeRepoLabel} can only emit `[a-z0-9._-]`, a name containing `:` can never
- * collide with a repository label, so putting tbd's own markers behind this prefix makes
- * the two namespaces disjoint by construction rather than by luck.
+ * Deliberately NOT where the origin marker lives: these mark specific conditions on
+ * some items, whereas the marker is on every mirrored item and should read as plainly
+ * as possible.
  */
 export const TBD_LABEL_PREFIX = 'tbd:';
 
 /**
- * Default name for the plain marker every mirrored item carries.
+ * The marker every mirrored item carries.
  *
- * Prefixed rather than a bare `tbd` because the bare form shares one flat namespace with
- * repository labels and every label a human already made. Mirroring a repository named
- * `tbd` — this one — made Linear reject the whole provisioning run with
- * `Label "tbd" already exists in team`, and a repository named `docs` would collide with
- * an existing `docs` label just as hard.
+ * Bare on purpose. It is the single most-seen label in the workspace, it is what the
+ * documented `label is not tbd` filter names, and nothing forces it to be longer: the
+ * repository labels carry the prefix instead (see {@link REPO_LABEL_PREFIX}).
  */
-export const ORIGIN_LABEL = `${TBD_LABEL_PREFIX}sync`;
+export const ORIGIN_LABEL = 'tbd';
 
-/** Linear label-group prefix for the per-repository label. */
-export const REPO_LABEL_GROUP = 'repo';
+/**
+ * Prefix for the per-repository label, e.g. `repo:tbd`.
+ *
+ * The colon is load-bearing. Repository segments are sanitized to `[a-z0-9._-]`, so a
+ * prefixed name can never equal a bare one — which is what keeps `repo:tbd` and the
+ * `tbd` marker from being the same Linear label in a namespace that has no scoping.
+ */
+export const REPO_LABEL_PREFIX = 'repo:';
+
+/**
+ * Colors tbd asks for when it creates one of its own labels.
+ *
+ * Set only at creation, never on update: the color is a presentation choice, and once a
+ * label exists it belongs to the workspace. Someone who recolors `tbd` to fit their own
+ * scheme should not have it changed back on the next sync.
+ *
+ * The marker is deliberately the odd one out. It appears on every mirrored item, so it
+ * is the one that has to be recognizable at a glance in a mixed board; the repository
+ * labels are supporting detail and share a quieter tone.
+ */
+export function labelColorFor(name: string): string | undefined {
+  if (name.startsWith(REPO_LABEL_PREFIX)) {
+    return '#6B7280'; // slate — metadata, not a signal
+  }
+  if (name === `${TBD_LABEL_PREFIX}blocked`) {
+    return '#EB5757'; // red, matching what "blocked" means everywhere else
+  }
+  if (name === `${TBD_LABEL_PREFIX}deferred`) {
+    return '#F2C94C'; // amber: paused, not stopped
+  }
+  if (name === ORIGIN_LABEL || name.startsWith(TBD_LABEL_PREFIX)) {
+    return '#556B2F'; // dark olive green: tbd's mark, distinct from Linear's own palette
+  }
+  return undefined;
+}
 
 /**
  * Sanitize a repository name into a label segment.
@@ -116,7 +158,7 @@ export function originLabelsFor(options: {
   const { settings, originRemoteUrl, idPrefix } = options;
   if (settings.originLabel === false) {
     // One switch turns off the whole scheme. A repository that wants the plain marker
-    // but not the repo group sets `labels.repo: false` instead.
+    // but not the repository label sets `labels.repo: false` instead.
     return [];
   }
 
@@ -133,42 +175,41 @@ export function originLabelsFor(options: {
     idPrefix,
   });
   if (repoName) {
-    labels.push(`${REPO_LABEL_GROUP}/${repoName}`);
+    labels.push(`${REPO_LABEL_PREFIX}${repoName}`);
   }
   return labels;
 }
 
 /**
- * Whether a label belongs to another repository's `repo` group.
+ * Whether a label names a repository other than this one.
  *
- * Used by the inbound scan: a candidate carrying a sibling repository's origin label is
- * that repository's business, and importing it here would duplicate the bead on both
- * sides of a shared scope.
+ * Used by the inbound scan: a candidate carrying a sibling repository's label is that
+ * repository's business, and importing it here would duplicate the bead on both sides of
+ * a shared scope.
  */
 export function isForeignRepoLabel(label: string, ownRepoName: string | undefined): boolean {
-  if (!label.startsWith(`${REPO_LABEL_GROUP}/`)) {
+  if (!label.startsWith(REPO_LABEL_PREFIX)) {
     return false;
   }
-  const name = label.slice(REPO_LABEL_GROUP.length + 1);
-  return name !== ownRepoName;
+  return label.slice(REPO_LABEL_PREFIX.length) !== ownRepoName;
 }
 
 /**
  * Whether a label is one tbd owns and needs, as opposed to one mirrored from a bead.
  *
- * The set is deliberately small and structural: anything in the `tbd:` namespace (the
- * default origin marker, the status carriers, and mirrored bead labels under the
- * prefixed mode — mirrored ones are only ever sent when the operator asked for them, so
- * treating the prefix as tbd-owned is right), plus anything in the `repo` group.
+ * The set is deliberately small and structural: the origin marker itself, anything in
+ * the `tbd:` namespace (the status carriers, and mirrored bead labels under the prefixed
+ * mode — those are only ever sent when the operator asked for them, so treating the
+ * prefix as tbd-owned is right), and any `repo:` label.
  *
- * `originName` is still consulted because an operator may override the marker with a
- * bare name via `labels.origin: <string>`. That override is theirs to make, but it opts
- * out of the collision-proofing the prefix provides.
+ * `originName` is consulted separately because an operator may rename the marker via
+ * `labels.origin: <string>`, and a renamed marker is still tbd's.
  */
 export function isTbdOwnedLabel(name: string, originName: string = ORIGIN_LABEL): boolean {
   return (
     name === originName ||
+    name === ORIGIN_LABEL ||
     name.startsWith(TBD_LABEL_PREFIX) ||
-    name.startsWith(`${REPO_LABEL_GROUP}/`)
+    name.startsWith(REPO_LABEL_PREFIX)
   );
 }

--- a/packages/tbd/src/integrations/core/sync-engine.ts
+++ b/packages/tbd/src/integrations/core/sync-engine.ts
@@ -71,7 +71,7 @@ import {
   type IntentOp,
   type IntentPatch,
 } from './intents.js';
-import { CONFLICT_COMMENT_MARKER } from './types.js';
+import { CONFLICT_COMMENT_MARKER, isWorkspaceLimitError } from './types.js';
 import type { ConflictReport, ExternalIssue, TrackerAdapter } from './types.js';
 
 /** Re-fetch this far behind the watermark; over-fetching costs nothing. */
@@ -1294,8 +1294,45 @@ export async function runSync(options: SyncEngineOptions): Promise<SyncRunReport
   }
 
   // 7a. Outbound-new creates.
+  //
+  // Two batch-level failure modes are handled above the per-item try/catch.
+  // A parent whose create failed leaves its children pointing at a client id
+  // that never came to exist, so attempting them is a guaranteed provider
+  // rejection ("parentId … could not be found" — observed live); they are
+  // reported without an API call and their intents stay journaled. And a
+  // workspace plan limit dooms every remaining create for the same reason it
+  // failed the first, so the batch halts at the first such error rather than
+  // paying a request per doomed item.
+  const failedCreateClientIds = new Set<string>();
+  let workspaceLimitHalt: string | undefined;
   for (const issue of outboundNew) {
     const displayId = options.displayId(issue.id);
+    const haltClientId = outboundClientIds.get(issue.id);
+    const haltParentId = outboundParentIds.get(issue.id);
+    if (workspaceLimitHalt !== undefined) {
+      journalDirty = true;
+      if (haltClientId) {
+        failedCreateClientIds.add(haltClientId);
+      }
+      report.failures.push({
+        beadId: displayId,
+        error: `not attempted: ${workspaceLimitHalt}`,
+      });
+      continue;
+    }
+    if (haltParentId && failedCreateClientIds.has(haltParentId)) {
+      journalDirty = true;
+      if (haltClientId) {
+        failedCreateClientIds.add(haltClientId);
+      }
+      report.failures.push({
+        beadId: displayId,
+        error:
+          'not attempted: its parent failed to create in this run. ' +
+          'Both stay journaled and converge on a later sync.',
+      });
+      continue;
+    }
     try {
       const clientId = outboundClientIds.get(issue.id);
       const parentExternalId = outboundParentIds.get(issue.id);
@@ -1365,6 +1402,12 @@ export async function runSync(options: SyncEngineOptions): Promise<SyncRunReport
       report.createdOutbound.push(displayId);
     } catch (error) {
       journalDirty = true;
+      if (haltClientId) {
+        failedCreateClientIds.add(haltClientId);
+      }
+      if (isWorkspaceLimitError(error)) {
+        workspaceLimitHalt = error.message;
+      }
       report.failures.push({
         beadId: displayId,
         error: error instanceof Error ? error.message : String(error),

--- a/packages/tbd/src/integrations/core/sync-engine.ts
+++ b/packages/tbd/src/integrations/core/sync-engine.ts
@@ -182,6 +182,10 @@ export interface SyncRunReport {
   commentsPulled: number;
   commentsPushed: number;
   orphaned: string[];
+  /** Pairs whose archived tracker item was revived because the bead reopened. */
+  unarchived: string[];
+  /** Pairs retired to the tracker's archive under `policy.archive: on_close`. */
+  archived: string[];
   createdOutbound: string[];
   skippedOutbound: { beadId: string; reason: string }[];
   importedInbound: string[];
@@ -360,6 +364,8 @@ export async function runSync(options: SyncEngineOptions): Promise<SyncRunReport
     commentsPulled: 0,
     commentsPushed: 0,
     orphaned: [],
+    unarchived: [],
+    archived: [],
     createdOutbound: [],
     skippedOutbound: [],
     importedInbound: [],
@@ -557,6 +563,10 @@ export async function runSync(options: SyncEngineOptions): Promise<SyncRunReport
   const outboundSelected = mirrorSet(currentIssues, policy.outbound, provider);
   const outboundSelectedIds = new Set(outboundSelected.map((issue) => issue.id));
   const maxNesting = options.maxNesting ?? 2;
+  // Manual by default: the tracker's archive is a human filing decision, and a
+  // repository's automation is a poor judge of when someone is done looking at
+  // something. See ArchiveMode.
+  const archiveMode = options.policy.archive ?? 'manual';
   const outboundDepth = new Map(
     outboundSelected.map((issue) => [
       issue.id,
@@ -607,12 +617,56 @@ export async function runSync(options: SyncEngineOptions): Promise<SyncRunReport
       continue;
     }
     if (remote.archivedAt || remote.trashed) {
-      const record = recordByBead.get(bead.id);
-      if (!dryRun && record && record.state !== 'orphaned') {
-        await writeLinkRecord(dataSyncDir, provider, { ...record, state: 'orphaned' });
+      // A reopened bead revives its issue rather than going quiet. Archival is how a
+      // settled pair is meant to end — the tracker's own retention runs it, and the
+      // pair costs nothing afterwards — but that has to be reversible, or reopening
+      // work silently stops syncing it forever. Creating a fresh issue instead would
+      // be worse: two issues for one bead, the history stranded in the archived one.
+      //
+      // Trashed items are deliberately excluded. Linear purges trash after 30 days,
+      // so reviving one races a deletion that would strand the link again; a human
+      // restores it, or unlinks and lets a clean issue be created.
+      const reopened = !remote.trashed && bead.status !== 'closed';
+      if (reopened && archiveMode === 'on_close' && adapter.unarchiveIssue && !inboundOnly) {
+        if (!dryRun) {
+          try {
+            await adapter.unarchiveIssue(link.id);
+          } catch (error) {
+            report.failures.push({
+              beadId: options.displayId(bead.id),
+              error: `could not unarchive: ${error instanceof Error ? error.message : String(error)}`,
+            });
+            continue;
+          }
+          const record = recordByBead.get(bead.id);
+          if (record && record.state !== 'linked') {
+            await writeLinkRecord(dataSyncDir, provider, { ...record, state: 'linked' });
+          }
+        }
+        report.unarchived.push(options.displayId(bead.id));
+        // Fall through: the pair is live again, so it reconciles in this same run
+        // and any edits made while it was archived flow normally.
+      } else {
+        const record = recordByBead.get(bead.id);
+        if (!dryRun && record && record.state !== 'orphaned') {
+          await writeLinkRecord(dataSyncDir, provider, { ...record, state: 'orphaned' });
+        }
+        report.orphaned.push(options.displayId(bead.id));
+        // Under `manual` the archive belongs to whoever is using the tracker, so a
+        // reopened bead is reported rather than acted on. Saying so matters: the pair
+        // has gone quiet in a way the operator did not ask for and would otherwise
+        // have no way to notice.
+        if (reopened) {
+          report.warnings.push({
+            externalId: link.id,
+            ...(remote.key ? { externalKey: remote.key } : {}),
+            message:
+              `${options.displayId(bead.id)} reopened but its tracker item is archived; ` +
+              `restore it in the tracker, or set policy.archive: on_close to let tbd do it.`,
+          });
+        }
+        continue;
       }
-      report.orphaned.push(options.displayId(bead.id));
-      continue;
     }
     const record = recordByBead.get(bead.id);
     // A live pending create has an exact creation snapshot in its journal even
@@ -1156,6 +1210,22 @@ export async function runSync(options: SyncEngineOptions): Promise<SyncRunReport
         }
       }
 
+      // Retire a settled pair, when the operator has handed tbd that job. Last among
+      // the pair's writes on purpose: Linear rejects edits to an archived issue, so
+      // archiving before the patch and splice would lose them. Not journaled as an
+      // intent either — it is idempotent and inferable from the bead's own status, so
+      // a crash before it simply means the next sync archives instead.
+      if (
+        !inboundOnly &&
+        archiveMode === 'on_close' &&
+        adapter.archiveIssue &&
+        pair.result.merged.status === 'closed' &&
+        !pair.remote.archivedAt
+      ) {
+        await adapter.archiveIssue(link.id);
+        report.archived.push(displayId);
+      }
+
       // Conflict artifacts: a comment per conflicted field, exactly-once. An
       // inbound-only run writes nothing outward, so it reports the conflict
       // without posting; the next full sync posts it.
@@ -1342,6 +1412,12 @@ export async function runSync(options: SyncEngineOptions): Promise<SyncRunReport
           ...(issue.description != null ? { description: issue.description } : {}),
           status: issue.status,
           priority: issue.priority,
+          // The bead's real dates, not the moment this sync happened to run. Only the
+          // create surface accepts them, which is also the only place they matter:
+          // backfilling an existing repository is what would otherwise stamp years of
+          // history as today. See CanonicalPatch.sourceCreatedAt.
+          sourceCreatedAt: issue.created_at,
+          sourceCompletedAt: issue.closed_at ?? null,
           ...(adapter.canPushAssignee(issue.assignee ?? null)
             ? { assignee: issue.assignee ?? null }
             : {}),

--- a/packages/tbd/src/integrations/core/types.ts
+++ b/packages/tbd/src/integrations/core/types.ts
@@ -193,7 +193,6 @@ export interface TrackerAdapter {
   /** Create an external item and return its ref. */
   createIssue(patch: CanonicalPatch, clientId?: string): Promise<ExternalRef>;
 
-  /** Apply a patch, returning the provider's new updatedAt for echo suppression. */
   /**
    * Apply a patch. Returns the post-write timestamp, which is what suppresses
    * the echo on the next pull, plus the item's human identifier and URL when the
@@ -262,10 +261,24 @@ export interface ProvisionOptions {
   apply: boolean;
 }
 
+/**
+ * Whether an error means the WORKSPACE is refusing writes — a billing or plan
+ * limit — rather than one item failing.
+ *
+ * A duck-typed marker (`workspaceLimit: true` on the error) instead of an
+ * `instanceof`, because the class lives with the provider that threw it and
+ * this core layer must not import provider modules. Batch loops use this to
+ * stop after the first such failure: every later create is doomed for the same
+ * reason, and attempting them anyway burns a request per item on every sync.
+ */
+export function isWorkspaceLimitError(error: unknown): error is Error {
+  return error instanceof Error && (error as { workspaceLimit?: unknown }).workspaceLimit === true;
+}
+
 /** One piece of tracker-side scaffolding and its state. */
 export interface ProvisionItem {
-  /** What the thing is, for the operator: `label` or `label group`. */
-  kind: 'label' | 'label group';
+  /** What the thing is, for the operator: `label`, `label group`, or `project`. */
+  kind: 'label' | 'label group' | 'project';
   /** The name tbd refers to it by. */
   name: string;
   /** `present` needed nothing; `created` was made now; `missing` is an unapplied gap. */

--- a/packages/tbd/src/integrations/core/types.ts
+++ b/packages/tbd/src/integrations/core/types.ts
@@ -85,6 +85,28 @@ export interface CanonicalPatch {
   ensureLabels?: string[];
   assignee?: string | null;
   parentId?: string | null;
+  /**
+   * The bead's own timestamps, for a provider that can backdate on create.
+   *
+   * **Create-only, by the provider's design and ours.** Linear accepts `createdAt` and
+   * `completedAt` on `IssueCreateInput` — self-described as "e.g. if importing from
+   * another system", which is exactly what a mirror is — and accepts neither on update.
+   * That asymmetry is the right shape rather than a limitation to route around: in
+   * steady state a bead closes and the next sync pushes the transition within minutes,
+   * so a provider-stamped time is already honest. The distortion is an onboarding
+   * artifact, where months of history are mirrored in one afternoon, and onboarding
+   * goes through create.
+   *
+   * Getting this wrong is not cosmetic. The tracker's own lifecycle automation keys off
+   * these: Linear auto-archives from `completedAt`, so a backfilled repository whose
+   * long-closed work is stamped "today" keeps that work in the active view — and, on a
+   * capped plan, in the issue quota — for the whole archive period.
+   *
+   * `applyChanges` ignores both, so an update path cannot accidentally rewrite history.
+   */
+  sourceCreatedAt?: string;
+  /** Null when the bead is not closed; omitted entirely for a non-completed state. */
+  sourceCompletedAt?: string | null;
 }
 
 /**
@@ -238,6 +260,27 @@ export interface TrackerAdapter {
    * primitive for pull: an efficiency prefilter, never a correctness input.
    */
   fetchUpdatedSince(since: string): Promise<ExternalIssue[]>;
+
+  /**
+   * Retire an item from the active view, under the `on_close` archive policy.
+   *
+   * Optional, like its counterpart: a provider without an archive concept omits both,
+   * and the policy then has nothing to act on.
+   */
+  archiveIssue?(id: string): Promise<void>;
+
+  /**
+   * Bring an archived item back into the active view.
+   *
+   * The counterpart to letting the tracker's own archival end a pair's life. Archived
+   * items are skipped as orphaned, which is right for closed work — but a reopened bead
+   * must be able to revive its issue rather than silently stopping syncing, and rather
+   * than creating a duplicate alongside the archived original.
+   *
+   * Optional: a provider without an archive concept simply omits it, and the engine
+   * treats an archived remote as terminal there.
+   */
+  unarchiveIssue?(id: string): Promise<void>;
 
   /** Resolve, and cache, the provider metadata needed to push. */
   ensureMeta(force?: boolean): Promise<ProviderMeta>;

--- a/packages/tbd/src/integrations/linear/adapter.ts
+++ b/packages/tbd/src/integrations/linear/adapter.ts
@@ -50,7 +50,7 @@ import {
   USERS_BY_EMAIL_QUERY,
 } from './queries.js';
 import { spliceManagedBlock } from '../core/managed-block.js';
-import { isTbdOwnedLabel } from '../core/origin-labels.js';
+import { isTbdOwnedLabel, labelColorFor } from '../core/origin-labels.js';
 import {
   indexLabels,
   qualifiedIssueLabels,
@@ -889,6 +889,12 @@ export class LinearAdapter implements TrackerAdapter {
       name: options.name,
       teamId: await this.resolveTeamId(),
     };
+    // Only on create. Recoloring an existing label on every sync would overwrite a
+    // choice the workspace made; see labelColorFor.
+    const color = labelColorFor(options.qualifiedName ?? options.name);
+    if (color) {
+      input.color = color;
+    }
     if (options.isGroup) {
       input.isGroup = true;
     }

--- a/packages/tbd/src/integrations/linear/adapter.ts
+++ b/packages/tbd/src/integrations/linear/adapter.ts
@@ -41,6 +41,7 @@ import {
   ISSUE_LABELS_QUERY,
   ISSUE_UPDATE_MUTATION,
   LABEL_CREATE_MUTATION,
+  PROJECT_CREATE_MUTATION,
   PROJECT_QUERY,
   TEAM_META_QUERY,
   TEAM_LABELS_QUERY,
@@ -162,6 +163,29 @@ export class LinearAdapter implements TrackerAdapter {
       return this.projectId ?? undefined;
     }
 
+    const { match, available } = await this.findProject();
+    if (!match) {
+      throw new Error(
+        `Linear project not found: ${this.project}. Available: ${available || 'none'}. ` +
+          `Run \`tbd integration setup\` to create it.`,
+      );
+    }
+    this.projectId = match.id;
+    return match.id;
+  }
+
+  /**
+   * Look the configured project up without deciding what absence means.
+   *
+   * Split from {@link resolveProjectId} because the two callers disagree about
+   * a missing project: the sync path treats it as an error (filing issues into
+   * "no project" because of a typo is the failure the throw prevents), while
+   * `provision` treats it as work to do.
+   */
+  private async findProject(): Promise<{
+    match?: { id: string; name: string; slugId: string };
+    available: string;
+  }> {
     const projects: { id: string; name: string; slugId: string }[] = [];
     let after: string | undefined;
     do {
@@ -177,18 +201,13 @@ export class LinearAdapter implements TrackerAdapter {
         : undefined;
     } while (after);
 
-    const wanted = this.project.toLowerCase();
-    const match = projects.find(
-      (node) => node.slugId.toLowerCase() === wanted || node.name.toLowerCase() === wanted,
-    );
-    if (!match) {
-      const available = projects.map((node) => `${node.name} (${node.slugId})`).join(', ');
-      throw new Error(
-        `Linear project not found: ${this.project}. Available: ${available || 'none'}`,
-      );
-    }
-    this.projectId = match.id;
-    return match.id;
+    const wanted = (this.project ?? '').toLowerCase();
+    return {
+      match: projects.find(
+        (node) => node.slugId.toLowerCase() === wanted || node.name.toLowerCase() === wanted,
+      ),
+      available: projects.map((node) => `${node.name} (${node.slugId})`).join(', '),
+    };
   }
 
   /**
@@ -827,17 +846,63 @@ export class LinearAdapter implements TrackerAdapter {
   }
 
   /**
-   * Inspect, and optionally create, the label scaffolding this mirror needs.
+   * Inspect, and optionally create, the tracker scaffolding this mirror needs.
    *
    * Idempotent by construction: everything is find-or-create against the qualified-name
    * index, so running it twice creates nothing the second time. The group is reported as
    * its own item because it is a distinct object in Linear with its own failure mode —
    * a plain label already sitting on the group's name blocks the child, and an operator
    * needs to be told that rather than watching the label quietly not appear.
+   *
+   * The configured project is scaffolding too: `resolveProjectId` fails a sync outright
+   * when `target.project` names nothing, so a setup that provisioned only labels walked
+   * the operator into a guaranteed first-sync error. Found live wiring the second
+   * repository of a multi-repo team, where per-repo projects are the intended shape.
    */
   async provision(options: ProvisionOptions): Promise<ProvisionReport> {
     const index = await this.ensureLabelIndex();
     const items: ProvisionItem[] = [];
+
+    if (this.project) {
+      const { match } = await this.findProject();
+      if (match) {
+        items.push({ kind: 'project', name: this.project, state: 'present' });
+      } else if (!options.apply) {
+        items.push({ kind: 'project', name: this.project, state: 'missing' });
+      } else {
+        try {
+          const data = await this.client.request<{
+            projectCreate: {
+              success: boolean;
+              project: { id: string; name: string; slugId: string } | null;
+            };
+          }>(PROJECT_CREATE_MUTATION, {
+            input: { name: this.project, teamIds: [await this.resolveTeamId()] },
+          });
+          const created = data.projectCreate.project;
+          if (!data.projectCreate.success || !created) {
+            items.push({
+              kind: 'project',
+              name: this.project,
+              state: 'blocked',
+              reason: 'Linear declined to create the project',
+            });
+          } else {
+            // Cache the id so the sync that typically follows setup does not
+            // re-list every project just to find the one this run created.
+            this.projectId = created.id;
+            items.push({ kind: 'project', name: this.project, state: 'created' });
+          }
+        } catch (error) {
+          items.push({
+            kind: 'project',
+            name: this.project,
+            state: 'blocked',
+            reason: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
 
     /**
      * Where each leaf name is already taken, keyed by the bare leaf.

--- a/packages/tbd/src/integrations/linear/adapter.ts
+++ b/packages/tbd/src/integrations/linear/adapter.ts
@@ -39,6 +39,8 @@ import {
   ISSUE_ATTACHMENTS_QUERY,
   ISSUE_CREATE_MUTATION,
   ISSUE_LABELS_QUERY,
+  ISSUE_ARCHIVE_MUTATION,
+  ISSUE_UNARCHIVE_MUTATION,
   ISSUE_UPDATE_MUTATION,
   LABEL_CREATE_MUTATION,
   PROJECT_CREATE_MUTATION,
@@ -96,6 +98,55 @@ const LINEAR_URL_RE = /linear\.app\/[^/]+\/issue\/([A-Za-z0-9]+-\d+)/;
 const IDENTIFIER_RE = /^[A-Za-z][A-Za-z0-9]*-\d+$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const EMAIL_RE = /^[^@\s]+@[^@\s]+$/;
+
+/**
+ * The bead's real timestamps, shaped into what `IssueCreateInput` will accept.
+ *
+ * Linear enforces three rules, and violating any of them fails the whole create — so a
+ * date good enough to be worth sending is clamped rather than trusted, and one that
+ * cannot be made legal is dropped. A mirrored issue with a slightly-adjusted date is
+ * strictly better than a bead that will not mirror at all.
+ *
+ * 1. Both must be in the past. Clock skew between the machine writing beads and
+ *    Linear's servers is enough to make "now" land in the future, so anything at or
+ *    after now is dropped rather than sent.
+ * 2. `completedAt` must be after `createdAt`. A bead created and closed inside the same
+ *    second — routine for scripted work — otherwise fails, so it is nudged forward by a
+ *    millisecond instead.
+ * 3. `completedAt` requires a completed-type workflow state. Only tbd's `closed` maps to
+ *    one, so any other status omits it even when the bead carries a `closed_at`.
+ */
+export function importTimestamps(patch: CanonicalPatch): {
+  createdAt?: string;
+  completedAt?: string;
+} {
+  const now = Date.now();
+  const out: { createdAt?: string; completedAt?: string } = {};
+
+  const created = patch.sourceCreatedAt ? Date.parse(patch.sourceCreatedAt) : Number.NaN;
+  const createdOk = Number.isFinite(created) && created < now;
+  if (createdOk) {
+    out.createdAt = new Date(created).toISOString();
+  }
+
+  // Only `closed` reaches a completed state; sending completedAt with any other is a
+  // hard rejection, not a silently ignored field.
+  if (patch.status !== 'closed' || !patch.sourceCompletedAt) {
+    return out;
+  }
+  const completed = Date.parse(patch.sourceCompletedAt);
+  if (!Number.isFinite(completed) || completed >= now) {
+    return out;
+  }
+  // Ordering only has to hold when a createdAt is actually being sent; without one
+  // Linear stamps creation at now, and any past completedAt precedes it — which it
+  // rejects. So a completedAt is only safe alongside a createdAt.
+  if (!createdOk) {
+    return out;
+  }
+  out.completedAt = new Date(Math.max(completed, created + 1)).toISOString();
+  return out;
+}
 
 export class LinearAdapter implements TrackerAdapter {
   readonly provider: ProviderNameType = 'linear';
@@ -269,6 +320,7 @@ export class LinearAdapter implements TrackerAdapter {
   async createIssue(patch: CanonicalPatch, clientId?: string): Promise<ExternalRef> {
     const meta = await this.ensureMeta();
     const input = await this.toInput(patch, meta);
+    Object.assign(input, importTimestamps(patch));
     let data: { issueCreate: { success: boolean; issue: RawIssue | null } };
     try {
       data = await this.client.request<{
@@ -336,6 +388,26 @@ export class LinearAdapter implements TrackerAdapter {
       ...(issue.identifier != null ? { key: issue.identifier } : {}),
       ...(issue.url != null ? { url: issue.url } : {}),
     };
+  }
+
+  async archiveIssue(id: string): Promise<void> {
+    const data = await this.client.request<{ issueArchive: { success: boolean } }>(
+      ISSUE_ARCHIVE_MUTATION,
+      { id },
+    );
+    if (!data.issueArchive.success) {
+      throw new Error(`Linear declined to archive ${id}`);
+    }
+  }
+
+  async unarchiveIssue(id: string): Promise<void> {
+    const data = await this.client.request<{ issueUnarchive: { success: boolean } }>(
+      ISSUE_UNARCHIVE_MUTATION,
+      { id },
+    );
+    if (!data.issueUnarchive.success) {
+      throw new Error(`Linear declined to unarchive ${id}`);
+    }
   }
 
   /**

--- a/packages/tbd/src/integrations/linear/client.ts
+++ b/packages/tbd/src/integrations/linear/client.ts
@@ -45,6 +45,26 @@ export class LinearDuplicateIdError extends LinearApiError {
   }
 }
 
+/**
+ * Raised when the workspace refuses a write for plan/billing reasons — e.g.
+ * "You've exceeded the free issue limit for this workspace."
+ *
+ * Distinct from a per-item failure because it is a property of the WORKSPACE:
+ * once one create hits it, every later create in the run will too. Callers use
+ * that to halt a batch instead of burning a request per doomed item — observed
+ * live as a 77-create sync that kept re-attempting its whole backlog on every
+ * run, ~141 failing API calls each time, against a 2,500/hr budget.
+ */
+export class LinearWorkspaceLimitError extends LinearApiError {
+  /** Duck-typed marker consumed by `isWorkspaceLimitError` in the core layer. */
+  readonly workspaceLimit = true;
+
+  constructor(message: string) {
+    super(message, 'INPUT_ERROR', false);
+    this.name = 'LinearWorkspaceLimitError';
+  }
+}
+
 export interface LinearClientOptions {
   apiKey: string;
   /** Overridable so tests can point at a local mock server. */
@@ -209,6 +229,12 @@ export class LinearClient {
       const haystack = `${firstError.message} ${presentable ?? ''}`;
       if (/already exists/i.test(haystack) || /conflict on insert/i.test(haystack)) {
         throw new LinearDuplicateIdError(detail);
+      }
+      // Matched on "exceeded … limit for this workspace" rather than any
+      // mention of upgrading, so an unrelated message that happens to suggest a
+      // plan change does not halt a batch.
+      if (/exceeded .* limit for this workspace/i.test(haystack)) {
+        throw new LinearWorkspaceLimitError(detail);
       }
       throw new LinearApiError(detail, code, false, response.status);
     }

--- a/packages/tbd/src/integrations/linear/queries.ts
+++ b/packages/tbd/src/integrations/linear/queries.ts
@@ -19,6 +19,19 @@ export const PROJECT_QUERY = `query Projects($first: Int!, $after: String) {
   }
 }`;
 
+/**
+ * Create the configured project during `tbd integration setup`.
+ *
+ * Verified against Linear's published schema: `name` and `teamIds` are the two
+ * required fields of `ProjectCreateInput`.
+ */
+export const PROJECT_CREATE_MUTATION = `mutation ProjectCreate($input: ProjectCreateInput!) {
+  projectCreate(input: $input) {
+    success
+    project { id name slugId url }
+  }
+}`;
+
 /** Resolve a team key (e.g. `FIN`) to its UUID plus states and labels. */
 export const TEAM_META_QUERY = `query TeamMeta($key: String!) {
   teams(filter: { key: { eq: $key } }, first: 1) {

--- a/packages/tbd/src/integrations/linear/queries.ts
+++ b/packages/tbd/src/integrations/linear/queries.ts
@@ -134,6 +134,20 @@ export const ISSUE_CREATE_MUTATION = `mutation IssueCreate($input: IssueCreateIn
   }
 }`;
 
+/** Archive an issue, under the `on_close` archive policy. */
+export const ISSUE_ARCHIVE_MUTATION = `mutation IssueArchive($id: String!) {
+  issueArchive(id: $id) {
+    success
+  }
+}`;
+
+/** Bring an archived issue back, so a reopened bead can revive its pair. */
+export const ISSUE_UNARCHIVE_MUTATION = `mutation IssueUnarchive($id: String!) {
+  issueUnarchive(id: $id) {
+    success
+  }
+}`;
+
 export const ISSUE_UPDATE_MUTATION = `mutation IssueUpdate($id: String!, $input: IssueUpdateInput!) {
   issueUpdate(id: $id, input: $input) {
     success

--- a/packages/tbd/src/lib/schemas.ts
+++ b/packages/tbd/src/lib/schemas.ts
@@ -599,10 +599,35 @@ export const FieldSyncClauseSchema = z
 // will serialize for declaration emit (TS7056), and it buys little: the clauses are
 // where new keys actually land, and a whole new sibling clause is a big enough change
 // to warrant its own format decision anyway.
+/**
+ * Who owns a mirrored item's archive state.
+ *
+ * `manual` (the default) means the tracker's archive belongs to the people using it.
+ * tbd never archives or unarchives; it treats an archived item as a settled pair and
+ * goes quiet, and if a bead reopens under an archived item it reports that plainly
+ * rather than reaching into the tracker. Archiving in most trackers is a filing
+ * decision — it governs what a human sees in their own views — and a repository's
+ * automation is a poor judge of when someone is finished looking at something. The
+ * tracker's own retention rules (Linear's team-level auto-archive, for instance) keep
+ * working underneath, which is the right place for that policy to live.
+ *
+ * `on_close` hands the whole lifecycle to tbd: closing a bead archives its item, and
+ * reopening one restores it. Coherent because whoever owns the state owns both halves —
+ * an integration that archived but never restored would strand reopened work. Suits a
+ * tracker used purely as a projection of the repository, where a settled pair has no
+ * reason to occupy a human's active view.
+ *
+ * The enum, rather than a boolean, is the extension point: `on_close_after: <duration>`
+ * and similar belong here without another format bump.
+ */
+export const ArchiveMode = z.enum(['manual', 'on_close']);
+
 export const PolicyDefinitionSchema = z.object({
   outbound: IntegrationSelectSchema.default({}),
   inbound: InboundClauseSchema.default({}),
   field_sync: FieldSyncClauseSchema.default({}),
+  /** Optional so it is not written into configs that never set it; resolved to `manual`. */
+  archive: ArchiveMode.optional(),
 });
 
 /** Named policy presets. Growing this enum is the extension point. */

--- a/packages/tbd/src/lib/schemas.ts
+++ b/packages/tbd/src/lib/schemas.ts
@@ -690,7 +690,7 @@ export const IntegrationLabelsSchema = z
   .object({
     /**
      * The marker on every mirrored issue, so a human can filter agent traffic out
-     * with `label is not tbd:sync`.
+     * with `label is not tbd`.
      *
      * `true` uses the default name; a string overrides it, which a workspace already
      * using that name for something else needs. Overriding with a bare name opts out

--- a/packages/tbd/tests/helpers/linear-mock-server.ts
+++ b/packages/tbd/tests/helpers/linear-mock-server.ts
@@ -70,10 +70,14 @@ export class LinearMockServer {
     { id: 'user-1', name: 'Josh', displayName: 'Josh', email: 'josh@example.com' },
     { id: 'user-2', name: 'Test User', displayName: 'Test User', email: 'test@example.com' },
   ];
-  readonly projects: { id: string; name: string; slugId: string }[] = [];
+  readonly projects: { id: string; name: string; slugId: string; url?: string }[] = [];
 
   /** Number of requests to fail with RATELIMITED before succeeding. */
   rateLimitFailures = 0;
+  /** Refuse issue creates once `issues.size` reaches this, like the free tier. */
+  freeIssueLimit?: number;
+  /** Hard-fail creates with these titles: a per-item rejection, unlike the limit. */
+  readonly failCreateTitles = new Set<string>();
   /** Number of requests to fail with a 500 before succeeding. */
   serverFailures = 0;
   /** Number of attachment upserts to reject without retry. */
@@ -264,6 +268,31 @@ export class LinearMockServer {
       };
     }
 
+    if (query.includes('mutation ProjectCreate')) {
+      const input = variables.input as { name: string; teamIds: string[] };
+      // Linear rejects a project create naming an unknown team; without this the
+      // mock would accept a provisioning bug the real API refuses.
+      if (!input.teamIds?.length || input.teamIds.some((id) => id !== 'team-1')) {
+        return {
+          status: 200,
+          payload: {
+            errors: [{ message: `Unknown team in teamIds: ${input.teamIds?.join(',')}` }],
+          },
+        };
+      }
+      const project = {
+        id: this.nextId('project'),
+        name: input.name,
+        slugId: `${input.name.toLowerCase().replace(/[^a-z0-9]+/g, '')}${this.projects.length}`,
+        url: `https://linear.app/acme/project/${input.name.toLowerCase()}`,
+      };
+      this.projects.push(project);
+      return {
+        status: 200,
+        payload: { data: { projectCreate: { success: true, project } } },
+      };
+    }
+
     if (query.includes('query Projects')) {
       const first = variables.first as number;
       const offset = Number(variables.after ?? 0);
@@ -371,7 +400,42 @@ export class LinearMockServer {
 
     if (query.includes('mutation IssueCreate')) {
       const input = variables.input as Record<string, unknown>;
+      if (this.failCreateTitles.has(input.title as string)) {
+        return {
+          status: 200,
+          payload: {
+            errors: [{ message: `create rejected by test for title: ${input.title as string}` }],
+          },
+        };
+      }
       const clientId = input.id as string | undefined;
+      // Order matters, and is taken from live behavior: a replayed create whose
+      // client id already exists gets the DUPLICATE error even when the
+      // workspace is over its issue limit — observed as a full backlog of
+      // already-created issues recovering while new creates were being
+      // refused. Duplicate detection first, then the limit.
+      if (this.freeIssueLimit !== undefined && this.issues.size >= this.freeIssueLimit) {
+        if (!(clientId && this.issues.has(clientId))) {
+          return {
+            status: 200,
+            payload: {
+              errors: [
+                {
+                  message: 'issue limit exceeded',
+                  extensions: {
+                    type: 'invalid input',
+                    code: 'INPUT_ERROR',
+                    statusCode: 400,
+                    userError: true,
+                    userPresentableMessage:
+                      "You've exceeded the free issue limit for this workspace. Please upgrade or contact sales@linear.app for a free trial.",
+                  },
+                },
+              ],
+            },
+          };
+        }
+      }
       if (clientId && this.issues.has(clientId)) {
         // Matches the real API: a duplicate client id is a hard error, so a
         // retried create must treat this as success rather than failure.
@@ -392,6 +456,18 @@ export class LinearMockServer {
         };
       }
       const id = clientId ?? this.nextId('issue');
+      // Linear rejects a create naming a parent that does not exist; silently
+      // storing `parent: null` instead let the suite bless orphan creates that
+      // the real API refuses — observed live when a parent's create failed and
+      // its children were attempted against the never-created client id.
+      if (typeof input.parentId === 'string' && !this.issues.has(input.parentId)) {
+        return {
+          status: 200,
+          payload: {
+            errors: [{ message: 'parentId contained an entry that could not be found.' }],
+          },
+        };
+      }
       const identifier = `FIN-${this.issues.size + 1}`;
       const issue = this.addIssue({
         id,

--- a/packages/tbd/tests/helpers/linear-mock-server.ts
+++ b/packages/tbd/tests/helpers/linear-mock-server.ts
@@ -27,6 +27,9 @@ export interface MockIssue {
   description: string | null;
   priority: number;
   updatedAt: string;
+  /** Backdatable on create only, like the real API. */
+  createdAt: string;
+  completedAt: string | null;
   state: { id: string; name: string; type: string };
   assignee: { id: string; name: string; displayName: string; email?: string } | null;
   labels: { nodes: MockLabel[] };
@@ -165,6 +168,8 @@ export class LinearMockServer {
       description: null,
       priority: 0,
       updatedAt: '2026-08-10T00:00:00.000Z',
+      createdAt: '2026-08-10T00:00:00.000Z',
+      completedAt: null,
       state: this.states[1]!,
       assignee: null,
       labels: { nodes: [] },
@@ -398,6 +403,30 @@ export class LinearMockServer {
       };
     }
 
+    if (query.includes('mutation IssueArchive')) {
+      const issue = this.issues.get(variables.id as string);
+      if (!issue) {
+        return {
+          status: 200,
+          payload: { errors: [{ message: 'Could not find referenced Issue.' }] },
+        };
+      }
+      issue.archivedAt = new Date().toISOString();
+      return { status: 200, payload: { data: { issueArchive: { success: true } } } };
+    }
+
+    if (query.includes('mutation IssueUnarchive')) {
+      const issue = this.issues.get(variables.id as string);
+      if (!issue) {
+        return {
+          status: 200,
+          payload: { errors: [{ message: 'Could not find referenced Issue.' }] },
+        };
+      }
+      issue.archivedAt = null;
+      return { status: 200, payload: { data: { issueUnarchive: { success: true } } } };
+    }
+
     if (query.includes('mutation IssueCreate')) {
       const input = variables.input as Record<string, unknown>;
       if (this.failCreateTitles.has(input.title as string)) {
@@ -468,10 +497,47 @@ export class LinearMockServer {
           },
         };
       }
+      // Backdating rules, enforced exactly as the real API states them. Modelled
+      // because a mock that accepts any date would let tbd ship an import that
+      // Linear rejects outright — the create fails whole, it does not drop the field.
+      const nowMs = Date.now();
+      const createdAtIn = input.createdAt as string | undefined;
+      const completedAtIn = input.completedAt as string | undefined;
+      if (createdAtIn !== undefined && Date.parse(createdAtIn) >= nowMs) {
+        return {
+          status: 200,
+          payload: { errors: [{ message: 'createdAt must be a time in the past' }] },
+        };
+      }
+      if (completedAtIn !== undefined) {
+        const state = this.states.find((s) => s.id === input.stateId);
+        if (Date.parse(completedAtIn) >= nowMs) {
+          return {
+            status: 200,
+            payload: { errors: [{ message: 'completedAt must be a time in the past' }] },
+          };
+        }
+        if (createdAtIn !== undefined && Date.parse(completedAtIn) <= Date.parse(createdAtIn)) {
+          return {
+            status: 200,
+            payload: { errors: [{ message: 'completedAt must be after createdAt' }] },
+          };
+        }
+        if (state?.type !== 'completed') {
+          return {
+            status: 200,
+            payload: {
+              errors: [{ message: 'completedAt cannot be provided with an incompatible state' }],
+            },
+          };
+        }
+      }
       const identifier = `FIN-${this.issues.size + 1}`;
       const issue = this.addIssue({
         id,
         identifier,
+        ...(createdAtIn !== undefined ? { createdAt: createdAtIn } : {}),
+        ...(completedAtIn !== undefined ? { completedAt: completedAtIn } : {}),
         title: (input.title as string) ?? 'Untitled',
         description: LinearMockServer.storeDescription(
           (input.description as string | null) ?? null,

--- a/packages/tbd/tests/integration-cli-e2e.test.ts
+++ b/packages/tbd/tests/integration-cli-e2e.test.ts
@@ -119,23 +119,25 @@ describe('tbd integration, end to end via the built binary', () => {
     const leading = await cli(['--dry-run', 'integration', 'setup']);
     expect(leading.code).toBe(0);
     expect(leading.stdout).toContain('would create');
-    expect(result.stdout).toContain('label group repo');
+    expect(result.stdout).toContain('label repo:');
     expect(result.stdout).toContain('would create');
     expect(result.stdout).toContain('Re-run without --dry-run to apply');
     // A dry run that writes is worse than no dry run at all.
     expect(server.labels.length).toBe(before);
   });
 
-  it('setup creates the origin label and the repo group, and is idempotent', async () => {
+  it('setup creates both origin labels flat, and is idempotent', async () => {
     const first = await cli(['integration', 'setup']);
     expect(first.code).toBe(0);
     expect(first.stdout).toContain('created');
 
-    const group = server.labels.find((l) => l.name === 'repo' && l.isGroup);
-    expect(group).toBeDefined();
-    // The repo label is a child of the group, not a flat label with a slash in its name.
+    // Both flat, and the marker is bare: a `repo` group with bare children would put
+    // `repo/<name>` and the marker in conflict for any repo sharing the marker's name.
+    expect(server.labels.find((l) => l.name === 'tbd' && !l.parent)).toBeDefined();
+    expect(server.labels.find((l) => l.name.startsWith('repo:') && !l.parent)).toBeDefined();
+    expect(server.labels.some((l) => l.isGroup)).toBe(false);
+    // And never a flat label with a slash in its name.
     expect(server.labels.find((l) => l.name.includes('/'))).toBeUndefined();
-    expect(server.labels.some((l) => l.parent?.id === group!.id)).toBe(true);
 
     const countAfterFirst = server.labels.length;
     const second = await cli(['integration', 'setup']);

--- a/packages/tbd/tests/integration-nesting-config.e2e.test.ts
+++ b/packages/tbd/tests/integration-nesting-config.e2e.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Config-driven `max_nesting`, through the real CLI.
+ *
+ * The engine honored its `maxNesting` option and the mirror-only `--push` path
+ * forwarded it, but the full synchronization never passed it — so the engine's
+ * fallback default (2) silently overrode any configured value, and the two
+ * modes disagreed about which beads even qualify. A unit test on the engine
+ * cannot see that: the defect was one missing property at the call site, which
+ * only a run through the CLI exercises. Found live on a repo set to 3 that kept
+ * reporting `past max_nesting 2`.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { LinearMockServer } from './helpers/linear-mock-server.js';
+
+const execFileAsync = promisify(execFile);
+const BIN = join(import.meta.dirname, '..', 'dist', 'bin.mjs');
+
+describe('config-driven max_nesting via the CLI', () => {
+  let dir: string;
+  let remoteDir: string;
+  let server: LinearMockServer;
+
+  async function cli(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+    try {
+      const { stdout, stderr } = await execFileAsync(process.execPath, [BIN, ...args], {
+        cwd: dir,
+        env: {
+          ...process.env,
+          LINEAR_API_KEY: 'lin_api_test',
+          LINEAR_API_URL: server.endpoint,
+        },
+      });
+      return { stdout, stderr, code: 0 };
+    } catch (error) {
+      const failed = error as { stdout?: string; stderr?: string; code?: number };
+      return { stdout: failed.stdout ?? '', stderr: failed.stderr ?? '', code: failed.code ?? 1 };
+    }
+  }
+
+  beforeAll(async () => {
+    server = new LinearMockServer();
+    await server.start();
+
+    dir = await mkdtemp(join(tmpdir(), 'tbd-nesting-e2e-'));
+    remoteDir = await mkdtemp(join(tmpdir(), 'tbd-nesting-e2e-origin-'));
+    const sh = async (cmd: string, args: string[]): Promise<void> => {
+      await execFileAsync(cmd, args, { cwd: dir });
+    };
+    await execFileAsync('git', ['init', '--bare', '-q', remoteDir]);
+    await sh('git', ['init', '-q', '--initial-branch=main']);
+    await sh('git', ['config', 'user.email', 't@e.com']);
+    await sh('git', ['config', 'user.name', 'T']);
+    await sh('git', ['config', 'commit.gpgsign', 'false']);
+    await writeFile(join(dir, 'README.md'), '# t\n');
+    await writeFile(join(dir, '.gitignore'), '.env\n');
+    await sh('git', ['add', '-A']);
+    await sh('git', ['commit', '-q', '-m', 'init']);
+    await sh('git', ['remote', 'add', 'origin', remoteDir]);
+    await sh('git', ['push', '-q', '-u', 'origin', 'main']);
+
+    const init = await cli(['init', '--prefix=nst', '--force']);
+    expect(init.code).toBe(0);
+
+    // The grouped f08 form, exactly as a configured repo carries it. The value
+    // under test: max_nesting 3, one past the engine's fallback default.
+    const config = await readFile(join(dir, '.tbd', 'config.yml'), 'utf8');
+    await writeFile(
+      join(dir, '.tbd', 'config.yml'),
+      `${config}
+integrations:
+  on_tbd_sync: 'off'
+  linear:
+    enabled: true
+    target:
+      team_key: FIN
+    policy:
+      outbound:
+        kinds: [epic, task]
+        statuses: [open]
+        max_nesting: 3
+`,
+    );
+
+    // A three-level chain: epic > task > task. Depth 3 is exactly what the
+    // default would exclude and the configured value must include.
+    const root = await cli(['create', 'Root epic', '-t', 'epic']);
+    expect(root.code).toBe(0);
+    const rootId = /Created (\S+):/.exec(root.stdout)![1]!;
+    const mid = await cli(['create', 'Mid task', '-t', 'task', '--parent', rootId]);
+    expect(mid.code).toBe(0);
+    const midId = /Created (\S+):/.exec(mid.stdout)![1]!;
+    const leaf = await cli(['create', 'Leaf task', '-t', 'task', '--parent', midId]);
+    expect(leaf.code).toBe(0);
+  }, 60_000);
+
+  afterAll(async () => {
+    await server.stop();
+    await rm(dir, { recursive: true, force: true });
+    await rm(remoteDir, { recursive: true, force: true });
+  });
+
+  it('the full sync honors configured max_nesting instead of the engine default', async () => {
+    const result = await cli(['integration', 'sync', '--dry-run']);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('would create 3');
+    expect(result.stdout).not.toContain('past max_nesting');
+  });
+});

--- a/packages/tbd/tests/integrations-archive-policy.test.ts
+++ b/packages/tbd/tests/integrations-archive-policy.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Who owns a mirrored item's archive state.
+ *
+ * `manual` is the default and means exactly that: tbd never archives or unarchives.
+ * Archiving is a filing decision about what a human sees in their own views, and a
+ * repository's automation is a poor judge of when someone is finished looking at
+ * something. The tracker's own retention (Linear's team-level auto-archive) keeps
+ * working underneath, which is where that policy belongs.
+ *
+ * `on_close` hands tbd the whole lifecycle, and the pairing is the point: an
+ * integration that archived on close but never restored on reopen would strand
+ * reopened work in a tracker nobody is looking at.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { readLink, writeLink } from '../src/integrations/core/link-store.js';
+import { runSync, type SyncCallbacks } from '../src/integrations/core/sync-engine.js';
+import { LinearAdapter } from '../src/integrations/linear/adapter.js';
+import { LinearClient } from '../src/integrations/linear/client.js';
+import { PolicyDefinitionSchema } from '../src/lib/schemas.js';
+import { LinearMockServer } from './helpers/linear-mock-server.js';
+import type { Issue, PolicyDefinition } from '../src/lib/types.js';
+
+function policy(archive?: 'manual' | 'on_close'): PolicyDefinition {
+  return PolicyDefinitionSchema.parse({
+    outbound: { kinds: ['epic'], statuses: ['open', 'closed'], specs: 'none', linked: true },
+    ...(archive ? { archive } : {}),
+  });
+}
+
+function bead(id: string, overrides: Partial<Issue> = {}): Issue {
+  return {
+    type: 'is',
+    id,
+    title: 'An epic',
+    kind: 'epic',
+    status: 'open',
+    priority: 2,
+    version: 1,
+    created_at: '2026-08-10T00:00:00.000Z',
+    updated_at: '2026-08-10T00:00:00.000Z',
+    labels: [],
+    dependencies: [],
+    ...overrides,
+  } as Issue;
+}
+
+describe('archive policy', () => {
+  let dir: string;
+  let server: LinearMockServer;
+  let adapter: LinearAdapter;
+  let store: Map<string, Issue>;
+  let callbacks: SyncCallbacks;
+
+  const BEAD = 'is-01hx5zzkbkactav9wevgemmg01';
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'tbd-archive-'));
+    server = new LinearMockServer();
+    const endpoint = await server.start();
+    adapter = new LinearAdapter({
+      client: new LinearClient({ apiKey: 'k', endpoint, sleep: () => Promise.resolve() }),
+      teamKey: 'FIN',
+    });
+    store = new Map();
+    callbacks = {
+      readBead: (id) => Promise.resolve(store.get(id)!),
+      writeBead: (issue) => {
+        store.set(issue.id, issue);
+        return Promise.resolve();
+      },
+      createBead: () => Promise.reject(new Error('not used')),
+      afterJournal: () => Promise.resolve(),
+      archiveConflict: () => Promise.resolve('attic/x.md'),
+      affirmBulk: () => Promise.resolve(),
+    };
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  function run(archive?: 'manual' | 'on_close') {
+    return runSync({
+      provider: 'linear',
+      adapter,
+      policy: policy(archive),
+      dataSyncDir: dir,
+      allIssues: [...store.values()],
+      displayId: (id) => id.slice(-4),
+      mirrorLabels: 'none',
+      callbacks,
+      dryRun: false,
+      now: () => new Date().toISOString(),
+    });
+  }
+
+  /** Create the pair, then close the bead so the next run sees a settled pair. */
+  async function linkThenClose(archive?: 'manual' | 'on_close') {
+    store.set(BEAD, bead(BEAD));
+    await run(archive);
+    const linked = store.get(BEAD)!;
+    store.set(BEAD, { ...linked, status: 'closed', closed_at: '2026-08-12T00:00:00.000Z' });
+    return readLink(linked, 'linear')!.id;
+  }
+
+  it('manual: closing a bead leaves the tracker item in the active view', async () => {
+    const externalId = await linkThenClose();
+
+    const result = await run();
+
+    expect(server.issues.get(externalId)!.archivedAt).toBeNull();
+    expect(result.archived).toEqual([]);
+  });
+
+  it('on_close: closing a bead retires its tracker item', async () => {
+    const externalId = await linkThenClose('on_close');
+
+    const result = await run('on_close');
+
+    expect(server.issues.get(externalId)!.archivedAt).not.toBeNull();
+    expect(result.archived).toEqual(['mg01']);
+  });
+
+  it('on_close: archiving happens after the edits, which an archived issue rejects', async () => {
+    const externalId = await linkThenClose('on_close');
+    store.set(BEAD, { ...store.get(BEAD)!, title: 'Renamed as it closed' });
+
+    await run('on_close');
+
+    // Both landed: the title edit reached the item before it was retired.
+    expect(server.issues.get(externalId)!.title).toBe('Renamed as it closed');
+    expect(server.issues.get(externalId)!.archivedAt).not.toBeNull();
+  });
+
+  it('on_close: reopening restores the item rather than stranding the work', async () => {
+    const externalId = await linkThenClose('on_close');
+    await run('on_close');
+    expect(server.issues.get(externalId)!.archivedAt).not.toBeNull();
+
+    store.set(BEAD, { ...store.get(BEAD)!, status: 'open', closed_at: null });
+    const result = await run('on_close');
+
+    expect(server.issues.get(externalId)!.archivedAt).toBeNull();
+    expect(result.unarchived).toEqual(['mg01']);
+    // Revived in the same run, so it reconciles rather than waiting for the next.
+    expect(result.orphaned).toEqual([]);
+  });
+
+  it('manual: a reopened bead under an archived item is reported, never silently stuck', async () => {
+    // The failure mode this warning exists for: without it the pair simply stops
+    // syncing and nothing says so.
+    const externalId = await linkThenClose();
+    server.issues.get(externalId)!.archivedAt = '2026-08-13T00:00:00.000Z';
+    store.set(BEAD, { ...store.get(BEAD)!, status: 'open', closed_at: null });
+
+    const result = await run();
+
+    expect(server.issues.get(externalId)!.archivedAt).not.toBeNull();
+    expect(result.orphaned).toEqual(['mg01']);
+    expect(result.warnings.map((w) => w.message).join(' ')).toContain('reopened but its tracker');
+  });
+
+  it('never revives a trashed item, which the provider purges on its own schedule', async () => {
+    const externalId = await linkThenClose('on_close');
+    const remote = server.issues.get(externalId)!;
+    remote.archivedAt = '2026-08-13T00:00:00.000Z';
+    remote.trashed = true;
+    store.set(BEAD, { ...store.get(BEAD)!, status: 'open', closed_at: null });
+
+    const result = await run('on_close');
+
+    expect(result.unarchived).toEqual([]);
+    expect(result.orphaned).toEqual(['mg01']);
+  });
+
+  it('defaults to manual when the policy says nothing', () => {
+    expect(policy().archive).toBeUndefined();
+  });
+
+  it('an unlinked bead whose item was archived does not get a duplicate', async () => {
+    const externalId = await linkThenClose('on_close');
+    await run('on_close');
+    const before = server.issues.size;
+
+    // Still closed, still archived: quiet, and emphatically not re-created.
+    const result = await run('on_close');
+
+    expect(server.issues.size).toBe(before);
+    expect(result.createdOutbound).toEqual([]);
+    expect(readLink(store.get(BEAD)!, 'linear')!.id).toBe(externalId);
+    expect(writeLink).toBeDefined();
+  });
+});

--- a/packages/tbd/tests/integrations-import-timestamps.test.ts
+++ b/packages/tbd/tests/integrations-import-timestamps.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Backdating a mirrored issue to the bead's own timestamps.
+ *
+ * The tracker is a projection; the bead is the system of record, so mirroring must not
+ * re-date history. Linear accepts `createdAt` and `completedAt` on create only —
+ * "e.g. if importing from another system", which is what a mirror is — and enforces
+ * three rules whose violation fails the whole create rather than dropping the field.
+ *
+ * This matters beyond tidiness: Linear auto-archives from `completedAt`, so a backfilled
+ * repository stamped "today" keeps years of closed work in the active view, and on a
+ * capped plan in the issue quota, for the entire archive period. Observed live across
+ * three repositories: 99 issues stamped completed within one week, including beads
+ * genuinely closed seven months earlier.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { importTimestamps, LinearAdapter } from '../src/integrations/linear/adapter.js';
+import { LinearClient } from '../src/integrations/linear/client.js';
+import { LinearMockServer } from './helpers/linear-mock-server.js';
+import type { CanonicalPatch } from '../src/integrations/core/types.js';
+
+const PAST_CREATED = '2026-01-15T10:00:00.000Z';
+const PAST_CLOSED = '2026-01-16T21:55:31.083Z';
+
+describe('importTimestamps', () => {
+  it('passes through honest past dates on a closed bead', () => {
+    expect(
+      importTimestamps({
+        status: 'closed',
+        sourceCreatedAt: PAST_CREATED,
+        sourceCompletedAt: PAST_CLOSED,
+      }),
+    ).toEqual({ createdAt: PAST_CREATED, completedAt: PAST_CLOSED });
+  });
+
+  it('omits completedAt for any status that is not a completed state', () => {
+    // Linear rejects the whole create rather than ignoring the field, so an open
+    // bead carrying a stale closed_at must not send one.
+    for (const status of ['open', 'in_progress', 'blocked', 'deferred'] as const) {
+      expect(
+        importTimestamps({
+          status,
+          sourceCreatedAt: PAST_CREATED,
+          sourceCompletedAt: PAST_CLOSED,
+        }),
+      ).toEqual({ createdAt: PAST_CREATED });
+    }
+  });
+
+  it('nudges completedAt past createdAt when a bead opened and closed in the same instant', () => {
+    // Routine for scripted work, and a hard rejection if sent verbatim.
+    const same = '2026-01-15T10:00:00.000Z';
+    const out = importTimestamps({
+      status: 'closed',
+      sourceCreatedAt: same,
+      sourceCompletedAt: same,
+    });
+    expect(Date.parse(out.completedAt!)).toBe(Date.parse(same) + 1);
+  });
+
+  it('drops a future date rather than risking the create', () => {
+    const future = new Date(Date.now() + 86_400_000).toISOString();
+    expect(importTimestamps({ status: 'closed', sourceCreatedAt: future })).toEqual({});
+    expect(
+      importTimestamps({
+        status: 'closed',
+        sourceCreatedAt: PAST_CREATED,
+        sourceCompletedAt: future,
+      }),
+    ).toEqual({ createdAt: PAST_CREATED });
+  });
+
+  it('withholds completedAt when no createdAt is being sent', () => {
+    // Without a createdAt, Linear stamps creation at now — and then every past
+    // completedAt precedes it, which it rejects.
+    expect(importTimestamps({ status: 'closed', sourceCompletedAt: PAST_CLOSED })).toEqual({});
+  });
+
+  it('sends nothing when the bead carries no source dates', () => {
+    expect(importTimestamps({ title: 'x' } as CanonicalPatch)).toEqual({});
+  });
+});
+
+describe('createIssue backdating against the provider', () => {
+  let server: LinearMockServer;
+  let adapter: LinearAdapter;
+
+  beforeEach(async () => {
+    server = new LinearMockServer();
+    const endpoint = await server.start();
+    adapter = new LinearAdapter({
+      client: new LinearClient({ apiKey: 'k', endpoint, sleep: () => Promise.resolve() }),
+      teamKey: 'FIN',
+    });
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it('stores the bead dates on a closed bead, not the time of the sync', async () => {
+    const ref = await adapter.createIssue({
+      title: 'Long-closed work',
+      status: 'closed',
+      priority: 2,
+      sourceCreatedAt: PAST_CREATED,
+      sourceCompletedAt: PAST_CLOSED,
+    });
+
+    const stored = server.issues.get(ref.id)!;
+    expect(stored.createdAt).toBe(PAST_CREATED);
+    expect(stored.completedAt).toBe(PAST_CLOSED);
+  });
+
+  it('backdates creation for an open bead and leaves completedAt unset', async () => {
+    const ref = await adapter.createIssue({
+      title: 'Old but still open',
+      status: 'open',
+      priority: 2,
+      sourceCreatedAt: PAST_CREATED,
+      sourceCompletedAt: null,
+    });
+
+    const stored = server.issues.get(ref.id)!;
+    expect(stored.createdAt).toBe(PAST_CREATED);
+    expect(stored.completedAt).toBeNull();
+  });
+
+  it('never rewrites history through the update path', async () => {
+    const ref = await adapter.createIssue({
+      title: 'Created once',
+      status: 'open',
+      priority: 2,
+      sourceCreatedAt: PAST_CREATED,
+    });
+
+    await adapter.applyChanges(ref.id, {
+      title: 'Edited later',
+      status: 'closed',
+      sourceCreatedAt: '2020-01-01T00:00:00.000Z',
+      sourceCompletedAt: '2020-01-02T00:00:00.000Z',
+    });
+
+    // The update carried both fields and the adapter ignored them, which is also
+    // what the provider requires: neither is on IssueUpdateInput.
+    const stored = server.issues.get(ref.id)!;
+    expect(stored.createdAt).toBe(PAST_CREATED);
+    expect(stored.title).toBe('Edited later');
+  });
+});

--- a/packages/tbd/tests/integrations-provision-project.test.ts
+++ b/packages/tbd/tests/integrations-provision-project.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Project provisioning in `tbd integration setup`.
+ *
+ * `resolveProjectId` fails a sync outright when `target.project` names nothing,
+ * so a setup that provisioned only labels walked the operator into a guaranteed
+ * first-sync error: setup printed success, the very next `tbd integration sync`
+ * died with `Linear project not found`. Found live while wiring the second
+ * repository of a multi-repo team, where one project per repository is the
+ * intended shape.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { LinearAdapter } from '../src/integrations/linear/adapter.js';
+import { LinearClient } from '../src/integrations/linear/client.js';
+import { LinearMockServer } from './helpers/linear-mock-server.js';
+
+describe('project provisioning', () => {
+  let server: LinearMockServer;
+  let adapter: LinearAdapter;
+
+  beforeEach(async () => {
+    server = new LinearMockServer();
+    const endpoint = await server.start();
+    adapter = new LinearAdapter({
+      client: new LinearClient({ apiKey: 'k', endpoint, sleep: () => Promise.resolve() }),
+      teamKey: 'FIN',
+      project: 'metaproc',
+    });
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it('reports a missing project on a dry run, creating nothing', async () => {
+    const report = await adapter.provision({ originLabels: [], apply: false });
+
+    expect(report.items).toContainEqual(
+      expect.objectContaining({ kind: 'project', name: 'metaproc', state: 'missing' }),
+    );
+    expect(server.projects).toHaveLength(0);
+  });
+
+  it('creates the missing project on apply, and is idempotent', async () => {
+    const first = await adapter.provision({ originLabels: [], apply: true });
+    expect(first.items).toContainEqual(
+      expect.objectContaining({ kind: 'project', name: 'metaproc', state: 'created' }),
+    );
+    expect(server.projects.map((p) => p.name)).toEqual(['metaproc']);
+
+    // A fresh adapter, as a re-run of setup would construct: the project now
+    // exists, so nothing is created and nothing is duplicated.
+    const again = new LinearAdapter({
+      client: new LinearClient({
+        apiKey: 'k',
+        endpoint: server.endpoint,
+        sleep: () => Promise.resolve(),
+      }),
+      teamKey: 'FIN',
+      project: 'metaproc',
+    });
+    const second = await again.provision({ originLabels: [], apply: true });
+    expect(second.items).toContainEqual(
+      expect.objectContaining({ kind: 'project', name: 'metaproc', state: 'present' }),
+    );
+    expect(server.projects).toHaveLength(1);
+  });
+
+  it('matches an existing project by name or slug, case-insensitively', async () => {
+    server.projects.push({ id: 'project-9', name: 'Metaproc', slugId: 'abc123' });
+
+    const report = await adapter.provision({ originLabels: [], apply: true });
+
+    expect(report.items).toContainEqual(
+      expect.objectContaining({ kind: 'project', name: 'metaproc', state: 'present' }),
+    );
+    expect(server.projects).toHaveLength(1);
+  });
+
+  it('reports nothing about projects when none is configured', async () => {
+    const bare = new LinearAdapter({
+      client: new LinearClient({
+        apiKey: 'k',
+        endpoint: server.endpoint,
+        sleep: () => Promise.resolve(),
+      }),
+      teamKey: 'FIN',
+    });
+
+    const report = await bare.provision({ originLabels: [], apply: true });
+
+    expect(report.items.filter((item) => item.kind === 'project')).toHaveLength(0);
+  });
+
+  it('a create straight after provisioning files into the project setup just made', async () => {
+    // The failure this feature exists to prevent, end to end: before it, setup
+    // printed success and the very next outbound write died with `Linear
+    // project not found`. createIssue exercises resolveProjectId on the same
+    // adapter, which must find the project — via the cached id, not a re-list.
+    await adapter.provision({ originLabels: [], apply: true });
+    const requestsAfterProvision = server.requests.length;
+
+    const ref = await adapter.createIssue({
+      title: 'First bead of the newly integrated repo',
+      status: 'open',
+      priority: 2,
+    });
+
+    const stored = server.issues.get(ref.id);
+    expect(stored?.projectId).toBe(server.projects[0]!.id);
+    // No `query Projects` after provisioning: the created id was cached.
+    const later = server.requests.slice(requestsAfterProvision);
+    expect(later.filter((request) => request.query.includes('query Projects'))).toHaveLength(0);
+  });
+});

--- a/packages/tbd/tests/integrations-sync-engine.test.ts
+++ b/packages/tbd/tests/integrations-sync-engine.test.ts
@@ -179,69 +179,48 @@ describe('the sync engine', () => {
     expect(settled.nothingToDo).toBe(true);
   });
 
-  describe('origin labels in a Linear label group', () => {
-    it('creates repo/<name> as a real group, not a flat slash-named label', async () => {
+  describe('origin labels', () => {
+    it('creates both markers as flat labels, and applies them to the issue', async () => {
       const epic = bead('is-01hx5zzkbkactav9wevgemmvrz');
       store.set(epic.id, epic);
 
-      await run([...store.values()], POLICY, false, ['tbd:sync', 'repo/tbd']);
-
-      const flat = server.labels.find((l) => l.name === 'repo/tbd');
-      expect(flat).toBeUndefined();
-
-      const group = server.labels.find((l) => l.name === 'repo' && l.isGroup);
-      expect(group).toBeDefined();
-
-      // The child stores only the LEAF name; the group is carried by `parent`.
-      const child = server.labels.find((l) => l.name === 'tbd' && l.parent?.id === group!.id);
-      expect(child).toBeDefined();
-
-      // The origin marker is a separate root label, and it must NOT share the repo's
-      // leaf name: Linear enforces name uniqueness across the whole team regardless of
-      // group, so `tbd` beside `repo/tbd` is rejected outright. The `tbd:` prefix is
-      // what keeps the two namespaces disjoint — a repo leaf can never contain a colon.
-      const origin = server.labels.find((l) => l.name === 'tbd:sync' && !l.parent);
-      expect(origin).toBeDefined();
-      expect(origin!.id).not.toBe(child!.id);
-    });
-
-    it('refuses the shape Linear refuses: a root label sharing a grouped leaf name', async () => {
-      // The guard that would have caught this before it reached a live workspace. If the
-      // mock ever stops enforcing team-wide leaf uniqueness, this test goes green while
-      // real provisioning stays broken — which is exactly what happened once already.
-      const epic = bead('is-01hx5zzkbkactav9wevgemmvrz');
-      store.set(epic.id, epic);
-
-      await run([...store.values()], POLICY, false, ['tbd', 'repo/tbd']);
-
-      const rootTbd = server.labels.filter((l) => l.name === 'tbd' && !l.parent);
-      const groupedTbd = server.labels.filter((l) => l.name === 'tbd' && l.parent);
-      // One of the two can exist, never both.
-      expect(rootTbd.length + groupedTbd.length).toBe(1);
-    });
-
-    it('applies both labels to the created issue', async () => {
-      const epic = bead('is-01hx5zzkbkactav9wevgemmvrz');
-      store.set(epic.id, epic);
-
-      await run([...store.values()], POLICY, false, ['tbd:sync', 'repo/tbd']);
+      await run([...store.values()], POLICY, false, ['tbd', 'repo:tbd']);
 
       const issue = [...server.issues.values()][0]!;
       const applied = issue.labels.nodes.map((n) =>
         n.parent ? `${n.parent.name}/${n.name}` : n.name,
       );
-      expect(applied.sort()).toEqual(['repo/tbd', 'tbd:sync']);
+      expect(applied.sort()).toEqual(['repo:tbd', 'tbd']);
+
+      // Neither is grouped: the repository label carries its own prefix instead, which
+      // is what lets the marker stay a bare `tbd`.
+      expect(server.labels.find((l) => l.name === 'tbd' && !l.parent)).toBeDefined();
+      expect(server.labels.find((l) => l.name === 'repo:tbd' && !l.parent)).toBeDefined();
+      expect(server.labels.some((l) => l.isGroup)).toBe(false);
     });
 
-    it('settles once the group exists, rather than re-asserting the grouped label', async () => {
-      // The loop this guards against: a grouped label reads back as its bare leaf
-      // (`tbd`), so an engine comparing against its required `repo/tbd` never finds it,
-      // and re-asserts on every sync for the life of the repository. Qualifying both
-      // sides is what makes the comparison terminate.
+    it('marker and repository label coexist for a repo whose name is the marker', async () => {
+      // The collision that forced this shape. As a `repo` group with bare children,
+      // `repo/tbd` and a root `tbd` are the same name to Linear and the second create
+      // is rejected — so mirroring this very repository was impossible.
       const epic = bead('is-01hx5zzkbkactav9wevgemmvrz');
       store.set(epic.id, epic);
 
-      const labels = ['tbd:sync', 'repo/tbd'];
+      await run([...store.values()], POLICY, false, ['tbd', 'repo:tbd']);
+
+      expect(server.labels.filter((l) => l.name === 'tbd')).toHaveLength(1);
+      expect(server.labels.filter((l) => l.name === 'repo:tbd')).toHaveLength(1);
+      const issue = [...server.issues.values()][0]!;
+      expect(issue.labels.nodes.map((n) => n.name).sort()).toEqual(['repo:tbd', 'tbd']);
+    });
+
+    it('settles rather than re-asserting labels that are already present', async () => {
+      // The loop this guards against: an engine that cannot recognize a label it just
+      // applied re-asserts it on every sync for the life of the repository.
+      const epic = bead('is-01hx5zzkbkactav9wevgemmvrz');
+      store.set(epic.id, epic);
+
+      const labels = ['tbd', 'repo:tbd'];
       await run([...store.values()], POLICY, false, labels);
       await run([...store.values()], POLICY, false, labels); // settle, as any mirror does
       const labelCountAfterSettle = server.labels.length;
@@ -250,9 +229,37 @@ describe('the sync engine', () => {
 
       expect(settled.nothingToDo).toBe(true);
       expect(settled.pushed).toEqual([]);
-      // No duplicate group or child was minted on the way to quiet.
       expect(server.labels.length).toBe(labelCountAfterSettle);
-      expect(server.labels.filter((l) => l.name === 'repo' && l.isGroup)).toHaveLength(1);
+    });
+
+    it('still reads a human-made grouped label by its qualified name', async () => {
+      // tbd no longer CREATES groups, but a workspace may well have them, and a grouped
+      // label reads back as its bare leaf. Qualifying on read is what stops an engine
+      // mistaking `area/api` for a label named `api`.
+      const group = { id: 'label-grp', name: 'area', isGroup: true };
+      server.labels.push(group, { id: 'label-api', name: 'api', parent: group });
+      server.addIssue({
+        id: 'grouped-item',
+        identifier: 'FIN-77',
+        labels: { nodes: [{ id: 'label-api', name: 'api', parent: group }] },
+      });
+
+      const epic = writeLink(bead('is-01hx5zzkbkactav9wevgemmvrz'), {
+        provider: 'linear',
+        id: 'grouped-item',
+        linked_at: '2026-08-10T00:00:00.000Z',
+      });
+      store.set(epic.id, epic);
+
+      const result = await run([...store.values()], POLICY, false, ['tbd', 'repo:tbd']);
+
+      // The human's grouped label survives untouched alongside tbd's own.
+      const applied = server.issues
+        .get('grouped-item')!
+        .labels.nodes.map((n) => (n.parent ? `${n.parent.name}/${n.name}` : n.name));
+      expect(applied).toContain('area/api');
+      expect(applied).toContain('tbd');
+      expect(result.failures).toEqual([]);
     });
   });
 
@@ -299,7 +306,7 @@ describe('the sync engine', () => {
     const id = 'is-01hx5zzkbkactav9wevgemmb01';
     store.set(id, bead(id));
 
-    const labels = ['tbd:sync', 'repo/tbd'];
+    const labels = ['tbd', 'repo:tbd'];
     await run([...store.values()], POLICY, false, labels);
     await run([...store.values()], POLICY, false, labels); // settle, as any mirror does
 
@@ -317,11 +324,11 @@ describe('the sync engine', () => {
     await run([...store.values()]);
     await run([...store.values()]); // settle with no origin labels
 
-    const labelled = await run([...store.values()], POLICY, false, ['tbd:sync', 'repo/tbd']);
+    const labelled = await run([...store.values()], POLICY, false, ['tbd', 'repo:tbd']);
     expect(labelled.nothingToDo).toBe(false);
 
     // And once backfilled, it settles again rather than re-asserting forever.
-    const after = await run([...store.values()], POLICY, false, ['tbd:sync', 'repo/tbd']);
+    const after = await run([...store.values()], POLICY, false, ['tbd', 'repo:tbd']);
     expect(after.nothingToDo).toBe(true);
   });
 

--- a/packages/tbd/tests/integrations-sync-engine.test.ts
+++ b/packages/tbd/tests/integrations-sync-engine.test.ts
@@ -390,6 +390,127 @@ describe('the sync engine', () => {
     expect(store.get(id)!.extensions?.linear).not.toHaveProperty('key');
   });
 
+  describe('batch failure containment on outbound creates', () => {
+    const createAttempts = () =>
+      server.requests.filter((request) => request.query.includes('mutation IssueCreate'));
+
+    it('halts remaining creates at the first workspace-limit rejection', async () => {
+      // The limit is a property of the workspace, so once one create hits it,
+      // every later one in the batch is doomed for the same reason. Observed
+      // live: a 77-create sync burned a request per doomed item, then its
+      // replay backlog did it again on every subsequent sync.
+      const ids = [
+        'is-01hx5zzkbkactav9wevgemmc01',
+        'is-01hx5zzkbkactav9wevgemmc02',
+        'is-01hx5zzkbkactav9wevgemmc03',
+        'is-01hx5zzkbkactav9wevgemmc04',
+      ];
+      for (const id of ids) {
+        store.set(id, bead(id, { title: `Epic ${id.slice(-3)}` }));
+      }
+      server.freeIssueLimit = 1;
+
+      const result = await run([...store.values()]);
+
+      expect(result.createdOutbound).toHaveLength(1);
+      expect(result.failures).toHaveLength(3);
+      // One success, one limit rejection — the two remaining were never sent.
+      expect(createAttempts()).toHaveLength(2);
+      const notAttempted = result.failures.filter((failure) =>
+        failure.error.startsWith('not attempted:'),
+      );
+      expect(notAttempted).toHaveLength(2);
+    });
+
+    it('does not attempt a child whose parent failed to create in this run', async () => {
+      // The child's parentId is the parent's pre-assigned client id, which
+      // never came to exist — Linear rejects it with "parentId contained an
+      // entry that could not be found" (observed live). Skipping locally keeps
+      // both journaled, and a later replay creates parent then child in order.
+      const parentId = 'is-01hx5zzkbkactav9wevgemmd01';
+      const childId = 'is-01hx5zzkbkactav9wevgemmd02';
+      store.set(parentId, bead(parentId, { title: 'Doomed parent' }));
+      store.set(childId, bead(childId, { title: 'Orphan child', parent_id: parentId }));
+      server.failCreateTitles.add('Doomed parent');
+
+      const result = await run([...store.values()]);
+
+      expect(result.createdOutbound).toHaveLength(0);
+      expect(result.failures).toHaveLength(2);
+      const childFailure = result.failures.find((failure) => failure.beadId === 'md02');
+      expect(childFailure?.error).toContain('parent failed to create');
+      // Only the parent's create reached the provider.
+      expect(createAttempts()).toHaveLength(1);
+    });
+
+    it('replays a halted backlog without re-paying a request per doomed item', async () => {
+      const ids = [
+        'is-01hx5zzkbkactav9wevgemme01',
+        'is-01hx5zzkbkactav9wevgemme02',
+        'is-01hx5zzkbkactav9wevgemme03',
+      ];
+      for (const id of ids) {
+        store.set(id, bead(id, { title: `Epic ${id.slice(-3)}` }));
+      }
+      server.freeIssueLimit = 0;
+      await run([...store.values()]); // journals 3 creates, halts after the first rejection
+
+      const before = createAttempts().length;
+      const second = await run([...store.values()]);
+
+      // One probe rediscovers the limit; the rest of the backlog stays parked.
+      expect(createAttempts().length - before).toBe(1);
+      expect(second.createdOutbound).toHaveLength(0);
+
+      // And the backlog is a backlog, not a graveyard: lift the limit and the
+      // next sync converges everything.
+      server.freeIssueLimit = undefined;
+      const recovered = await run([...store.values()]);
+      expect(recovered.failures).toEqual([]);
+      expect(server.issues.size).toBe(3);
+    });
+
+    it('compacts a partially-failed journal so replay pays only for pending ops', async () => {
+      // File-granular retention meant a 200-op journal replayed its succeeded
+      // ops on every sync until the last one cleared — observed live as ~90
+      // redundant requests per run. After a partial pass, the journal keeps
+      // only what is still pending.
+      const ids = [
+        'is-01hx5zzkbkactav9wevgemmf01',
+        'is-01hx5zzkbkactav9wevgemmf02',
+        'is-01hx5zzkbkactav9wevgemmf03',
+      ];
+      for (const id of ids) {
+        store.set(id, bead(id, { title: `Epic ${id.slice(-3)}` }));
+      }
+      server.freeIssueLimit = 2; // two fit, the third trips the limit
+      await run([...store.values()]); // journals everything, applies partially
+
+      // The first sync keeps its own journal whole — the engine does not track
+      // per-op completion. The NEXT sync's replay pass recovers the succeeded
+      // ops (idempotently) and it is that pass which compacts.
+      const [before] = await listIntentFiles(dir, 'linear');
+      expect(before!.ops.filter((op) => op.kind === 'create_issue')).toHaveLength(3);
+
+      await run([...store.values()]); // replay recovers 2, re-fails 1, compacts
+
+      const [journal] = await listIntentFiles(dir, 'linear');
+      expect(journal).toBeDefined();
+      // Only the doomed create's ops remain; every recovered op is gone, so a
+      // third sync pays one probe rather than one request per completed op.
+      expect(
+        journal!.ops.filter((op) => op.kind === 'create_issue').map((op) => op.bead_id),
+      ).toEqual(['is-01hx5zzkbkactav9wevgemmf03']);
+
+      // The compacted journal converges once the limit lifts.
+      server.freeIssueLimit = undefined;
+      const recovered = await run([...store.values()]);
+      expect(recovered.failures).toEqual([]);
+      expect(await listIntentFiles(dir, 'linear')).toEqual([]);
+      expect(server.issues.size).toBe(3);
+    });
+  });
+
   it('backfills and preserves the managed block on a pre-existing linked item', async () => {
     server.addIssue({
       id: 'linked-item',

--- a/packages/tbd/tests/origin-labels.test.ts
+++ b/packages/tbd/tests/origin-labels.test.ts
@@ -1,20 +1,22 @@
 /**
- * Origin labels: the `tbd:sync` marker and the `repo/<name>` group label.
+ * Origin labels: the `tbd` marker and the `repo:<name>` label.
  *
- * These are what make a shared tracker legible — `label is not tbd:sync` gives a human
- * their board back, and the `repo` group answers "which repository is this from" when
- * several report into one surface.
+ * These are what make a shared tracker legible — `label is not tbd` gives a human their
+ * board back, and `repo:<name>` answers "which repository is this from" when several
+ * report into one surface.
  *
- * The marker is prefixed rather than a bare `tbd` because Linear enforces label-name
- * uniqueness across a whole team and a group does not scope it, so a bare marker
- * collides with the repo label of any repository sharing its name.
+ * Both are flat, and the REPOSITORY label carries the prefix rather than the marker.
+ * Linear enforces label-name uniqueness across a whole team and a label group does not
+ * scope it, so a `repo` group whose children were bare repository names collided with
+ * the marker for a repo named `tbd`. Prefixing the repository side resolves that while
+ * leaving the most-seen label in the workspace as plain `tbd`.
  */
 
 import { describe, it, expect } from 'vitest';
 
 import {
   ORIGIN_LABEL,
-  REPO_LABEL_GROUP,
+  REPO_LABEL_PREFIX,
   sanitizeRepoLabel,
   resolveRepoLabelName,
   originLabelsFor,
@@ -69,12 +71,12 @@ describe('repo label naming', () => {
 });
 
 describe('origin labels', () => {
-  it('marks every mirrored item with tbd and its repo group', () => {
+  it('marks every mirrored item with tbd and its repo label', () => {
     const labels = originLabelsFor({
       settings: ON,
       originRemoteUrl: 'git@github.com:jlevy/tbd.git',
     });
-    expect(labels).toEqual([ORIGIN_LABEL, `${REPO_LABEL_GROUP}/tbd`]);
+    expect(labels).toEqual([ORIGIN_LABEL, `${REPO_LABEL_PREFIX}tbd`]);
   });
 
   it('drops the whole scheme when origin labelling is off', () => {
@@ -94,20 +96,20 @@ describe('origin labels', () => {
     // filtered out of a human's board at all.
     expect(originLabelsFor({ settings: ON, idPrefix: 'proj' })).toEqual([
       ORIGIN_LABEL,
-      `${REPO_LABEL_GROUP}/proj`,
+      `${REPO_LABEL_PREFIX}proj`,
     ]);
   });
 });
 
 describe('foreign repo labels', () => {
   it('recognizes a sibling repository’s label in a shared scope', () => {
-    // A candidate carrying another repo's group label is that repo's business; importing
+    // A candidate carrying another repo's label is that repo's business; importing
     // it here would duplicate the bead on both sides.
-    expect(isForeignRepoLabel(`${REPO_LABEL_GROUP}/other-repo`, 'tbd')).toBe(true);
-    expect(isForeignRepoLabel(`${REPO_LABEL_GROUP}/tbd`, 'tbd')).toBe(false);
+    expect(isForeignRepoLabel(`${REPO_LABEL_PREFIX}other-repo`, 'tbd')).toBe(true);
+    expect(isForeignRepoLabel(`${REPO_LABEL_PREFIX}tbd`, 'tbd')).toBe(false);
   });
 
-  it('ignores labels outside the repo group', () => {
+  it('ignores labels outside the repo namespace', () => {
     expect(isForeignRepoLabel(ORIGIN_LABEL, 'tbd')).toBe(false);
     expect(isForeignRepoLabel('bug', 'tbd')).toBe(false);
   });

--- a/packages/tbd/vitest.config.ts
+++ b/packages/tbd/vitest.config.ts
@@ -16,6 +16,13 @@ export default defineConfig({
     // See tests/scrub-git-env.ts and the tbd-a1lc incident.
     setupFiles: ['tests/scrub-git-env.ts'],
     hookTimeout: isWindows ? 30000 : 10000,
+    // The same reasoning, for the test body rather than the hook. Several tests
+    // drive a dozen real git subprocesses (branch, commit, a conflicting merge,
+    // then the resolver), which fits the 5s default comfortably on Linux and
+    // macOS and lands right at the edge on Windows — `bridge-merge` failed CI at
+    // 5472ms. Raising it only on Windows keeps the tight budget everywhere it is
+    // meaningful, and a genuine hang still fails rather than running forever.
+    testTimeout: isWindows ? 20000 : 5000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'json-summary', 'lcov', 'html'],


### PR DESCRIPTION
Stacked on #235 (branched from it, so review that first). Two lifecycle questions the multi-repo rollout raised, plus the reference doc that should have made both obvious before they were bugs.

## Honest import dates

The tracker is a projection and the bead is the system of record, so mirroring must not re-date history. tbd sent neither `createdAt` nor `completedAt`, so Linear stamped both at sync time. Onboarding three repositories produced **99 issues "completed" inside one week**, including beads genuinely closed seven months earlier.

Linear accepts both on `IssueCreateInput` — self-described as *"e.g. if importing from another system"*, which is exactly what a mirror is — and **neither on update**. That asymmetry is the right shape rather than a limitation to route around: in steady state a bead closes and the next sync pushes within minutes, so a provider-stamped time is already honest. The distortion is purely an onboarding artifact, and onboarding goes through create.

**This is not cosmetic.** Linear's auto-archive counts from `completedAt`, so a backfilled repository stamped "today" keeps years of closed work in the active view — and, on a capped plan, in the issue quota — for the entire archive period. That is exactly how this workspace hit its free-tier cap.

Linear enforces three rules and fails the *whole create* on any violation, so `importTimestamps` clamps rather than trusts:

- past-only (clock skew alone can push "now" into the future)
- `completedAt` strictly after `createdAt` (a bead opened and closed in the same second is nudged a millisecond)
- `completedAt` only with a completed-type state (only tbd's `closed` maps to one)

A `completedAt` without a `createdAt` is withheld entirely, since Linear stamps creation at now and then rejects the earlier completion.

**Verified live:** a bead backdated to `2026-02-03` mirrors with that `createdAt`, not today's.

## Archive ownership as policy, defaulting to manual

Archiving is how a settled pair stops costing anything — but it is also a filing decision about what a human sees in their own views, and a repository's automation is a poor judge of when someone is finished looking at something. So `policy.archive` names the owner, and the default gives it to the human.

**`manual` (default)** — tbd never archives or unarchives. An archived item is a settled pair and the sync goes quiet. A bead reopened under an archived item is **reported with the remedy** rather than silently not syncing, which is what it did before — forever, once Linear's own auto-archive ran.

**`on_close`** — tbd owns the lifecycle: closing archives, reopening restores. Both halves together on purpose, since archiving without restoring would strand reopened work. Archiving runs **last** among a pair's writes, because Linear rejects edits to an archived issue.

Under either policy: an archived item is never re-created (the bead keeps its link, so the pair is quiescent rather than duplicated), and a trashed item is never revived (Linear purges trash after 30 days, so reviving one races a deletion that would strand the link again).

An enum rather than a boolean, so `on_close_after: <duration>` fits later without another format bump.

## The reference doc

Adds `docs/references/linear-integration-design.md` — the *why* behind the whole integration, with **every rule paired to the Linear behavior that forces it**: identity, the flat label namespace, markdown round-tripping, import semantics, the archive lifecycle, multi-repo shape, the request-cost model, and what tbd deliberately does not do.

The repo had an operational shortcut (`setup-linear`, how to connect) and research briefs (why we built it), but nothing explaining how the two models meet. That gap is why the same class of bug kept reaching a live workspace: the constraints were known to whoever hit them and written down nowhere a reader would find them.

## Verification

- **147 test files, 2,224 tests, 1,101 golden assertions**
- Mock server gained the create-date rules, both archive mutations, and archive state — so none of this can regress invisibly
- Live: backdated create confirmed; the close path confirmed to stamp at transition time, exactly the asymmetry documented

Closes `tbd-3lfc`, `tbd-0t6r`, `tbd-o0sj`, `tbd-xhua`, `tbd-brg2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core Linear sync behavior (dates, archive/unarchive, labels, create batching, and provisioning) that directly affect live workspaces and issue quotas; extensive tests mitigate but operators must understand `policy.archive` and label renames.
> 
> **Overview**
> Linear mirroring now sends each bead’s **`createdAt` / `completedAt` on issue create only** (via `importTimestamps` and `CanonicalPatch.sourceCreatedAt`), so backfills no longer stamp sync-time dates that distort quotas and auto-archive. **`policy.archive`** (`manual` default vs `on_close`) drives whether tbd archives on close, unarchives on reopen, or only warns when a reopened bead sits under an archived item.
> 
> **Origin labels** shift from `tbd:sync` + `repo/<name>` groups to flat **`tbd`** and **`repo:<name>`**, avoiding team-wide label collisions when mirroring a repo named `tbd`. **`tbd integration setup`** can **create the configured Linear project**; full **`integration sync`** now forwards **`max_nesting`** from config like `--push` already did.
> 
> **Batch containment** halts outbound creates on workspace plan limits, skips children of failed parent creates, and **compacts** partially failed intent journals on replay. Docs add **`linear-integration-design`**, **`TODO.md` / `TODO.archive.md`**, and setup troubleshooting for archive and import dates; the Linear mock and tests cover dates, archive mutations, limits, and nesting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec49dd79674acdee69a151f661f9b0b844ddc985. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->