### PR TITLE
Triage epics mechanically in update-specs-status, and name two drifts the pass misses

### DIFF
--- a/packages/tbd/docs/shortcuts/standard/update-specs-status.md
+++ b/packages/tbd/docs/shortcuts/standard/update-specs-status.md
@@ -28,16 +28,45 @@ from the top-level work index, the plan specs, and tbd beads.
      `docs/project/reviews/*.md` only when the current work moved, completed, deferred,
      or originated from those documents.
 
-2. **Build a workstream map.**
+2. **Triage mechanically before reading anything.**
+
+   In a large repository the epic list is too long to eyeball, and reading them in ID
+   order wastes the pass on epics that need no decision.
+   Compute three signals for every open epic first, then read only what they flag:
+
+   - **Where its spec lives**: `active/`, `done/`, `archive/`, `draft/`, missing from
+     disk, or no `spec_path` at all.
+   - **How many open children it has.** `tbd list --json` omits closed beads, so an epic
+     with `child_order_hints` and no children in that dump has had every child closed.
+   - **How many unchecked boxes its spec carries** (`grep -c '^\s*-\s*\[ \]'`).
+
+   The combinations sort themselves:
+
+| Spec location | Open children | Unchecked | Disposition |
+| --- | --- | --- | --- |
+| `done/` or `archive/` | 0 | 0 | Closable. Confirm against the spec status line, then bulk-close. |
+| any | 0 | 0 | Closable: everything it decomposed into is finished. |
+| any | 0 | **many** | **Do not close.** Work exists only as spec checkboxes and is invisible to `tbd ready`. Break it into beads or record what was dropped. |
+| `done/` or `archive/` | **>0** | any | The beads are usually right and the spec filing is wrong. See step 4. |
+| missing from disk | any | any | Check `git log --diff-filter=D` for the path before assuming it is stale; the spec may simply live on an unmerged branch, which needs no action. |
+
+Sizing this first also tells you whether the pass is an afternoon or a week.
+
+3. **Build a workstream map.**
    - Group beads under top-level features or epics.
    - For every active feature, identify exactly one governing active spec unless the
      work is intentionally future-only or done.
    - For every active spec, identify the parent bead or epic tracking it.
    - For every `TODO.md` line, identify the bead and governing spec it points to.
 
-3. **Reconcile beads to reality.**
+4. **Reconcile beads to reality.**
    - Check code, docs, commits, PRs, CI, deploy state, or review docs as needed before
      changing status.
+   - **Never close an epic on bead state alone.** Every child being closed proves only
+     that what was decomposed is finished.
+     Read the governing spec for unchecked items first; an epic whose beads are all
+     closed but whose spec still lists real work is the one case where closing destroys
+     information rather than recording it.
    - Close completed beads with a concrete reason that names what shipped and how it was
      validated — group beads that share a reason into one bulk call
      (`tbd close <id1> <id2> … --reason "..."`, one call per group), not a per-ID loop.
@@ -48,25 +77,31 @@ from the top-level work index, the plan specs, and tbd beads.
    - Do not close or retarget another agent’s in-progress bead unless the user asked for
      that workstream.
 
-4. **Reconcile plan specs.**
+5. **Reconcile plan specs.**
    - Update each active spec’s status, checklist, milestone table, and validation notes
      to match the beads and verified state.
    - Move completed specs from `docs/project/specs/active/` to
      `docs/project/specs/done/`.
+   - **Fix the inverse too: specs filed as done while their beads are still open.** This
+     is the more common drift, because filing a spec to `done/` is a deliberate act and
+     nobody revisits it when follow-on work appears.
+     Each one is either a spec that belongs back in `active/`, or residual work that
+     should be re-parented or closed.
+     Decide which; do not leave the pair contradicting itself.
    - Move deferred or future-only plans to `docs/project/specs/future/`.
    - Fix every link or bead `spec_path` affected by a move.
    - Never silently shrink scope.
      If reality changed the goal, state the scope change in the spec and track any
      remaining work as beads.
 
-5. **Reconcile `TODO.md`.**
+6. **Reconcile `TODO.md`.**
    - Keep it short: one line per active workstream, grouped by area.
    - Link to the governing spec and relevant bead or epic instead of duplicating detail.
    - Remove closed or future-only work from active groups unless it remains a launch
      blocker.
    - Update sync metadata, counts, and checkboxes.
 
-6. **Validate consistency.**
+7. **Validate consistency.**
    - Every active top-level workstream appears in `TODO.md` once.
    - Every `TODO.md` line maps to a real open or in-progress bead and an active spec, or
      clearly says why no active spec applies.
