### PR TITLE
feat: resolve .env from the main worktree so credentials work in linked worktrees

### DIFF
--- a/docs/project/specs/active/plan-2026-08-19-worktree-env-credential-resolution.md
+++ b/docs/project/specs/active/plan-2026-08-19-worktree-env-credential-resolution.md
@@ -1,0 +1,224 @@
+---
+title: "Worktree .env Credential Resolution"
+description: Resolve integration credentials from the main worktree's .env so a configured repository stays configured when viewed from any linked worktree
+author: Joshua Levy (github.com/jlevy) with Claude assistance
+---
+# Feature: Worktree .env Credential Resolution
+
+**Date:** 2026-08-19
+
+**Author:** Joshua Levy (github.com/jlevy) with Claude assistance
+
+**Status:** Draft
+
+## Overview
+
+In a linked git worktree, tbd reports `LINEAR_API_KEY not found` even when the key sits
+in the repository’s `.env`. `.env` is gitignored, and gitignored files do not propagate
+to worktrees, so a fully configured repository looks unconfigured from any worktree of
+it.
+
+Add the main worktree’s `.env` as a final fallback in credential resolution, resolved
+through git rather than through the filesystem.
+
+## Goals
+
+- A worktree created anywhere on disk resolves the credential its repository already
+  holds.
+- The reported credential source names the file it came from, so a per-worktree override
+  is discoverable and a cross-directory read is never silent.
+- Resolution cannot reach outside the repository, under every repository shape.
+- Outside a git repository, behavior is unchanged and no new error appears.
+
+## Non-Goals
+
+- Writing to the main worktree’s `.env`. The fallback is read-only.
+- Sharing any other gitignored file across worktrees.
+  This covers integration secrets only.
+- Changing CI behavior.
+  GitHub Actions injects secrets as environment variables and does not use worktrees.
+
+## Background
+
+The failure mode is worse than a missing feature, because the diagnosis is misleading.
+`tbd integration status` prints what reads as “Linear is not set up here”, when the
+truth is “the key exists, in the main checkout, and this process did not look there”.
+That sent an operator into the guided first-time-setup path for a repository whose
+Linear integration was already configured and working.
+
+This is now common rather than exotic.
+Agent tooling creates worktrees automatically, and a single machine can carry many per
+repository, created by different tools in different locations.
+
+### Why Directory Walking Does Not Work
+
+Walking up the directory tree looking for `.env`, which is what `python-dotenv`’s
+`find_dotenv()` and `direnv` do, only works when the worktree happens to be nested
+inside the main checkout.
+Measured against one real machine’s worktrees for a single repository, five of six lived
+outside it:
+
+| Worktree location | Walk-up reaches the repo? |
+| --- | --- |
+| `~/wrk/{org}/{repo}/.claude/worktrees/{id}` | yes, nested |
+| `~/.cache/{tool}/{id}` | no |
+| `~/.codex/worktrees/{id}/{repo}` | no, three of these |
+| `~/.codex/worktrees/{id}/{other-repo}` | no |
+
+Directory walking also has a security footgun: past the repository root it can pick up
+an unrelated project’s secrets, and the deeper the walk the likelier that is.
+
+### Why Git’s Answer Needs Validation
+
+Asking git which repository this is beats inferring it from the filesystem:
+
+```bash
+dirname "$(git rev-parse --path-format=absolute --git-common-dir)"
+```
+
+The precedent is git’s own design.
+Config, hooks, and refs live in the common dir because they are repository-scoped rather
+than branch-scoped.
+A gitignored `.env` holding machine-local credentials is exactly that
+class of state: it does not vary by branch, so sharing it across worktrees is correct
+rather than merely convenient.
+
+That expression is right for the ordinary repository shape and wrong for one real
+variant. Under `git init --separate-git-dir`, the common dir is not inside the checkout,
+so its dirname lands on an unrelated sibling directory:
+
+| Repository shape | `dirname(--git-common-dir)` | Correct? |
+| --- | --- | --- |
+| Normal repo, main checkout | the checkout | yes |
+| Normal repo, linked worktree outside it | the main checkout | yes |
+| `--separate-git-dir`, main checkout | the git dir’s parent | no |
+| `--separate-git-dir`, linked worktree | the git dir’s parent | no |
+
+`git worktree list --porcelain` is no better: under the same shape its first entry
+reports the git dir rather than a checkout.
+
+So the candidate must be verified rather than trusted.
+A candidate is the main worktree only when git, asked from inside that candidate, agrees
+on both facts: the candidate is a worktree root, and it belongs to this same repository.
+Both checks together are what make the “cannot leave the repository” property true
+rather than assumed.
+
+## Design
+
+### Resolution Order
+
+Resolution order for `LINEAR_API_KEY` and any other integration secret:
+
+1. The process environment.
+   Always wins. Unchanged.
+2. `./.env` in the current working tree.
+   Present-but-different is a deliberate override, so a worktree can point at different
+   credentials.
+3. `<main-worktree>/.env`, resolved and validated through git.
+   This is the new fallback.
+4. Not found.
+
+Layers 1 and 2 keep their current precedence and behavior.
+
+### Resolving the Main Worktree
+
+`resolveGitCommonDir` in `lib/paths.ts` already asks git for the common directory, with
+the `--path-format=absolute` fallback and realpath normalization handled.
+The new helper builds on it rather than issuing its own `rev-parse`.
+
+Taking the dirname produces a candidate.
+Accept it only when both hold:
+
+- `git -C <candidate> rev-parse --path-format=absolute --show-toplevel` equals the
+  candidate, so the candidate is a worktree root rather than an arbitrary directory.
+- `git -C <candidate> rev-parse --path-format=absolute --git-common-dir` equals the
+  common dir we started from, so it belongs to this repository.
+
+Anything else returns nothing, and layer 3 is skipped.
+Outside a git repository, or when `git` is not on PATH, the helper returns nothing
+rather than raising.
+
+Under `--separate-git-dir` this costs a linked worktree its fallback, which is the right
+trade: the alternative is reading a neighboring project’s `.env`. The main checkout of
+such a repository is unaffected, since layer 2 already covers it.
+
+### Reporting the Source
+
+`CredentialSource` currently distinguishes `env`, `dotenv`, and `gh-cli`, and status
+renders `dotenv` as the bare string `.env`. Once resolution can reach outside the
+current directory that is ambiguous, so `ResolvedCredential` carries the absolute path
+it was read from and status prints it.
+Masking is unchanged: never print the key itself.
+
+The `.env` safety finding follows the same file.
+`envFileFinding` reports whether a `.env` exists and whether git ignores it, and today
+it asks only about the current working tree.
+When the credential came from the main worktree, that is the file whose ignore status
+matters, and reporting on a different file than the one in use is how a committed key
+stays invisible.
+
+### Components
+
+| File | Change |
+| --- | --- |
+| `lib/paths.ts` | Add the validated main-worktree helper beside `resolveGitCommonDir` |
+| `integrations/core/credentials.ts` | Add layer 3; carry the resolved path on `ResolvedCredential` |
+| `integrations/core/status.ts` | Name the source path; point the safety finding at the file actually read |
+| `docs/shortcuts/standard/setup-linear.md` | Joining from a worktree needs no per-worktree key |
+
+## Implementation Plan
+
+One phase. The four steps are sequential because each consumes the previous one’s
+surface.
+
+- [ ] **Main-worktree helper** (`tbd-mcw6`). The validated resolver, built on
+  `resolveGitCommonDir`, returning nothing rather than raising.
+- [ ] **Credential fallback** (`tbd-fzm7`). Layer 3 wired into `resolveCredential`, with
+  the read path carried on the result.
+- [ ] **Source reporting** (`tbd-lxjr`). Status names the file, and the `.env` safety
+  finding follows it.
+- [ ] **Tests and setup guidance** (`tbd-0tc3`).
+
+## Testing Strategy
+
+Over a real linked worktree created outside the main checkout, since a temp-directory
+stand-in cannot exercise the resolution this feature exists for:
+
+- Key only in the main checkout’s `.env` resolves, and status names that path.
+- A worktree-local `.env` overrides the main one.
+- An exported environment variable overrides both.
+- Outside a git repository, behavior is unchanged and no new error appears.
+- Under `--separate-git-dir`, the candidate is rejected and no `.env` outside the
+  repository is read. This is the case that distinguishes the validated resolver from the
+  bare dirname, so it belongs in the suite rather than in review notes.
+
+`tests/integrations-status.test.ts` already builds a temp repo with `git init` per case,
+so `git worktree add` extends the existing harness rather than needing a new one.
+
+## Rollout
+
+No format change, no config change, no migration.
+The behavior is additive: a repository that resolves its credential today resolves the
+same one afterward, from the same layer.
+
+Until this lands, exporting the key from a shell profile or a secret-manager wrapper
+satisfies layer 1 and works in every worktree.
+
+## Open Questions
+
+- A worktree on a branch whose `.gitignore` does not cover `.env` will report a
+  different safety verdict than the main checkout does for the same file.
+  Reporting on the file actually read is the intended behavior, and whether it deserves
+  distinct wording is worth deciding when the finding is written.
+
+## References
+
+- [Beads: `tbd-30t7`](https://linear.app/finterm-ai/issue/OS-350) and its four children
+- `git rev-parse --git-common-dir`,
+  [git-rev-parse documentation](https://git-scm.com/docs/git-rev-parse)
+- `plan-2026-08-10-external-tracker-integrations.md`, which introduced `.env` credential
+  loading
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/docs/project/specs/active/plan-2026-08-19-worktree-env-credential-resolution.md
+++ b/docs/project/specs/active/plan-2026-08-19-worktree-env-credential-resolution.md
@@ -9,7 +9,7 @@ author: Joshua Levy (github.com/jlevy) with Claude assistance
 
 **Author:** Joshua Levy (github.com/jlevy) with Claude assistance
 
-**Status:** Draft
+**Status:** Implemented
 
 ## Overview
 
@@ -171,13 +171,13 @@ stays invisible.
 One phase. The four steps are sequential because each consumes the previous one’s
 surface.
 
-- [ ] **Main-worktree helper** (`tbd-mcw6`). The validated resolver, built on
+- [x] **Main-worktree helper** (`tbd-mcw6`). The validated resolver, built on
   `resolveGitCommonDir`, returning nothing rather than raising.
-- [ ] **Credential fallback** (`tbd-fzm7`). Layer 3 wired into `resolveCredential`, with
+- [x] **Credential fallback** (`tbd-fzm7`). Layer 3 wired into `resolveCredential`, with
   the read path carried on the result.
-- [ ] **Source reporting** (`tbd-lxjr`). Status names the file, and the `.env` safety
+- [x] **Source reporting** (`tbd-lxjr`). Status names the file, and the `.env` safety
   finding follows it.
-- [ ] **Tests and setup guidance** (`tbd-0tc3`).
+- [x] **Tests and setup guidance** (`tbd-0tc3`).
 
 ## Testing Strategy
 

--- a/packages/tbd/docs/shortcuts/standard/setup-linear.md
+++ b/packages/tbd/docs/shortcuts/standard/setup-linear.md
@@ -160,8 +160,16 @@ Rules that are not negotiable:
 - If a key was ever committed, say so plainly and tell the user to rotate it in Linear.
   Removing the commit is not enough.
 
-tbd reads `LINEAR_API_KEY` from the process environment first, then from `.env`. An
-exported environment variable is equally fine and needs no file.
+tbd reads `LINEAR_API_KEY` from the process environment first, then from this working
+tree’s `.env`, then from the main worktree’s `.env`. An exported environment variable is
+equally fine and needs no file.
+
+**In a linked worktree, do not create a second key.** `.env` is gitignored, so it does
+not propagate to worktrees, but tbd resolves the main checkout through git and reads the
+key already there. `tbd integration status` names the exact file it loaded, so a
+`✓ credential` line pointing at the main checkout’s path is the expected result and not
+something to fix. Write a worktree-local `.env` only to point that one worktree at a
+*different* key, since it takes precedence over the main one.
 
 ## Step 4: Verify
 

--- a/packages/tbd/src/integrations/core/credentials.ts
+++ b/packages/tbd/src/integrations/core/credentials.ts
@@ -1,16 +1,20 @@
 /**
  * Credential resolution for external tracker integrations.
  *
- * Credentials are read from the process environment or the repository `.env`,
- * and travel only through the `ResolvedCredential` returned here. They are never
- * written into `process.env` (see lib/env-file.ts for why), never persisted to
- * bridge state, and never logged or included in JSON output.
+ * Credentials are read from the process environment, this working tree's `.env`,
+ * or the main worktree's `.env`, and travel only through the `ResolvedCredential`
+ * returned here. They are never written into `process.env` (see lib/env-file.ts
+ * for why), never persisted to bridge state, and never logged or included in JSON
+ * output.
  */
 
 import { execFile } from 'node:child_process';
+import { realpath } from 'node:fs/promises';
+import { join } from 'node:path';
 import { promisify } from 'node:util';
 
-import { readEnvFile } from '../../lib/env-file.js';
+import { ENV_FILE_NAME, readEnvFile } from '../../lib/env-file.js';
+import { resolveMainWorktree } from '../../lib/paths.js';
 import type { ProviderNameType } from '../../lib/types.js';
 
 const execFileAsync = promisify(execFile);
@@ -22,6 +26,14 @@ export interface ResolvedCredential {
   /** The secret. Never log, serialize, or include in command output. */
   value: string;
   source: CredentialSource;
+  /**
+   * Absolute path the value was read from, for `dotenv` only.
+   *
+   * A `.env` can now be loaded from outside the current directory, so the source
+   * alone no longer identifies the file. Safe to display: it is a path, not a
+   * secret, and naming it is what keeps a cross-directory read from being silent.
+   */
+  path?: string;
 }
 
 /** The environment variable each provider reads. */
@@ -59,11 +71,38 @@ async function ghCliToken(): Promise<string | undefined> {
 }
 
 /**
+ * The main checkout's root, when it is a different directory than `repoRoot`.
+ *
+ * Returns undefined in the main checkout itself, where the fallback would reread
+ * the file layer 2 already tried, and outside a repository, where there is no
+ * main checkout to find.
+ */
+async function otherWorktreeRoot(repoRoot: string): Promise<string | undefined> {
+  const mainWorktree = await resolveMainWorktree(repoRoot);
+  if (!mainWorktree) {
+    return undefined;
+  }
+  const here = await realpath(repoRoot).catch(() => repoRoot);
+  return mainWorktree === here ? undefined : mainWorktree;
+}
+
+/**
  * Resolve a provider credential.
  *
- * Order, first match wins: process environment, then repository `.env`, then
- * (GitHub only) the `gh` CLI. The process environment wins so a one-off override
- * does not require editing a file.
+ * Order, first match wins: process environment, this working tree's `.env`, the
+ * main worktree's `.env`, then (GitHub only) the `gh` CLI. The process
+ * environment wins so a one-off override does not require editing a file, and a
+ * worktree's own `.env` beats the main checkout's so pointing one worktree at
+ * different credentials stays possible.
+ *
+ * The main-worktree layer exists because `.env` is gitignored and gitignored
+ * files do not propagate to linked worktrees, which made a configured repository
+ * look unconfigured from any worktree of it. It is read-only: nothing here or in
+ * setup writes to the main checkout's `.env`.
+ *
+ * Every layer past the first costs a git subprocess, so the common cases pay
+ * nothing: an exported variable returns before any git call, and a worktree-local
+ * `.env` returns before the main-worktree lookup.
  */
 export async function resolveCredential(
   provider: ProviderNameType,
@@ -79,7 +118,20 @@ export async function resolveCredential(
   const dotenv = await readEnvFile(repoRoot);
   const fromDotenv = dotenv.get(varName);
   if (fromDotenv && fromDotenv.length > 0) {
-    return { value: fromDotenv, source: 'dotenv' };
+    return { value: fromDotenv, source: 'dotenv', path: join(repoRoot, ENV_FILE_NAME) };
+  }
+
+  const mainWorktree = await otherWorktreeRoot(repoRoot);
+  if (mainWorktree) {
+    const mainDotenv = await readEnvFile(mainWorktree);
+    const fromMainDotenv = mainDotenv.get(varName);
+    if (fromMainDotenv && fromMainDotenv.length > 0) {
+      return {
+        value: fromMainDotenv,
+        source: 'dotenv',
+        path: join(mainWorktree, ENV_FILE_NAME),
+      };
+    }
   }
 
   if (provider === 'github') {

--- a/packages/tbd/src/integrations/core/status.ts
+++ b/packages/tbd/src/integrations/core/status.ts
@@ -69,10 +69,25 @@ function describeSource(credential: ResolvedCredential): string {
     case 'env':
       return 'process environment';
     case 'dotenv':
+      // Every dotenv result carries its path today; the bare name is a
+      // type-honest fallback, not a reachable case.
       return credential.path ?? ENV_FILE_NAME;
     case 'gh-cli':
       return 'gh auth token';
   }
+}
+
+/** One `.env` location's safety state: where it is and how git treats it. */
+interface EnvFileCheck {
+  dir: string;
+  path: string;
+  exists: boolean;
+  ignored: boolean;
+}
+
+async function checkEnvFile(dir: string): Promise<EnvFileCheck> {
+  const status = await checkEnvIgnored(dir);
+  return { dir, path: join(dir, ENV_FILE_NAME), ...status };
 }
 
 /**
@@ -81,39 +96,59 @@ function describeSource(credential: ResolvedCredential): string {
  * An unignored `.env` holding an API key is the highest-cost, lowest-visibility
  * failure in this feature, so it is reported as an error even though nothing is
  * broken yet.
+ *
+ * When the credential came from outside this working tree (`loadedFrom`), BOTH
+ * files are examined and the worse one wins. Checking only the file in use would
+ * vouch by omission for a local `.env` nobody read: it can sit unignored, holding
+ * some other credential, while the finding reports the main worktree's file as
+ * safe. Checking only the local one is the inverse mistake, examining a file
+ * that is not the one holding the key. Worktrees make the two genuinely
+ * different: `.gitignore` is branch content, so one checkout can ignore `.env`
+ * while another does not.
+ *
+ * Paths appear in the detail and remedy only when two files are in play; the
+ * single-file case keeps its historical wording.
  */
 async function envFileFinding(repoRoot: string, loadedFrom?: string): Promise<StatusFinding> {
-  // Report on the file a credential actually came from. Once resolution can reach
-  // the main worktree, checking only the current directory would vouch for a file
-  // nobody read while the one in use went unexamined, which is how a committed key
-  // stays invisible.
-  const target = loadedFrom ? dirname(loadedFrom) : repoRoot;
-  const where = loadedFrom ? ` (${loadedFrom})` : '';
-  const status = await checkEnvIgnored(target);
-  if (!status.exists) {
-    if (!status.ignored) {
-      return {
-        label: ENV_FILE_NAME,
-        state: 'warn',
-        detail: `not present and not gitignored${where}`,
-        remedy: `Add ${ENV_FILE_NAME} to .gitignore before creating it or putting any credential in it.`,
-      };
-    }
-    return {
-      label: ENV_FILE_NAME,
-      state: 'ok',
-      detail: `not present and gitignored${where}`,
-    };
-  }
-  if (!status.ignored) {
+  const local = await checkEnvFile(repoRoot);
+  const external =
+    loadedFrom && dirname(loadedFrom) !== repoRoot
+      ? await checkEnvFile(dirname(loadedFrom))
+      : undefined;
+  const naming = external !== undefined;
+  const where = (file: EnvFileCheck) => (naming ? ` (${file.path})` : '');
+  const remedyIn = (file: EnvFileCheck) => (naming ? ` in ${file.dir}` : '');
+
+  // An exposed file: exists and git would commit it. Local outranks external so
+  // the file the operator can fix from here is the one named first.
+  const exposed = [local, external].find((file) => file && file.exists && !file.ignored);
+  if (exposed) {
     return {
       label: ENV_FILE_NAME,
       state: 'error',
-      detail: `present and NOT gitignored${where}`,
-      remedy: `Add ${ENV_FILE_NAME} to .gitignore before putting any credential in it. If a key was already committed, rotate it.`,
+      detail: `present and NOT gitignored${where(exposed)}`,
+      remedy: `Add ${ENV_FILE_NAME} to .gitignore${remedyIn(exposed)} before putting any credential in it. If a key was already committed, rotate it.`,
     };
   }
-  return { label: ENV_FILE_NAME, state: 'ok', detail: `present and gitignored${where}` };
+
+  if (!local.exists && !local.ignored) {
+    return {
+      label: ENV_FILE_NAME,
+      state: 'warn',
+      detail: `not present and not gitignored${where(local)}`,
+      remedy: `Add ${ENV_FILE_NAME} to .gitignore${remedyIn(local)} before creating it or putting any credential in it.`,
+    };
+  }
+
+  // Nothing is exposed; describe the file actually in use.
+  const inUse = external ?? local;
+  return {
+    label: ENV_FILE_NAME,
+    state: 'ok',
+    detail: inUse.exists
+      ? `present and gitignored${where(inUse)}`
+      : `not present and gitignored${where(inUse)}`,
+  };
 }
 
 /** A provider's findings, plus the `.env` its credential came from, if any. */

--- a/packages/tbd/src/integrations/core/status.ts
+++ b/packages/tbd/src/integrations/core/status.ts
@@ -7,13 +7,15 @@
  * a network call to report.
  */
 
+import { dirname, join } from 'node:path';
+
 import { checkEnvIgnored, ENV_FILE_NAME } from '../../lib/env-file.js';
 import type { Config, ProviderNameType } from '../../lib/types.js';
 import {
   CREDENTIAL_ENV_VARS,
   maskSecret,
   resolveCredential,
-  type CredentialSource,
+  type ResolvedCredential,
 } from './credentials.js';
 import { configuredProviders, type ProviderConfig } from './registry.js';
 
@@ -55,12 +57,19 @@ export interface StatusOptions {
   probe?: ReachabilityProbe;
 }
 
-function describeSource(source: CredentialSource): string {
-  switch (source) {
+/**
+ * Name where a credential came from.
+ *
+ * A `.env` is named by its full path, because resolution can reach the main
+ * worktree's file and the bare name would not say which one answered. A path is
+ * not a secret; the value beside it is already masked.
+ */
+function describeSource(credential: ResolvedCredential): string {
+  switch (credential.source) {
     case 'env':
       return 'process environment';
     case 'dotenv':
-      return ENV_FILE_NAME;
+      return credential.path ?? ENV_FILE_NAME;
     case 'gh-cli':
       return 'gh auth token';
   }
@@ -73,39 +82,51 @@ function describeSource(source: CredentialSource): string {
  * failure in this feature, so it is reported as an error even though nothing is
  * broken yet.
  */
-async function envFileFinding(repoRoot: string): Promise<StatusFinding> {
-  const status = await checkEnvIgnored(repoRoot);
+async function envFileFinding(repoRoot: string, loadedFrom?: string): Promise<StatusFinding> {
+  // Report on the file a credential actually came from. Once resolution can reach
+  // the main worktree, checking only the current directory would vouch for a file
+  // nobody read while the one in use went unexamined, which is how a committed key
+  // stays invisible.
+  const target = loadedFrom ? dirname(loadedFrom) : repoRoot;
+  const where = loadedFrom ? ` (${loadedFrom})` : '';
+  const status = await checkEnvIgnored(target);
   if (!status.exists) {
     if (!status.ignored) {
       return {
         label: ENV_FILE_NAME,
         state: 'warn',
-        detail: 'not present and not gitignored',
+        detail: `not present and not gitignored${where}`,
         remedy: `Add ${ENV_FILE_NAME} to .gitignore before creating it or putting any credential in it.`,
       };
     }
     return {
       label: ENV_FILE_NAME,
       state: 'ok',
-      detail: 'not present and gitignored',
+      detail: `not present and gitignored${where}`,
     };
   }
   if (!status.ignored) {
     return {
       label: ENV_FILE_NAME,
       state: 'error',
-      detail: 'present and NOT gitignored',
+      detail: `present and NOT gitignored${where}`,
       remedy: `Add ${ENV_FILE_NAME} to .gitignore before putting any credential in it. If a key was already committed, rotate it.`,
     };
   }
-  return { label: ENV_FILE_NAME, state: 'ok', detail: 'present and gitignored' };
+  return { label: ENV_FILE_NAME, state: 'ok', detail: `present and gitignored${where}` };
+}
+
+/** A provider's findings, plus the `.env` its credential came from, if any. */
+interface ProviderStatusResult {
+  status: ProviderStatus;
+  envPath?: string;
 }
 
 async function providerStatus(
   entry: ProviderConfig,
   repoRoot: string,
   probe?: ReachabilityProbe,
-): Promise<ProviderStatus> {
+): Promise<ProviderStatusResult> {
   const findings: StatusFinding[] = [];
   const varName = CREDENTIAL_ENV_VARS[entry.provider];
 
@@ -116,7 +137,7 @@ async function providerStatus(
       detail: 'configured but disabled',
       remedy: `Set integrations.${entry.provider}.enabled: true to use it.`,
     });
-    return { provider: entry.provider, enabled: false, findings };
+    return { status: { provider: entry.provider, enabled: false, findings } };
   }
 
   findings.push({ label: 'enabled', state: 'ok', detail: 'yes' });
@@ -144,15 +165,16 @@ async function providerStatus(
       detail: `${varName} not found`,
       remedy: `Set ${varName} in the environment or add it to ${ENV_FILE_NAME} (which must be gitignored).`,
     });
-    return { provider: entry.provider, enabled: true, findings };
+    return { status: { provider: entry.provider, enabled: true, findings } };
   }
 
   findings.push({
     label: 'credential',
     state: 'ok',
     // Enough to tell two keys apart, never enough to use.
-    detail: `${maskSecret(credential.value)} from ${describeSource(credential.source)}`,
+    detail: `${maskSecret(credential.value)} from ${describeSource(credential)}`,
   });
+  const envPath = credential.source === 'dotenv' ? credential.path : undefined;
 
   if (!probe) {
     findings.push({
@@ -160,7 +182,10 @@ async function providerStatus(
       state: 'skipped',
       detail: 'network check not run',
     });
-    return { provider: entry.provider, enabled: true, findings };
+    return {
+      status: { provider: entry.provider, enabled: true, findings },
+      ...(envPath ? { envPath } : {}),
+    };
   }
 
   const result = await probe(entry.provider, credential.value, entry.target);
@@ -175,7 +200,10 @@ async function providerStatus(
         },
   );
 
-  return { provider: entry.provider, enabled: true, findings };
+  return {
+    status: { provider: entry.provider, enabled: true, findings },
+    ...(envPath ? { envPath } : {}),
+  };
 }
 
 /**
@@ -183,12 +211,24 @@ async function providerStatus(
  */
 export async function integrationStatus(options: StatusOptions): Promise<IntegrationStatus> {
   const entries = configuredProviders(options.config);
-  const envFile = await envFileFinding(options.repoRoot);
 
   const providers: ProviderStatus[] = [];
+  const loadedFrom = new Set<string>();
   for (const entry of entries) {
-    providers.push(await providerStatus(entry, options.repoRoot, options.probe));
+    const result = await providerStatus(entry, options.repoRoot, options.probe);
+    providers.push(result.status);
+    if (result.envPath) {
+      loadedFrom.add(result.envPath);
+    }
   }
+
+  // Providers run first so the safety check knows which file to examine. Only a
+  // file outside this working tree needs naming; the local one is what the check
+  // has always meant, and every provider that reaches outside reaches the same
+  // main worktree, so at most one path qualifies.
+  const localEnv = join(options.repoRoot, ENV_FILE_NAME);
+  const external = [...loadedFrom].find((path) => path !== localEnv);
+  const envFile = await envFileFinding(options.repoRoot, external);
 
   return { inert: entries.length === 0, envFile, providers };
 }

--- a/packages/tbd/src/lib/paths.ts
+++ b/packages/tbd/src/lib/paths.ts
@@ -35,7 +35,7 @@ import { execFile } from 'node:child_process';
 
 import { gitSafeEnv } from './git-env.js';
 import { homedir } from 'node:os';
-import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { promisify } from 'node:util';
 
 /** The tbd configuration directory on main branch */
@@ -176,6 +176,68 @@ export async function resolveGitCommonDir(cwd: string): Promise<string> {
 
   const gitCommonDir = isAbsolute(output) ? output : resolve(cwd, output);
   return realpath(gitCommonDir).catch(() => gitCommonDir);
+}
+
+/**
+ * Resolve the checkout at the top of a worktree, normalized through realpath.
+ *
+ * Realpath matters on macOS, where `/tmp` is a symlink to `/private/tmp`: git
+ * answers one way here and another there, and an unnormalized comparison of two
+ * true answers reads as a mismatch.
+ */
+async function resolveWorktreeTopLevel(cwd: string): Promise<string> {
+  const { stdout } = await execFileAsync(
+    'git',
+    ['-C', cwd, 'rev-parse', '--path-format=absolute', '--show-toplevel'],
+    { env: gitSafeEnv(), maxBuffer: 1024 * 1024 },
+  );
+  const topLevel = stdout.trim();
+  if (!topLevel) {
+    throw new Error(`Unable to resolve the worktree top level from ${cwd}`);
+  }
+  return realpath(topLevel).catch(() => topLevel);
+}
+
+/**
+ * Resolve the main worktree of the repository containing `baseDir`.
+ *
+ * Linked worktrees do not receive gitignored files, so repository-scoped local
+ * state (a `.env` holding machine-local credentials) lives only in the main
+ * checkout. This answers where that checkout is, from anywhere in the repository.
+ * In the main checkout it returns that checkout, so callers need no worktree case.
+ *
+ * The common dir's parent is a *candidate*, not the answer. Under
+ * `git init --separate-git-dir` the common dir sits outside the checkout, so the
+ * dirname lands on an unrelated sibling directory, and reading a `.env` from
+ * there would hand one project's secrets to another. `git worktree list` shares
+ * the flaw: under that shape its first entry reports the git dir, not a checkout.
+ *
+ * So the candidate is verified. Asked from inside it, git must agree on both
+ * counts: the candidate is a worktree root, and it belongs to the repository we
+ * started from. Anything else returns undefined, as does a missing `git` or a
+ * directory outside any repository. Callers treat undefined as "skip this layer",
+ * never as an error, so behavior outside a repository is unchanged.
+ */
+export async function resolveMainWorktree(baseDir: string): Promise<string | undefined> {
+  let gitCommonDir: string;
+  try {
+    gitCommonDir = await resolveGitCommonDir(baseDir);
+  } catch {
+    return undefined;
+  }
+
+  const candidate = dirname(gitCommonDir);
+  try {
+    const [topLevel, candidateCommonDir] = await Promise.all([
+      resolveWorktreeTopLevel(candidate),
+      resolveGitCommonDir(candidate),
+    ]);
+    const isWorktreeRoot = resolve(topLevel) === resolve(candidate);
+    const isSameRepository = resolve(candidateCommonDir) === resolve(gitCommonDir);
+    return isWorktreeRoot && isSameRepository ? candidate : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/packages/tbd/src/lib/paths.ts
+++ b/packages/tbd/src/lib/paths.ts
@@ -218,7 +218,27 @@ async function resolveWorktreeTopLevel(cwd: string): Promise<string> {
  * directory outside any repository. Callers treat undefined as "skip this layer",
  * never as an error, so behavior outside a repository is unchanged.
  */
-export async function resolveMainWorktree(baseDir: string): Promise<string | undefined> {
+export function resolveMainWorktree(baseDir: string): Promise<string | undefined> {
+  let pending = mainWorktreeByBaseDir.get(baseDir);
+  if (!pending) {
+    pending = resolveMainWorktreeUncached(baseDir);
+    mainWorktreeByBaseDir.set(baseDir, pending);
+  }
+  return pending;
+}
+
+/**
+ * Memo for {@link resolveMainWorktree}, keyed by `baseDir`.
+ *
+ * One answer costs three or four git spawns and every provider asks the same
+ * question (`integration status` asks once for Linear and once for GitHub), so
+ * identical questions within a process share the first answer. Worktree topology
+ * does not change mid-command; `.env` CONTENT is not cached anywhere and is
+ * reread on every resolution.
+ */
+const mainWorktreeByBaseDir = new Map<string, Promise<string | undefined>>();
+
+async function resolveMainWorktreeUncached(baseDir: string): Promise<string | undefined> {
   let gitCommonDir: string;
   try {
     gitCommonDir = await resolveGitCommonDir(baseDir);

--- a/packages/tbd/tests/worktree-credentials.test.ts
+++ b/packages/tbd/tests/worktree-credentials.test.ts
@@ -264,6 +264,23 @@ describe('status reporting of the credential source', () => {
     expect(status.envFile.detail).toContain(join(await realish(main), '.env'));
   });
 
+  it('flags an unignored local .env even when the credential comes from the main worktree', async () => {
+    await writeFile(join(main, '.gitignore'), '.env\n');
+    await writeFile(join(main, '.env'), `LINEAR_API_KEY=${MAIN_VALUE}\n`);
+    // The local file lacks the key, so resolution falls through to the main
+    // worktree; it is also not ignored on this branch. The safety check must not
+    // vouch for it by omission just because the main worktree's file answered.
+    await writeFile(join(linked, '.env'), 'SOME_OTHER_VAR=value\n');
+
+    const status = await integrationStatus({ config: config(), repoRoot: linked });
+    const credential = status.providers[0]?.findings.find((f) => f.label === 'credential');
+
+    expect(credential?.state).toBe('ok');
+    expect(status.envFile.state).toBe('error');
+    expect(status.envFile.detail).toContain(join(linked, '.env'));
+    expect(status.envFile.remedy).toContain(linked);
+  });
+
   it('says nothing about another file when the local .env answered', async () => {
     await writeFile(join(linked, '.gitignore'), '.env\n');
     await writeFile(join(linked, '.env'), `LINEAR_API_KEY=${LOCAL_VALUE}\n`);

--- a/packages/tbd/tests/worktree-credentials.test.ts
+++ b/packages/tbd/tests/worktree-credentials.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Credential resolution across linked worktrees.
+ *
+ * `.env` is gitignored, and gitignored files do not propagate to worktrees, so a
+ * configured repository looked unconfigured from any worktree of it. These tests
+ * run over real `git worktree` checkouts created outside the main one, because a
+ * temp directory standing in for a worktree cannot exercise the resolution this
+ * feature exists for: the whole question is what git reports about a directory.
+ */
+
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { git } from '../src/file/git.js';
+import { resolveCredential } from '../src/integrations/core/credentials.js';
+import { integrationStatus } from '../src/integrations/core/status.js';
+import { resolveMainWorktree } from '../src/lib/paths.js';
+import type { Config } from '../src/lib/types.js';
+
+/**
+ * The realpath of a directory, matching what git reports.
+ *
+ * macOS resolves `/tmp` to `/private/tmp`, so a literal temp path and git's answer
+ * for the same directory are different strings.
+ */
+async function realish(dir: string): Promise<string> {
+  return realpath(dir).catch(() => dir);
+}
+
+const MAIN_SECRET = 'lin_api_mainworktree_0123456789';
+const LOCAL_SECRET = 'lin_api_worktreelocal_9876543210';
+const EXPORTED_SECRET = 'lin_api_exported_abcdefabcdef';
+
+function config(): Config {
+  return {
+    version: 1,
+    display: { id_prefix: 'tbd' },
+    settings: { auto_sync: false, doc_auto_sync_hours: 24, use_gh_cli: true },
+    sync: { branch: 'tbd-sync' },
+    integrations: {
+      on_tbd_sync: 'off' as const,
+      linear: {
+        enabled: true,
+        team_key: 'FIN',
+        select: { kinds: ['epic'], statuses: ['open'], labels: [], linked: true },
+        max_nesting: 2,
+        create_labels: true,
+        user_map: {},
+      },
+    },
+  } as unknown as Config;
+}
+
+/**
+ * Identity and signing, set per repository.
+ *
+ * The suite must not depend on the developer's global git config, and a machine
+ * with `commit.gpgsign` on would otherwise fail in the fixture rather than in
+ * anything a test is about.
+ */
+async function configureCommits(dir: string): Promise<void> {
+  await git('-C', dir, 'config', 'user.name', 'tbd tests');
+  await git('-C', dir, 'config', 'user.email', 'tests@example.invalid');
+  await git('-C', dir, 'config', 'commit.gpgsign', 'false');
+}
+
+/** A repository with one commit, so `git worktree add` has something to branch from. */
+async function initRepo(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true });
+  await git('-C', dir, 'init', '-q');
+  await configureCommits(dir);
+  await git('-C', dir, 'commit', '-q', '--allow-empty', '-m', 'init');
+}
+
+/** A checkout whose git dir sits outside it, the shape a bare dirname resolves wrong. */
+async function initSeparateGitDirRepo(checkout: string, gitDir: string): Promise<void> {
+  await git('-C', dirname(checkout), 'init', '-q', `--separate-git-dir=${gitDir}`, checkout);
+  await configureCommits(checkout);
+  await git('-C', checkout, 'commit', '-q', '--allow-empty', '-m', 'init');
+}
+
+describe('main worktree resolution', () => {
+  let root: string;
+  let main: string;
+  let linked: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'tbd-wt-'));
+    main = join(root, 'main');
+    // Deliberately a sibling of the checkout rather than a child. Five of six real
+    // worktrees measured on one machine lived outside their checkout, which is what
+    // rules out directory-walking as an implementation.
+    linked = join(root, 'linked');
+    await initRepo(main);
+    await git('-C', main, 'worktree', 'add', '-q', '-b', 'wt', linked);
+    delete process.env.LINEAR_API_KEY;
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+    delete process.env.LINEAR_API_KEY;
+  });
+
+  it('resolves the main checkout from a linked worktree outside it', async () => {
+    await expect(resolveMainWorktree(linked)).resolves.toBe(await realish(main));
+  });
+
+  it('resolves the main checkout from the main checkout, so callers need no special case', async () => {
+    await expect(resolveMainWorktree(main)).resolves.toBe(await realish(main));
+  });
+
+  it('returns nothing outside a git repository rather than raising', async () => {
+    const outside = await mkdtemp(join(tmpdir(), 'tbd-nogit-'));
+    try {
+      await expect(resolveMainWorktree(outside)).resolves.toBeUndefined();
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects the candidate under --separate-git-dir instead of reaching a sibling directory', async () => {
+    // The common dir's parent here is `root`, which is not a checkout of this
+    // repository. A bare dirname would hand back a directory holding unrelated
+    // projects, which is exactly the cross-project `.env` read this rules out.
+    const sepRoot = await mkdtemp(join(tmpdir(), 'tbd-sep-'));
+    const sepMain = join(sepRoot, 'checkout');
+    const sepGitDir = join(sepRoot, 'gitdir');
+    try {
+      await initSeparateGitDirRepo(sepMain, sepGitDir);
+      await expect(resolveMainWorktree(sepMain)).resolves.toBeUndefined();
+    } finally {
+      await rm(sepRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('credential resolution across worktrees', () => {
+  let root: string;
+  let main: string;
+  let linked: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'tbd-wtcred-'));
+    main = join(root, 'main');
+    linked = join(root, 'linked');
+    await initRepo(main);
+    await git('-C', main, 'worktree', 'add', '-q', '-b', 'wt', linked);
+    delete process.env.LINEAR_API_KEY;
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+    delete process.env.LINEAR_API_KEY;
+  });
+
+  it('reads the main checkout .env from a linked worktree that has none', async () => {
+    await writeFile(join(main, '.env'), `LINEAR_API_KEY=${MAIN_SECRET}\n`);
+
+    const credential = await resolveCredential('linear', linked);
+
+    expect(credential?.value).toBe(MAIN_SECRET);
+    expect(credential?.source).toBe('dotenv');
+    expect(credential?.path).toBe(join(await realish(main), '.env'));
+  });
+
+  it('prefers a worktree-local .env over the main one', async () => {
+    await writeFile(join(main, '.env'), `LINEAR_API_KEY=${MAIN_SECRET}\n`);
+    await writeFile(join(linked, '.env'), `LINEAR_API_KEY=${LOCAL_SECRET}\n`);
+
+    const credential = await resolveCredential('linear', linked);
+
+    expect(credential?.value).toBe(LOCAL_SECRET);
+    expect(credential?.path).toBe(join(linked, '.env'));
+  });
+
+  it('prefers an exported variable over both files', async () => {
+    await writeFile(join(main, '.env'), `LINEAR_API_KEY=${MAIN_SECRET}\n`);
+    await writeFile(join(linked, '.env'), `LINEAR_API_KEY=${LOCAL_SECRET}\n`);
+    process.env.LINEAR_API_KEY = EXPORTED_SECRET;
+
+    const credential = await resolveCredential('linear', linked);
+
+    expect(credential?.value).toBe(EXPORTED_SECRET);
+    expect(credential?.source).toBe('env');
+    expect(credential?.path).toBeUndefined();
+  });
+
+  it('finds nothing when neither worktree holds a key', async () => {
+    await expect(resolveCredential('linear', linked)).resolves.toBeUndefined();
+  });
+
+  it('does not read a .env outside the repository under --separate-git-dir', async () => {
+    const sepRoot = await mkdtemp(join(tmpdir(), 'tbd-sepcred-'));
+    const sepMain = join(sepRoot, 'checkout');
+    const sepGitDir = join(sepRoot, 'gitdir');
+    try {
+      await initSeparateGitDirRepo(sepMain, sepGitDir);
+      // Sitting where a bare dirname would land. Nothing may read it.
+      await writeFile(join(sepRoot, '.env'), `LINEAR_API_KEY=${MAIN_SECRET}\n`);
+
+      await expect(resolveCredential('linear', sepMain)).resolves.toBeUndefined();
+    } finally {
+      await rm(sepRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves behavior unchanged outside a git repository', async () => {
+    const outside = await mkdtemp(join(tmpdir(), 'tbd-nogitcred-'));
+    try {
+      await expect(resolveCredential('linear', outside)).resolves.toBeUndefined();
+
+      await writeFile(join(outside, '.env'), `LINEAR_API_KEY=${LOCAL_SECRET}\n`);
+      const credential = await resolveCredential('linear', outside);
+      expect(credential?.value).toBe(LOCAL_SECRET);
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('status reporting of the credential source', () => {
+  let root: string;
+  let main: string;
+  let linked: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'tbd-wtstatus-'));
+    main = join(root, 'main');
+    linked = join(root, 'linked');
+    await initRepo(main);
+    await git('-C', main, 'worktree', 'add', '-q', '-b', 'wt', linked);
+    delete process.env.LINEAR_API_KEY;
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+    delete process.env.LINEAR_API_KEY;
+  });
+
+  it('names the main checkout file it loaded, and never prints the key', async () => {
+    await writeFile(join(main, '.gitignore'), '.env\n');
+    await writeFile(join(main, '.env'), `LINEAR_API_KEY=${MAIN_SECRET}\n`);
+
+    const status = await integrationStatus({ config: config(), repoRoot: linked });
+    const credential = status.providers[0]?.findings.find((f) => f.label === 'credential');
+
+    expect(credential?.state).toBe('ok');
+    expect(credential?.detail).toContain(join(await realish(main), '.env'));
+    expect(credential?.detail).not.toContain(MAIN_SECRET);
+  });
+
+  it('reports .env safety for the file actually read, not the empty local one', async () => {
+    // No .gitignore anywhere, so the file in use is exposed. Reporting on the
+    // worktree's absent `.env` would call that safe.
+    await writeFile(join(main, '.env'), `LINEAR_API_KEY=${MAIN_SECRET}\n`);
+
+    const status = await integrationStatus({ config: config(), repoRoot: linked });
+
+    expect(status.envFile.state).toBe('error');
+    expect(status.envFile.detail).toContain('NOT gitignored');
+    expect(status.envFile.detail).toContain(join(await realish(main), '.env'));
+  });
+
+  it('says nothing about another file when the local .env answered', async () => {
+    await writeFile(join(linked, '.gitignore'), '.env\n');
+    await writeFile(join(linked, '.env'), `LINEAR_API_KEY=${LOCAL_SECRET}\n`);
+
+    const status = await integrationStatus({ config: config(), repoRoot: linked });
+
+    expect(status.envFile.state).toBe('ok');
+    expect(status.envFile.detail).toBe('present and gitignored');
+  });
+});

--- a/packages/tbd/tests/worktree-credentials.test.ts
+++ b/packages/tbd/tests/worktree-credentials.test.ts
@@ -30,9 +30,9 @@ async function realish(dir: string): Promise<string> {
   return realpath(dir).catch(() => dir);
 }
 
-const MAIN_SECRET = 'lin_api_mainworktree_0123456789';
-const LOCAL_SECRET = 'lin_api_worktreelocal_9876543210';
-const EXPORTED_SECRET = 'lin_api_exported_abcdefabcdef';
+const MAIN_SECRET = 'lin_api_test_main';
+const LOCAL_SECRET = 'lin_api_test_local';
+const EXPORTED_SECRET = 'lin_api_test_exported';
 
 function config(): Config {
   return {

--- a/packages/tbd/tests/worktree-credentials.test.ts
+++ b/packages/tbd/tests/worktree-credentials.test.ts
@@ -30,9 +30,9 @@ async function realish(dir: string): Promise<string> {
   return realpath(dir).catch(() => dir);
 }
 
-const MAIN_SECRET = 'lin_api_test_main';
-const LOCAL_SECRET = 'lin_api_test_local';
-const EXPORTED_SECRET = 'lin_api_test_exported';
+const MAIN_VALUE = 'main-worktree-placeholder';
+const LOCAL_VALUE = 'worktree-local-placeholder';
+const EXPORTED_VALUE = 'exported-placeholder';
 
 function config(): Config {
   return {
@@ -157,33 +157,33 @@ describe('credential resolution across worktrees', () => {
   });
 
   it('reads the main checkout .env from a linked worktree that has none', async () => {
-    await writeFile(join(main, '.env'), `LINEAR_API_KEY=${MAIN_SECRET}\n`);
+    await writeFile(join(main, '.env'), `LINEAR_API_KEY=${MAIN_VALUE}\n`);
 
     const credential = await resolveCredential('linear', linked);
 
-    expect(credential?.value).toBe(MAIN_SECRET);
+    expect(credential?.value).toBe(MAIN_VALUE);
     expect(credential?.source).toBe('dotenv');
     expect(credential?.path).toBe(join(await realish(main), '.env'));
   });
 
   it('prefers a worktree-local .env over the main one', async () => {
-    await writeFile(join(main, '.env'), `LINEAR_API_KEY=${MAIN_SECRET}\n`);
-    await writeFile(join(linked, '.env'), `LINEAR_API_KEY=${LOCAL_SECRET}\n`);
+    await writeFile(join(main, '.env'), `LINEAR_API_KEY=${MAIN_VALUE}\n`);
+    await writeFile(join(linked, '.env'), `LINEAR_API_KEY=${LOCAL_VALUE}\n`);
 
     const credential = await resolveCredential('linear', linked);
 
-    expect(credential?.value).toBe(LOCAL_SECRET);
+    expect(credential?.value).toBe(LOCAL_VALUE);
     expect(credential?.path).toBe(join(linked, '.env'));
   });
 
   it('prefers an exported variable over both files', async () => {
-    await writeFile(join(main, '.env'), `LINEAR_API_KEY=${MAIN_SECRET}\n`);
-    await writeFile(join(linked, '.env'), `LINEAR_API_KEY=${LOCAL_SECRET}\n`);
-    process.env.LINEAR_API_KEY = EXPORTED_SECRET;
+    await writeFile(join(main, '.env'), `LINEAR_API_KEY=${MAIN_VALUE}\n`);
+    await writeFile(join(linked, '.env'), `LINEAR_API_KEY=${LOCAL_VALUE}\n`);
+    process.env.LINEAR_API_KEY = EXPORTED_VALUE;
 
     const credential = await resolveCredential('linear', linked);
 
-    expect(credential?.value).toBe(EXPORTED_SECRET);
+    expect(credential?.value).toBe(EXPORTED_VALUE);
     expect(credential?.source).toBe('env');
     expect(credential?.path).toBeUndefined();
   });
@@ -199,7 +199,7 @@ describe('credential resolution across worktrees', () => {
     try {
       await initSeparateGitDirRepo(sepMain, sepGitDir);
       // Sitting where a bare dirname would land. Nothing may read it.
-      await writeFile(join(sepRoot, '.env'), `LINEAR_API_KEY=${MAIN_SECRET}\n`);
+      await writeFile(join(sepRoot, '.env'), `LINEAR_API_KEY=${MAIN_VALUE}\n`);
 
       await expect(resolveCredential('linear', sepMain)).resolves.toBeUndefined();
     } finally {
@@ -212,9 +212,9 @@ describe('credential resolution across worktrees', () => {
     try {
       await expect(resolveCredential('linear', outside)).resolves.toBeUndefined();
 
-      await writeFile(join(outside, '.env'), `LINEAR_API_KEY=${LOCAL_SECRET}\n`);
+      await writeFile(join(outside, '.env'), `LINEAR_API_KEY=${LOCAL_VALUE}\n`);
       const credential = await resolveCredential('linear', outside);
-      expect(credential?.value).toBe(LOCAL_SECRET);
+      expect(credential?.value).toBe(LOCAL_VALUE);
     } finally {
       await rm(outside, { recursive: true, force: true });
     }
@@ -242,20 +242,20 @@ describe('status reporting of the credential source', () => {
 
   it('names the main checkout file it loaded, and never prints the key', async () => {
     await writeFile(join(main, '.gitignore'), '.env\n');
-    await writeFile(join(main, '.env'), `LINEAR_API_KEY=${MAIN_SECRET}\n`);
+    await writeFile(join(main, '.env'), `LINEAR_API_KEY=${MAIN_VALUE}\n`);
 
     const status = await integrationStatus({ config: config(), repoRoot: linked });
     const credential = status.providers[0]?.findings.find((f) => f.label === 'credential');
 
     expect(credential?.state).toBe('ok');
     expect(credential?.detail).toContain(join(await realish(main), '.env'));
-    expect(credential?.detail).not.toContain(MAIN_SECRET);
+    expect(credential?.detail).not.toContain(MAIN_VALUE);
   });
 
   it('reports .env safety for the file actually read, not the empty local one', async () => {
     // No .gitignore anywhere, so the file in use is exposed. Reporting on the
     // worktree's absent `.env` would call that safe.
-    await writeFile(join(main, '.env'), `LINEAR_API_KEY=${MAIN_SECRET}\n`);
+    await writeFile(join(main, '.env'), `LINEAR_API_KEY=${MAIN_VALUE}\n`);
 
     const status = await integrationStatus({ config: config(), repoRoot: linked });
 
@@ -266,7 +266,7 @@ describe('status reporting of the credential source', () => {
 
   it('says nothing about another file when the local .env answered', async () => {
     await writeFile(join(linked, '.gitignore'), '.env\n');
-    await writeFile(join(linked, '.env'), `LINEAR_API_KEY=${LOCAL_SECRET}\n`);
+    await writeFile(join(linked, '.env'), `LINEAR_API_KEY=${LOCAL_VALUE}\n`);
 
     const status = await integrationStatus({ config: config(), repoRoot: linked });
 


### PR DESCRIPTION
## Summary

In a linked git worktree, tbd reported `LINEAR_API_KEY not found` even when the key sat in the repository's `.env`. `.env` is gitignored, and gitignored files do not propagate to worktrees, so a fully configured repository looked unconfigured from any worktree of it.

Credential resolution gains a third layer after the process environment and this working tree's `.env`: the main worktree's `.env`, resolved through git and verified before use. Status now names the exact file a credential came from.

Reproduced live in this repository: a worktree of `jlevy/tbd` reported the key missing while `/Users/levy/wrk/github/tbd/.env` held a working one.

## Changes

- **`lib/paths.ts`** — `resolveMainWorktree(baseDir)`, built on the existing `resolveGitCommonDir`. Returns undefined rather than throwing outside a repository or when `git` is unavailable.
- **`integrations/core/credentials.ts`** — layer 3 of the resolution order, and `ResolvedCredential.path` carrying the file a `dotenv` value came from.
- **`integrations/core/status.ts`** — the credential finding names its source path, and the `.env` safety finding reports on the file actually read rather than always the current directory.
- **`docs/shortcuts/standard/setup-linear.md`** — joining from a worktree needs no per-worktree key.
- **Spec** — `plan-2026-08-19-worktree-env-credential-resolution.md`.

### Why the obvious mechanism needed a guard

The epic proposed `dirname "$(git rev-parse --path-format=absolute --git-common-dir)"`, on the grounds that `--git-common-dir` cannot leave the repository. Measured, it can:

| Repository shape | `dirname(--git-common-dir)` | Correct? |
| --- | --- | --- |
| Normal repo, main checkout | the checkout | yes |
| Normal repo, linked worktree outside it | the main checkout | yes |
| `--separate-git-dir`, main checkout | the git dir's parent | **no** |
| `--separate-git-dir`, linked worktree | the git dir's parent | **no** |

Under `--separate-git-dir` the dirname lands on an unrelated sibling directory, which is exactly the cross-project `.env` read the approach was chosen to rule out. `git worktree list --porcelain` shares the flaw: under that shape its first entry reports the git dir rather than a checkout.

So the candidate is verified rather than trusted. Asked from inside it, git must agree both that it is a worktree root and that it belongs to the repository we started from. That costs a linked worktree of a `--separate-git-dir` repository its fallback, which is the right trade; its main checkout is unaffected because layer 2 already covers it.

Directory-walking was rejected for a separate reason recorded in the epic: five of six real worktrees measured on one machine lived outside their checkout, so a walk-up would not have reached the repository at all.

### Why the safety finding moved

`envFileFinding` asked only about the current working tree. Once a credential can come from elsewhere, vouching for a local file nobody read while the one in use goes unexamined is how a committed key stays invisible. It now follows the file that answered.

## Test Plan

- [x] **Quality gate** — `pnpm run ci:quality`: prettier, flowmark-rs, `tsc --noEmit` on both tsconfigs, `eslint --max-warnings 0`, config-contract probe.
- [x] **Build** — `pnpm build:check`.
- [x] **Full suite** — `pnpm test`: **2259 tests, 150 files, 0 failures**, run through the pre-push gate.
- [x] **Golden CLI suite** — `tryscript run 'tests/**/*.tryscript.md'`: **1101 passed**.
- [x] **New coverage** — 13 tests in `tests/worktree-credentials.test.ts`, over real `git worktree` checkouts created outside the main one rather than temp-directory stand-ins, since the whole question is what git reports about a directory:
  - main checkout resolves from a linked worktree outside it, and from the main checkout itself
  - key only in the main checkout resolves, and status names that path
  - worktree-local `.env` overrides the main one; an exported variable overrides both
  - nothing found when neither worktree holds a key
  - `--separate-git-dir` rejects the candidate and reads no `.env` outside the repository
  - outside a git repository, behavior unchanged and no new error
  - status reports `.env` safety for the file actually read, and says nothing extra when the local file answered
- [x] **Verified live against the real workspace**, from a worktree with no `.env` of its own and `LINEAR_API_KEY` explicitly unset, so layer 3 is what answers:

  ```
  ✓ .env: present and gitignored (/Users/levy/wrk/github/tbd/.env)

  linear:
    ✓ enabled: yes
    ✓ target: OS
    ✓ credential: ********hGDg from /Users/levy/wrk/github/tbd/.env
    ✓ reachable: Joshua Levy @ Finterm (team OS)
  ```

  The same command on `main` reports `✗ credential: LINEAR_API_KEY not found` and `.env: not present`, which is the bug.
- [x] **CI green** on macOS, Ubuntu (Node 22.12 and 24), and Windows, plus Coverage & Lint, Benchmark, and DeepSource.
- [x] **Hooks respected** — pre-commit and the full pre-push gate on every commit; no `--no-verify`.

### A note on flaky runs during development

Intermediate full-suite runs on a saturated machine (load average peaked above 60) produced varying failures: 5s/30s timeouts in `worktree-health`, `rescue-divergence`, `golden-output`, `git-remote`, a `performance` assertion at 604ms against a 500ms budget, and in tryscript a data-sync lock losing ownership plus `spawn /bin/sh ENOENT`. None of those files reference the changed code, each passed in isolation, and the final gated run on a settled machine was green across all 2259 tests. Recording it here so the pattern is recognizable rather than rediscovered.

The secrets analyzer also flagged the test fixtures twice. The placeholders originally carried the `lin_api_` vendor prefix and lived in constants named `*_SECRET`, either of which reads as a hardcoded credential. Since the code under test never inspects the format, they are now plain descriptive placeholders.

## Related Beads

| Bead | |
| --- | --- |
| `tbd-30t7` | epic: resolve `.env` from the main worktree ([OS-350](https://linear.app/finterm-ai/issue/OS-350)) |
| `tbd-mcw6` | main-worktree resolver |
| `tbd-fzm7` | credential fallback |
| `tbd-lxjr` | source reporting |
| `tbd-0tc3` | tests and setup guidance |

All five are closed by this change.

**Not in scope:** `tbd-k0rd` ([OS-351](https://linear.app/finterm-ai/issue/OS-351), assignee clearing) is deliberately excluded. It collides with PR #245 in all five files it would touch, and #245 already claims the `skipPush` generalization it needs. It is handed to that PR's author rather than raced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches secret resolution and cross-directory `.env` reads; mitigated by git-validated main-worktree lookup and explicit path reporting, with dedicated tests for separate-git-dir and precedence.
> 
> **Overview**
> Linked git worktrees no longer falsely report missing integration keys when `LINEAR_API_KEY` (and similar) live only in the main checkout’s gitignored `.env`.
> 
> **Credential resolution** adds a third layer after process env and the current tree’s `.env`: the **main worktree’s `.env`**, found via new `resolveMainWorktree()` in `paths.ts`. The candidate from `dirname(git-common-dir)` is validated (worktree root + same repo) so `--separate-git-dir` repos never read a sibling project’s secrets. `ResolvedCredential` now includes an optional **`path`** for dotenv sources.
> 
> **`integration status`** prints the full path for dotenv credentials and runs the `.env` gitignore safety check against the file actually used (and both local + main when credentials come from elsewhere).
> 
> Docs: active spec plus **setup-linear** guidance that worktrees inherit the main checkout key without duplicating it. **13 integration tests** use real `git worktree` fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4d5e107ce89a8f486e726e186990af67bb107e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->