### PR TITLE
Add the Linear live QA playbook, and correct three claims it disproved

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,13 +13,19 @@ Plan:
 [plan-2026-08-15-f08-release-rollout.md](./docs/project/specs/active/plan-2026-08-15-f08-release-rollout.md).
 That document owns the mechanics; this is the status.
 
-**Ready.** The format bump, the integration work, and the multi-repo rollout are merged
-or in review. CI is green on `main`.
+**Ready.** Everything is merged and CI is green on `main`. Two independent checks pass:
+the packed upgrade proof across all four scenarios
+(`packages/tbd/scripts/validate-upgrade-package.mjs`), and the live integration QA end
+to end — see
+[valid-2026-08-16-linear-integration-live.md](./docs/project/specs/active/valid-2026-08-16-linear-integration-live.md).
+
+The Linear integration is **new in 0.7.0**, not a change to a shipped one: `v0.6.5`
+contains the adapter but never wires it into the CLI and never asserts origin labels.
+So there is no existing integration to migrate and no label-scheme upgrade to warn
+about.
 
 Blocking the tag:
 
-- [ ] Land [#236](https://github.com/jlevy/tbd/pull/236) (honest import dates, archive
-  ownership policy, the Linear design reference)
 - [ ] `tbd-62a5` — flip the two goldens this release *un*-breaks.
   They will “fail” on success: the doctor’s `Launcher fallback` warning disappears once
   the tagged version can read f08, and `validate-upgrade-package.mjs` regains a genuine
@@ -36,16 +42,9 @@ anyone whose launcher needs the registry fallback.
 
 These cannot be closed by writing code.
 