@@ -77,7 +112,7 @@ from the top-level work index, the plan specs, and tbd beads.
      described as active.
    - Run a Markdown link check for moved or edited docs.
 
-7. **Finish cleanly.**
+8. **Finish cleanly.**
    - Format changed Markdown with `flowmark --auto`.
    - Run `tbd sync`.
    - Review `git diff` and stage only the files and tbd metadata you changed.
@@ -89,7 +124,23 @@ from the top-level work index, the plan specs, and tbd beads.
 tbd list --specs
 tbd list --json
 tbd shortcut --list
+tbd list --status open --type epic --json   # the triage input in step 2
 ```
+
+Two things to know before scripting the triage:
+
+- `tbd list --json` returns only non-closed beads, which is what makes “no children in
+  this dump” mean “every child is closed”.
+  It does **not** include `extensions`, so it cannot tell you about external-tracker
+  links.
+- `parentId` holds the **display** id (`abc1-xyz9`), not `internalId`, while
+  `child_order_hints` holds internal ids.
+  Matching the wrong pair silently yields zero children for every epic, which reads as
+  “everything is closable”.
+  If every epic looks closable, that is the bug, not a clean repository.
+
+Resolve `spec_path` from the repository root, not from wherever a scratch script runs;
+relative paths checked from the wrong directory report every spec as missing.
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.


### PR DESCRIPTION
`update-specs-status` currently assumes a repository small enough to read end to end. Run against a large one it degrades badly, and it is silent about two drifts that a reconciliation pass exists to catch.

Found while running the shortcut over **121 open epics / 120 active specs / 1450 open beads** in a private repo, ahead of a first Linear mirror.

## What changes

**New step 2 — triage mechanically before reading anything.** Compute three signals per open epic first, then read only what they flag:

- where its spec lives (`active/`, `done/`, `archive/`, `draft/`, missing, or absent)
- how many open children it has
- how many unchecked boxes its spec carries

A small table sorts the combinations into dispositions. In practice this reduced 121 epics to **18 verified closes and 26 flagged for follow-up**, and it sizes the pass before you commit to it. Reading epics in ID order instead spends the effort on ones that need no decision.

**Step 4 — never close an epic on bead state alone.** Every child being closed proves only that what was *decomposed* is finished. Three epics here had every bead closed while their specs still listed **20, 15, and 36** unchecked items. Closing them would have buried that work permanently, since checkbox-only work never surfaces in `tbd ready`.

**Step 5 — fix the inverse drift too.** The current text says to move completed specs to `done/`. The commoner drift is the opposite: **21 specs sat in `done/` or `archive/` while their beads stayed open.** Filing a spec to `done/` is a deliberate act, so nobody revisits it when follow-on work appears. I sampled nine; in every case the open children were genuine unfinished work, so the beads were right and the filing was wrong.

**Useful Checks — the two data shapes that cost the most time.**

- `tbd list --json` returns only non-closed beads (which is what makes "no children in this dump" mean "every child is closed"), and does **not** include `extensions`.
- `parentId` holds the **display** id while `child_order_hints` holds internal ids. Matching the wrong pair silently yields zero children for *every* epic, which reads as "everything is closable". I hit exactly this and briefly believed the whole backlog was closable. The note says plainly: if every epic looks closable, that is the bug.

Plus a line about resolving `spec_path` from the repository root, after a scratch script run from elsewhere reported every spec as missing.

## Notes

- Nothing here is project-specific; the one example id was genericized to `abc1-xyz9`.
- Formatted with the repo's pinned `flowmark-rs@0.3.1`, which produced no further changes.
- Applies cleanly: upstream `main` is byte-identical to the fork base this was written against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to a planning shortcut; no runtime or product behavior is modified.
> 
> **Overview**
> **Scales the `update-specs-status` shortcut for large backlogs** by adding a new step 2 that triages every open epic from three signals (spec location, open child count, unchecked spec boxes) and a disposition table, so agents read only flagged epics and can estimate pass size before diving in. Later steps are renumbered 3–8.
> 
> **Tightens reconciliation rules** so epics are not closed from bead state alone when the governing spec still has unchecked work, and so specs sitting in `done/`/`archive/` with open children are explicitly treated as drift (move back to `active/` or re-parent/close work) rather than only moving completed specs out of `active/`.
> 
> **Documents triage pitfalls** in Useful Checks: `tbd list --status open --type epic --json`, non-closed-only JSON semantics, `parentId` vs `child_order_hints` id shapes, and resolving `spec_path` from the repo root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b898c828c6d1039fb1f37f42aa6e6eb447933bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->