### PR TITLE
chore: release get-tbd v0.7.0

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,10 +19,13 @@ the packed upgrade proof across all four scenarios
 to end — see
 [valid-2026-08-16-linear-integration-live.md](./docs/project/specs/active/valid-2026-08-16-linear-integration-live.md).
 
-The Linear integration is **new in 0.7.0**, not a change to a shipped one: `v0.6.5`
-contains the adapter but never wires it into the CLI and never asserts origin labels.
-So there is no existing integration to migrate and no label-scheme upgrade to warn
-about.
+The Linear integration **did ship in 0.6.5**
+(`tbd integration status|sync|link|unlink| comment`), so 0.7.0 changes a live surface
+rather than introducing one.
+What is new: `integration setup`, origin labels, honest import dates, and
+`policy.archive`. Origin labels are additive — a 0.6.5 user’s linked beads simply gain
+`tbd` and `repo:<name>` on the next sync — so there is no migration, but the release
+notes must describe real fixes to a shipped integration, not just new features.
 
 Blocking the tag:
 

--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -1,5 +1,108 @@
 # get-tbd
 
+## 0.7.0
+
+**Every machine working in a tbd repository must upgrade.** This release stamps
+repositories at format `f08`, and a pre-0.7.0 client refuses a repository it cannot read
+rather than risk corrupting it.
+After upgrading, run `tbd setup --auto` in each repository — it applies the migration
+and refreshes the launcher’s fallback pin.
+Skipping it leaves agent sessions installing a version that cannot open the repository.
+
+The migration is mechanical, lossless, and idempotent.
+It rewrites `.tbd/config.yml` only; no issue file is touched.
+Commit the resulting diff.
+
+### Beads keep what they do not understand
+
+Bead files parsed in strip mode, so a client that did not know about a field silently
+deleted it when it rewrote a bead.
+Any tool writing its own keys lost them to the next `tbd` that touched the file.
+Unknown keys now survive parse, merge, and change detection, which is the reason for the
+format gate: older clients still strip, so they are locked out rather than allowed to
+quietly discard data.
+
+Two fields build on it, both list-valued and both merged by key so concurrent adds from
+different machines survive:
+
+- `tbd doc add|rm` — supporting documents for a bead, as repo-relative paths
+- `tbd ref add|rm` — external references (PRs, issues, dashboards) as URLs
+
+### Claiming work
+
+`tbd start <ids...>` claims issues: sets them in progress and records who is working, so
+a second agent joining a repository can see what is already taken.
+`tbd whoami` reports the identity tbd will record.
+
+### Linear integration
+
+The integration shipped in 0.6.5 and is substantially reworked here.
+
+**New: `tbd integration setup`** provisions what a sync needs — the configured project
+and the origin labels — and reports what is missing before creating anything.
+Re-running it is a no-op.
+A conflict it cannot resolve (a label name already taken by someone else) is reported
+with the remedy rather than half-applied.
+
+**New: origin labels.** Every mirrored issue now carries a `tbd` marker and a
+`repo:<name>` label.
+`label is not tbd` gives a human their own board back in a workspace agents also write
+to, and the repository label answers “where did this come from” once more than one
+repository reports into a team.
+Additive: existing links gain the labels on the next sync, and labels a person applied
+are never removed.
+
+**New: `policy.archive`.** Defaults to `manual`, meaning tbd never archives or
+unarchives anything — the tracker’s archive belongs to the people using it, and the
+tracker’s own retention rules keep working underneath.
+Set `on_close` to hand tbd the lifecycle, where closing a bead archives its issue and
+reopening restores it.
+
+### Fixed
+
+- **A settled mirror rewrote itself on every sync.** tbd renders a managed block into
+  each issue’s description; Linear stores markdown with link destinations wrapped in
+  angle brackets, and the comparison ran on raw strings.
+  Any issue whose block contained a link therefore looked changed forever — on a
+  200-issue mirror, most of them, on every run.
+  Comparison is now normalized against the rewrites the tracker actually performs.
+- **Beads carried tracker identifiers that go stale.** A bead stored the issue’s human
+  key and URL beside its UUID. Both are derived from mutable state — renaming a Linear
+  team rewrites every identifier in it — so a rename left every bead holding a wrong
+  value in a file committed to git.
+  Beads now store only the immutable id; the display identifier lives on the bridge
+  record, which each sync refreshes.
+- **`max_nesting` was ignored by the full synchronization.** The mirror honored it and
+  the full sync did not, so the two modes disagreed about which beads qualified and any
+  configured value above the default was silently discarded.
+- **Mirrored issues were stamped with the time of the sync**, not the bead’s own dates.
+  Backfilling an existing repository therefore created issues that all looked new, which
+  also defeats the tracker’s own auto-archive.
+  Creates now carry the bead’s `created_at` and `closed_at`.
+- **A failed batch got more expensive every run.** When a tracker refused a write for a
+  whole-workspace reason, tbd attempted every remaining item anyway, then replayed the
+  entire journal — including already-succeeded operations — on each later sync.
+  Failures now halt the batch, dependent operations are skipped without a request, and a
+  partially-failed journal is compacted so completed work is never re-attempted.
+- **Spec links pointed at the branch that ran the sync**, so they broke once that branch
+  was deleted. They now resolve against the default branch, falling back to the working
+  branch only for a spec that exists nowhere else.
+
+### Guidelines and content
+
+- New desktop guidelines for Electron, Electrobun, and Tauri, and the `electron`
+  category renamed to `desktop`
+- New reference: the Linear integration design, documenting each rule alongside the
+  tracker behavior that forces it
+- `release-notes-guidelines` gained a concrete test for whether a change belongs in a
+  “Fixed” section: was it broken for someone running the previous release?
+
+### Security
+
+Lockfile byte-identical to v0.6.5; the resolved dependency tree is unchanged.
+No runtime advisories (`pnpm audit --prod` clean); outstanding advisories are
+dev-tooling only. All 31 pins satisfy the 14-day age rule.
+
 ## 0.6.5
 
 ### Fixed