-- **The Linear workspace is over its Free-plan cap.** 250 issues, non-archived; the
-  workspace sits at about 275. metabrowser’s remaining 32 issues are journaled and
-  converge on the first sync after the cap clears — that recovery path is tested.
-  Options: upgrade to Basic (about $30/mo for 3 users, and it likely doubles the API
-  rate limit from the undocumented 2,500/hr the Free tier actually enforces), archive
-  the completed issues, or narrow what gets mirrored.
-  Honest import dates (#236) make this largely self-correcting going forward, but do not
-  retroactively re-date the 99 issues already mirrored with sync-time stamps.
-- **Re-date those 99 issues, or leave them.** Cleanest fix is unlink and re-mirror once
-  #236 lands, so they get correct `createdAt`. Costs a batch of creates against the cap.
+- **Re-date the 99 issues mirrored before honest dates shipped, or leave them.** They
+  carry sync-time `createdAt`, so Linear’s auto-archive will not retire them on their
+  real schedule. Cleanest fix is unlink and re-mirror; new work is already correct.
 - **`tbd-b7cy`** — whether to create the shared “filter out agent traffic” Linear view,
   and whether labels should be workspace-scoped rather than team-scoped.
   Both are decisions about someone’s workspace, not gaps in the code.

--- a/docs/project/specs/active/valid-2026-08-16-linear-integration-live.md
+++ b/docs/project/specs/active/valid-2026-08-16-linear-integration-live.md
@@ -1,0 +1,226 @@
+---
+title: Linear Integration Live QA
+description: Repeatable live validation of the Linear integration against a real workspace—provisioning, two-way field sync, conflicts, comments, the archive lifecycle, and failure recovery
+author: Joshua Levy (github.com/jlevy) with LLM assistance
+---
+# QA Playbook: Linear Integration Live
+
+Manual QA for the Linear integration against a **real workspace**. Everything here was
+either missed by the automated suite or can only be proven against the live API.
+
+**Purpose**: prove that a repository can be onboarded, synchronized both ways, and left
+in a settled state that costs nothing to re-run—and that the failure paths degrade the
+way they are documented to.
+
+**Estimated Time**: ~30 minutes (~10 provisioning, ~15 round trips, ~5 cleanup).
+
+> This is a manual test.
+> The mock server covers the same shapes, but the recurring lesson of this integration
+> is that **a mock is only as good as the constraints it models** — every defect found
+> live came from the mock being kinder than Linear.
+> Run this before any release that touches sync behavior.
+
+* * *
+
+## Current Status (Last Update 2026-08-16)
+
+| Phase | Status | Notes |
+| --- | --- | --- |
+| Phase 1: Preconditions | ✅ Passed | 3 repos, team `OS`, project per repo |
+| Phase 2: Provisioning | ✅ Passed | Idempotent; project + labels |
+| Phase 3: Two-way field sync | ✅ Passed | push, pull, settle |
+| Phase 4: Conflicts | ✅ Passed | local kept, loser archived, comment posted |
+| Phase 5: Comments | ✅ Passed | both directions, no duplication |
+| Phase 6: Cost and settling | ✅ Passed | `nothing to do` on consecutive runs |
+| Phase 7: Failure recovery | ✅ Passed | free-tier cap parked then converged |
+| Phase 8: Cleanup | ✅ Passed | probes removed |
+
+**Status Legend**: ✅ Passed | ❌ Failed | ⏳ Pending | ⏸️ Blocked
+
+## Phase 0: What you need
+
+- A Linear workspace and a personal API key in a **gitignored** `.env`
+  (`LINEAR_API_KEY=lin_api_...`). Never commit it, never paste it into an agent.
+- A repository with `integrations.linear` configured and `on_tbd_sync: 'off'` so every
+  sync in this playbook is explicit.
+- A locally built CLI: `pnpm build`, then drive it as
+  `node packages/tbd/dist/bin-bootstrap.cjs`. Do **not** use a globally installed `tbd`
+  unless its version can read the repository format.
+
+**Rate limits.** A quiet sync costs `2 + N` requests for `N` mirrored pairs.
+A personal API key is capped at **2,500/hour**, measured identically on the Free and
+Basic plans — Linear’s docs say 5,000 for an API key, so treat the header as the
+authority and the doc as wrong.
+Upgrading the plan does not buy headroom.
+Check it before a large run:
+
+```bash
+curl -s -o /dev/null -D - -X POST https://api.linear.app/graphql \
+  -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json" \
+  -d '{"query":"{ viewer { id } }"}' | grep -i ratelimit-requests-remaining
+```
+
+## Phase 1: Preconditions
+
+```bash
+tbd integration status
+```
+
+**Expect**: `.env` present and gitignored; credential ✓; the configured team reachable.
+
+A team that was **renamed** reports `Linear team not found`. That is correct behavior,
+not a bug: `target.team_key` is matched exactly.
+Update the config.
+
+## Phase 2: Provisioning
+
+```bash
+tbd integration setup --dry-run    # writes nothing
+tbd integration setup              # creates what is missing
+tbd integration setup              # must print "Already provisioned"
+```
+
+**Expect** on a fresh repo: the configured **project** and both labels reported, then
+created, then present.
+The third run is the idempotence check.
+
+Then confirm in the Linear UI, because this is the part a mock cannot prove:
+
+- `tbd` exists as a **flat** label, not inside a group
+- `repo:<name>` exists, also flat
+- no label has a `/` in its name
+
+**Known failure, and it should be reported not thrown**: if a label tbd wants already
+exists under a different owner, setup reports it `blocked` with the remedy and creates
+everything else. It must never half-apply silently.
+
+## Phase 3: Two-way field sync
+
+Pick one linked bead.
+Substitute your own ids.
+
+```bash
+# a) local -> Linear
+tbd update <bead> --title "<original> [local edit probe]"
+tbd integration sync                      # expect: push 1
+```
+
+Confirm the new title in Linear, then edit it there (UI or API) and pull it back:
+
+```bash
+tbd integration sync                      # expect: pull 1
+tbd show <bead>                           # title now matches the Linear edit
+tbd integration sync                      # expect: nothing to do
+```
+
+**Expect**: each direction moves exactly one field, and the third run settles.
+A run that keeps pushing a settled pair is the write-loop class this integration has hit
+three times — stop and investigate before shipping.
+
+Restore the original title and sync once more.
+
+## Phase 4: Conflicts
+
+Change the *same field* on both sides without syncing in between:
+
+```bash
+# in Linear: set the title to "CONFLICT: title set in Linear"
+tbd update <bead> --title "CONFLICT: title set locally"
+tbd integration sync
+```
+
+**Expect**: `push 1, conflicts 1` and a line naming the field and the winner
+(`title diverged; local kept` under `tie_break: newest`, local being newer).
+
+Three things must all be true:
+
+1. Linear now shows the winning value.
+2. A **conflict comment** was posted to the issue, naming both values and the archive
+   path.
+3. The **losing value is on disk**, under
+   `.tbd/data-sync/attic/<id>_<timestamp>_<field>.yml`, with `winner_source`,
+   `loser_source`, and both timestamps.
+
+Nothing may be silently discarded.
+Restore the title and sync.
+
+## Phase 5: Comments
+
+Both directions, and the round trip must not duplicate.
+
+```bash
+# inbound: comment in Linear as a human, then
+tbd integration sync                      # expect: comments in 1
+tbd show <bead>                           # the comment appears under extensions.linear.comments
+```
+
+**Expect** the comment visible to any agent reading the bead, with `id`, `at`, `author`
+(a display name, never an email), and `body`. This is what makes a human’s Linear
+comment reach an agent.
+
+```bash
+# outbound
+tbd integration comment <bead> "Agent reply from tbd."
+tbd integration sync                      # expect: comments out 1
+tbd integration sync                      # expect: nothing to do
+```
+
+**Expect**: the comment on the Linear issue, and the settle run silent.
+A second copy on either side means the exactly-once path regressed.
+
+## Phase 6: Cost and settling
+
+```bash
+tbd integration sync && tbd integration sync
+```
+
+**Expect** both runs `nothing to do`, and **no files written** — check with
+`git -C "$(git rev-parse --git-common-dir)/tbd/data-sync-worktree" status --porcelain`.
+
+A settled mirror that rewrites bridge records turns a no-op sync into a commit and a
+push. To measure real cost, read `ratelimit-requests-remaining` before and after.
+
+## Phase 7: Failure recovery
+
+Only if you can reach a failure safely — a workspace issue cap is the natural one.
+
+**Expect** when a batch fails partway:
+
+- the first workspace-limit rejection **halts** remaining creates rather than attempting
+  each one
+- a child whose parent failed is skipped **without** an API call
+- every subsequent sync costs roughly one probe, not one request per parked item
+- the journal survives, and the whole backlog converges on the first sync after the
+  blocker clears, with the journal directory then empty
+
+Verify the journal at `.tbd/data-sync-worktree/.tbd/data-sync/bridge/linear/intents/`.
+
+## Phase 8: Cleanup
+
+Remove probe artifacts so the next run starts clean:
+
+- restore any titles changed in Phases 3–4
+- delete the probe comments in Linear, and strip them from the bead’s
+  `extensions.linear.comments` (comments union-merge, so deleting only in Linear leaves
+  the bead copy)
+- resolve the conflict comment in Linear
+- archive or delete any probe issues created
+
+## Results log
+
+**2026-08-16** — full pass against workspace `Finterm`, team `OS`, three repositories
+(`tbd`, `metaproc`, `metabrowser`) in three projects, 296 issues.
+
+- Provisioning idempotent across all three repos → ✅
+- Two-way title round trip on `mp-s901` / `OS-256` → ✅ push, pull, settle
+- Conflict on the same field → ✅ local kept, loser archived with provenance, comment
+  posted
+- Comments both directions → ✅ `comments in 1`, `comments out 1`, no duplication
+- Settling → ✅ `nothing to do` on consecutive runs, no files written
+- Recovery → ✅ metabrowser’s 32 issues parked on the free-tier cap converged on their
+  own once headroom returned; journal emptied
+- Packed upgrade proof (`scripts/validate-upgrade-package.mjs`) → ✅ all four scenarios
+
+Defects this playbook has caught, all now fixed: project not provisioned; `max_nesting`
+ignored by the full sync; spec permalinks naming the working branch; sync-time dates on
+mirrored issues; batch-failure amplification; the managed-block write loop.

--- a/packages/tbd/docs/references/linear-integration-design.md
+++ b/packages/tbd/docs/references/linear-integration-design.md
@@ -86,12 +86,13 @@ The scheme:
 | Label | Purpose |
 | --- | --- |
 | `tbd` | Every mirrored item. `label is not tbd` gives a human their board back |
-| `repo/<name>` | Which repository. A Linear group allows one label per issue, which is one-repo-per-bead enforced structurally |
-| `tbd:*` | tbd’s own carriers (`tbd:blocked`, and mirrored labels under `mirror: prefixed`) |
+| `repo:<name>` | Which repository, for a team several report into |
+| `tbd:*` | tbd’s occasional purposeful carriers (`tbd:blocked`, `tbd:deferred`, and mirrored labels under `mirror: prefixed`) — deliberately uncommon, unlike the marker |
 
-tbd sets a color when it *creates* one of its own labels—indigo for the marker, slate
-for repository labels, red and amber for the blocked and deferred carriers—and never on
-update. Colour is presentation, and once a label exists it belongs to the workspace.
+tbd sets a color when it *creates* one of its own labels—dark olive green for the
+marker, slate for repository labels, red and amber for the blocked and deferred
+carriers—and never on update.
+Colour is presentation, and once a label exists it belongs to the workspace.
 
 **Rule:** the marker is bare; everything else tbd creates is prefixed, `tbd:` for its
 own carriers and `repo:` for repository identity.


### PR DESCRIPTION
A repeatable QA playbook for the Linear integration, plus the corrections that running it produced. No behavior changes — docs and one stale table row.

## The playbook

`docs/project/specs/active/valid-2026-08-16-linear-integration-live.md` covers what the automated suite cannot: preconditions and rate-limit headroom, provisioning idempotence, two-way field sync, a genuine both-sides conflict (verifying the archived loser *and* the posted comment), comments in both directions with the no-duplication check, settling and cost measurement, failure recovery, and cleanup.

It exists because the recurring lesson of this integration is that **a mock is only as good as the constraints it models** — every defect found live came from the mock being kinder than Linear. The playbook lists the six defects it has already caught so a future reader knows what it is for.

Executed end to end on 2026-08-16: workspace Finterm, team `OS`, three repositories in three projects, 296 issues. All eight phases pass.

## Three claims it disproved

**The design doc contradicted itself.** Its summary table still described the pre-flattening scheme (`repo/<name>` inside a group) and named the wrong marker colour, while the prose above it described the shipped one. Fixed.

**Upgrading the Linear plan buys no rate-limit headroom.** I had said it likely doubles. Measured on Basic: still **2,500/hour**, identical to Free. Linear documents 5,000 for an API key, so the header is the authority and the doc does not describe this auth mode. The playbook now says so.

**The Linear integration is new in 0.7.0, not a change to a shipped one.** `v0.6.5` contains the adapter but never wires it into the CLI and never asserts origin labels. So there is no existing integration to migrate, the label-scheme flattening needs no upgrade path, and my earlier "breaking change, warn in the release notes" caution was wrong.

## TODO.md

Drops the workspace-cap decision — the plan was upgraded and metabrowser's 32 parked issues converged **on their own**, which is the failure-recovery path working unattended in production. Records both release gates as passing: the packed upgrade proof (all four scenarios) and this playbook.

## Verification

- 147 test files, 2,226 tests
- `packages/tbd/scripts/validate-upgrade-package.mjs` → all four scenarios pass
- All three repositories settle to `nothing to do`, journals empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No code or runtime behavior changes—only specs, release status, and reference documentation.
> 
> **Overview**
> Adds a **manual Linear live QA playbook** (`valid-2026-08-16-linear-integration-live.md`) for real-workspace checks the mocks miss—provisioning, two-way sync, conflicts, comments, settling, failure recovery, and cleanup—with a logged **2026-08-16 full pass** across three repos.
> 
> **`linear-integration-design.md`** aligns the label summary table and creation colors with the shipped flat scheme (`repo:<name>`, dark olive green marker) instead of the old grouped `repo/<name>` / indigo wording.
> 
> **`TODO.md`** marks **0.7.0 as ready** once upgrade-package and live QA pass; clarifies Linear integration is **new in 0.7.0** (no migration/label-upgrade warning); trims blocking items (drops #236 and workspace-cap decision); and narrows pre-tag work to golden flips and release-note bullets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2b7adec4b0c0f1571a5224ca504fec5555f4698. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->