--- a/packages/tbd/docs/guidelines/release-notes-guidelines.md
+++ b/packages/tbd/docs/guidelines/release-notes-guidelines.md
@@ -55,6 +55,32 @@ compared to before.
 bug fix separately.
 Describe the feature as it now works (the complete, working version).
 
+### The test to apply to every “Fixed” entry
+
+Ask: **was this broken for someone running the previous release?**
+
+If no — the defect only ever existed on a development branch, or in code that ships for
+the first time in this release — it is **not a fix**. It is part of building the
+feature, and it belongs in the feature’s description or nowhere at all.
+
+This is the single most common error in these notes, because the development history is
+right there in the commit log and every one of those commits honestly says `fix:`. A
+commit message describes a change to the *branch*; a release note describes a change to
+the *published product*. They are different subjects, and only the second one has users.
+
+Two concrete cases:
+
+- A feature shipping for the first time this release had six bugs found and fixed while
+  building it. Users experienced none of them.
+  Describe the feature; mention none of the six.
+- A behavior was introduced, refined twice, and renamed before release.
+  Users see one new behavior under its final name.
+  Describe that, not the path taken to it.
+
+A useful cross-check: run `git log $PREV..HEAD` and, for each `fix:` commit, find the
+published version that carried the bug.
+If you cannot name one, cut the entry.
+
 ## Writing Principles
 
 ### 1. Consolidate Related Changes

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-tbd",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "description": "Git-native issue tracking for AI agents and humans",
   "license": "MIT",
   "author": "Joshua Levy <joshua@cal.berkeley.edu> (https://github.com/jlevy)",

--- a/packages/tbd/tests/cli-orientation-golden.tryscript.md
+++ b/packages/tbd/tests/cli-orientation-golden.tryscript.md
@@ -107,8 +107,7 @@ INTEGRATIONS
 HEALTH CHECKS
 ✓ Git version - [GIT_VERSION]
 ✓ Config file (.tbd/config.yml)
-⚠ Launcher fallback - tbd_fallback_version [SEMVER] cannot read format f08
-    Run: tbd setup --auto
+✓ Launcher fallback
 ✓ Issues directory (.tbd/issues)
 ✓ Dependencies
 ✓ Unique IDs


### PR DESCRIPTION
## 0.7.0

**Every machine working in a tbd repository must upgrade.** This release stamps
repositories at format `f08`, and a pre-0.7.0 client refuses a repository it cannot read
rather than risk corrupting it.
After upgrading, run `tbd setup --auto` in each repository — it applies the migration
and refreshes the launcher’s fallback pin.
Skipping it leaves agent sessions installing a version that cannot open the repository.

The migration is mechanical, lossless, and idempotent.
It rewrites `.tbd/config.yml` only; no issue file is touched.
Commit the resulting diff.

### Beads keep what they do not understand

Bead files parsed in strip mode, so a client that did not know about a field silently
deleted it when it rewrote a bead.
Any tool writing its own keys lost them to the next `tbd` that touched the file.
Unknown keys now survive parse, merge, and change detection, which is the reason for the
format gate: older clients still strip, so they are locked out rather than allowed to
quietly discard data.

Two fields build on it, both list-valued and both merged by key so concurrent adds from
different machines survive:

- `tbd doc add|rm` — supporting documents for a bead, as repo-relative paths
- `tbd ref add|rm` — external references (PRs, issues, dashboards) as URLs

### Claiming work

`tbd start <ids...>` claims issues: sets them in progress and records who is working, so
a second agent joining a repository can see what is already taken.
`tbd whoami` reports the identity tbd will record.

### Linear integration

The integration shipped in 0.6.5 and is substantially reworked here.

**New: `tbd integration setup`** provisions what a sync needs — the configured project
and the origin labels — and reports what is missing before creating anything.
Re-running it is a no-op.
A conflict it cannot resolve (a label name already taken by someone else) is reported
with the remedy rather than half-applied.

**New: origin labels.** Every mirrored issue now carries a `tbd` marker and a
`repo:<name>` label.
`label is not tbd` gives a human their own board back in a workspace agents also write
to, and the repository label answers “where did this come from” once more than one
repository reports into a team.
Additive: existing links gain the labels on the next sync, and labels a person applied
are never removed.

**New: `policy.archive`.** Defaults to `manual`, meaning tbd never archives or
unarchives anything — the tracker’s archive belongs to the people using it, and the
tracker’s own retention rules keep working underneath.
Set `on_close` to hand tbd the lifecycle, where closing a bead archives its issue and
reopening restores it.

### Fixed

- **A settled mirror rewrote itself on every sync.** tbd renders a managed block into
  each issue’s description; Linear stores markdown with link destinations wrapped in
  angle brackets, and the comparison ran on raw strings.
  Any issue whose block contained a link therefore looked changed forever — on a
  200-issue mirror, most of them, on every run.
  Comparison is now normalized against the rewrites the tracker actually performs.
- **Beads carried tracker identifiers that go stale.** A bead stored the issue’s human
  key and URL beside its UUID. Both are derived from mutable state — renaming a Linear
  team rewrites every identifier in it — so a rename left every bead holding a wrong
  value in a file committed to git.
  Beads now store only the immutable id; the display identifier lives on the bridge
  record, which each sync refreshes.
- **`max_nesting` was ignored by the full synchronization.** The mirror honored it and
  the full sync did not, so the two modes disagreed about which beads qualified and any
  configured value above the default was silently discarded.
- **Mirrored issues were stamped with the time of the sync**, not the bead’s own dates.
  Backfilling an existing repository therefore created issues that all looked new, which
  also defeats the tracker’s own auto-archive.
  Creates now carry the bead’s `created_at` and `closed_at`.
- **A failed batch got more expensive every run.** When a tracker refused a write for a
  whole-workspace reason, tbd attempted every remaining item anyway, then replayed the
  entire journal — including already-succeeded operations — on each later sync.
  Failures now halt the batch, dependent operations are skipped without a request, and a
  partially-failed journal is compacted so completed work is never re-attempted.
- **Spec links pointed at the branch that ran the sync**, so they broke once that branch
  was deleted. They now resolve against the default branch, falling back to the working
  branch only for a spec that exists nowhere else.

### Guidelines and content

- New desktop guidelines for Electron, Electrobun, and Tauri, and the `electron`
  category renamed to `desktop`
- New reference: the Linear integration design, documenting each rule alongside the
  tracker behavior that forces it
- `release-notes-guidelines` gained a concrete test for whether a change belongs in a
  “Fixed” section: was it broken for someone running the previous release?

### Security

Lockfile byte-identical to v0.6.5; the resolved dependency tree is unchanged.
No runtime advisories (`pnpm audit --prod` clean); outstanding advisories are
dev-tooling only. All 31 pins satisfy the 14-day age rule.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, version bump, and golden CLI output only; no application logic changes in this diff.
> 
> **Overview**
> **Release packaging for `get-tbd` 0.7.0** — bumps `packages/tbd/package.json` to **0.7.0** and adds the full **0.7.0** section to `CHANGELOG.md` (f08 format gate, mandatory `tbd setup --auto`, bead field preservation, `tbd start`/`whoami`, Linear rework, fixes, docs, security posture).
> 
> **Release-process docs and tests:** `TODO.md` now states Linear **shipped in 0.6.5** and frames 0.7.0 as changing a live integration (not a greenfield one). `release-notes-guidelines.md` adds a **“Fixed” entry test** — only bugs users hit on the previous release belong in Fixes. The orientation golden updates `tbd doctor` so **Launcher fallback** is ✓ (no f08 unreadable-pin warning once this version is what tests run against).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7941d4a37794f4b80e7eab76ea352d747ff3de07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->