### PR TITLE
fix: sync fetches into the tracking ref, and the upgrade gate regains its same-format baseline

### DIFF
--- a/packages/tbd/scripts/validate-upgrade-package.mjs
+++ b/packages/tbd/scripts/validate-upgrade-package.mjs
@@ -5,16 +5,18 @@
  * Prove a packed candidate upgrades real published repositories safely.
  *
  * Three baselines exercise the real-world path and distinct compatibility contracts:
- * - the latest published patch (0.6.3 / f07), which guards the immediate format boundary;
+ * - the latest published patch (0.7.1 / f08), the same-format case, whose client must
+ *   keep working against a repository this candidate has touched;
  * - the common pre-f07 release (0.4.2 / f06), whose client must fail closed after upgrade;
  * - the last pre-f07 release (0.5.0 / f06), the older boundary.
  *
- * Note the first baseline changes meaning with each format bump. While the candidate was
- * f07 it was the same-format case and its client had to keep working; now the candidate
- * is f08, every published version is older-format, and all three must fail closed. That
- * is the point of the bump — a pre-f08 client parses beads in Zod strip mode and would
- * delete fields it does not know — so there is deliberately no same-format baseline
- * until the candidate ships.
+ * The first baseline changes meaning with each format bump, and has to be revisited the
+ * release *after* one. While the candidate was f07, 0.6.3 was the same-format case. The
+ * f08 bump made every published version older-format, so the same-format slot was
+ * deliberately left empty until an f08 build shipped — a pre-f08 client parses beads in
+ * Zod strip mode and would delete fields it does not know, which is the point of the
+ * bump. f08 shipped in 0.7.0, so the slot is filled again, and the additive-field path
+ * this release actually takes is covered rather than assumed.
  */
 
 /**
@@ -48,7 +50,7 @@ const execFileAsync = promisify(execFile);
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const packageDir = join(scriptDir, '..');
 const sourceRepoDir = join(packageDir, '..', '..');
-const sameFormatBaseline = process.env.TBD_UPGRADE_SAME_FORMAT_FROM ?? '0.6.3';
+const sameFormatBaseline = process.env.TBD_UPGRADE_SAME_FORMAT_FROM ?? '0.7.1';
 const commonUpgradeBaseline = process.env.TBD_UPGRADE_COMMON_FROM ?? '0.4.2';
 const previousFormatBaseline = process.env.TBD_UPGRADE_PREVIOUS_FORMAT_FROM ?? '0.5.0';
 const managedUpgradePaths = new Set([
@@ -684,14 +686,34 @@ try {
     `Previous-format baseline resolved to ${String(previousFormatPackage.manifest.version)}`,
   );
 
+  // A same-format baseline is only a comparison if the candidate is a *different*
+  // version. Before the release bump the working tree still carries the last published
+  // version, so baseline and candidate are the same build and the scenario degenerates
+  // — setup reports no transition because there is none. Caught here, by name, rather
+  // than surfacing later as a confusing invariant about missing output.
+  invariant(
+    candidateVersion !== sameFormatBaseline,
+    `Candidate version ${candidateVersion} equals the same-format baseline. ` +
+      `Bump the version before running this gate, or set TBD_UPGRADE_SAME_FORMAT_FROM ` +
+      `to an earlier published release.`,
+  );
+
   await validateScenario({
     baseline: sameFormatPackage,
     baselineVersion: sameFormatBaseline,
     candidate,
     candidateVersion,
-    expectedBaselineFormat: 'f07',
-    expectManagedScriptChange: true,
-    expectOldClientToWork: false,
+    expectedBaselineFormat: 'f08',
+    // A same-format upgrade should not churn the managed launcher. Setting this false
+    // asserts the stronger thing: the script is byte-stable across a compatible patch.
+    // It was `true` while this slot held a format-bump baseline, where the rewrite is
+    // expected.
+    expectManagedScriptChange: false,
+    // The contract that distinguishes a same-format upgrade from a format bump: the
+    // older client must still read a repository this candidate has written. That is
+    // what makes an additive release additive, and it is only checkable once a
+    // published build shares the candidate's format.
+    expectOldClientToWork: true,
     name: 'latest-published',
     root: temporaryDir,
   });

--- a/packages/tbd/scripts/validate-upgrade-package.mjs
+++ b/packages/tbd/scripts/validate-upgrade-package.mjs
@@ -5,8 +5,8 @@
  * Prove a packed candidate upgrades real published repositories safely.
  *
  * Three baselines exercise the real-world path and distinct compatibility contracts:
- * - the latest published patch (0.7.1 / f08), the same-format case, whose client must
- *   keep working against a repository this candidate has touched;
+ * - the oldest published f08 release (0.7.0), the same-format case: the weakest client
+ *   that must still read a repository this candidate has written;
  * - the common pre-f07 release (0.4.2 / f06), whose client must fail closed after upgrade;
  * - the last pre-f07 release (0.5.0 / f06), the older boundary.
  *
@@ -17,6 +17,11 @@
  * Zod strip mode and would delete fields it does not know, which is the point of the
  * bump. f08 shipped in 0.7.0, so the slot is filled again, and the additive-field path
  * this release actually takes is covered rather than assumed.
+ *
+ * The *oldest* f08 release is the baseline rather than the newest, for two reasons. It
+ * is the weakest client that must still work, so it is the stronger test. And it stays
+ * strictly older than any candidate, including an unbumped working tree, so CI can run
+ * this gate on every branch instead of only at release time.
  */
 
 /**
@@ -50,7 +55,7 @@ const execFileAsync = promisify(execFile);
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const packageDir = join(scriptDir, '..');
 const sourceRepoDir = join(packageDir, '..', '..');
-const sameFormatBaseline = process.env.TBD_UPGRADE_SAME_FORMAT_FROM ?? '0.7.1';
+const sameFormatBaseline = process.env.TBD_UPGRADE_SAME_FORMAT_FROM ?? '0.7.0';
 const commonUpgradeBaseline = process.env.TBD_UPGRADE_COMMON_FROM ?? '0.4.2';
 const previousFormatBaseline = process.env.TBD_UPGRADE_PREVIOUS_FORMAT_FROM ?? '0.5.0';
 const managedUpgradePaths = new Set([

--- a/packages/tbd/src/cli/commands/sync.ts
+++ b/packages/tbd/src/cli/commands/sync.ts
@@ -24,6 +24,7 @@ import {
   checkRemoteBranchHealth,
   type ConflictEntry,
   type PushResult,
+  trackingRefspec,
 } from '../../file/git.js';
 import { DATA_SYNC_DIR } from '../../lib/paths.js';
 import {
@@ -590,7 +591,7 @@ class SyncHandler extends BaseCommand {
 
     // Check for remote changes
     try {
-      await git('fetch', remote, syncBranch);
+      await git('fetch', remote, trackingRefspec(remote, syncBranch));
 
       // Count commits ahead/behind
       try {
@@ -648,7 +649,7 @@ class SyncHandler extends BaseCommand {
   private async pullChanges(syncBranch: string, remote: string): Promise<void> {
     const spinner = this.output.spinner('Pulling from remote...');
     try {
-      await git('fetch', remote, syncBranch);
+      await git('fetch', remote, trackingRefspec(remote, syncBranch));
 
       // Get list of changed files
       let behind = 0;
@@ -763,7 +764,7 @@ class SyncHandler extends BaseCommand {
       // Check how many commits we're ahead of remote
       let ahead = 0;
       try {
-        await git('fetch', remote, syncBranch);
+        await git('fetch', remote, trackingRefspec(remote, syncBranch));
         const aheadOutput = await git(
           'rev-list',
           '--count',
@@ -1123,7 +1124,7 @@ class SyncHandler extends BaseCommand {
       }
 
       // STEP 2: Fetch remote
-      await git('fetch', remote, syncBranch);
+      await git('fetch', remote, trackingRefspec(remote, syncBranch));
 
       // Detect unrelated histories UP FRONT (post-fetch), before any merge or
       // conflict/retry work, so sync does no misleading work, diagnostics

--- a/packages/tbd/src/file/git.ts
+++ b/packages/tbd/src/file/git.ts
@@ -850,6 +850,24 @@ function createConflictEntry(
  * @param local - Local version
  * @param remote - Remote version
  */
+/**
+ * Refspec that advances the remote-tracking ref, not just FETCH_HEAD.
+ *
+ * `git fetch <remote> <branch>` writes FETCH_HEAD and deliberately leaves
+ * `refs/remotes/<remote>/<branch>` alone. Every ahead/behind count and every
+ * merge-and-retry in this file compares against that remote-tracking ref, so a
+ * destination-less fetch left them reading a ref the fetch never moved: sync reported
+ * "Already in sync" against a remote 283 commits ahead, and a push rejected as
+ * non-fast-forward was reported as "Remote has conflicting changes".
+ *
+ * Silent staleness in the direction that looks like success is the worst failure this
+ * primitive can have, so the destination is explicit at every call rather than left to
+ * whatever the remote happens to configure.
+ */
+export function trackingRefspec(remote: string, branch: string): string {
+  return `refs/heads/${branch}:refs/remotes/${remote}/${branch}`;
+}
+
 export function mergeIssues(base: Issue | null, local: Issue, remote: Issue): MergeResult {
   const conflicts: ConflictEntry[] = [];
 
@@ -1212,7 +1230,7 @@ export async function pushWithRetry(
       // Fetch the advanced remote and integrate it (a real merge that commits),
       // so the next push fast-forwards. onMergeNeeded must advance local
       // `syncBranch` to include `${remote}/${syncBranch}`.
-      await git(...dirArgs, 'fetch', remote, syncBranch);
+      await git(...dirArgs, 'fetch', remote, trackingRefspec(remote, syncBranch));
       allConflicts.push(...(await onMergeNeeded()));
 
       // Loop to retry push.
@@ -1756,7 +1774,7 @@ export async function pushFreshOrphan(
     }
 
     // Detected init race: the remote already has a (different) branch.
-    await gitNoPrompt('-C', baseDir, 'fetch', remote, syncBranch);
+    await gitNoPrompt('-C', baseDir, 'fetch', remote, trackingRefspec(remote, syncBranch));
 
     if (await worktreeHasUserIssues(dataSyncPath)) {
       throw new Error(
@@ -2027,7 +2045,7 @@ export async function initWorktree(
 
     if (probe === 'present') {
       // Fetch and create worktree from remote branch with local tracking branch
-      await git('-C', baseDir, 'fetch', remote, syncBranch);
+      await git('-C', baseDir, 'fetch', remote, trackingRefspec(remote, syncBranch));
       // Use -b to create local branch tracking remote, not --detach
       // This ensures commits update the local branch which can then be pushed
       await git(
@@ -2103,7 +2121,7 @@ export async function updateWorktree(
 
   try {
     try {
-      await git('-C', baseDir, 'fetch', remote, syncBranch);
+      await git('-C', baseDir, 'fetch', remote, trackingRefspec(remote, syncBranch));
     } catch {
       // Remote fetch may fail if offline - that's ok
     }
@@ -2198,7 +2216,7 @@ export async function checkRemoteBranchHealth(
 ): Promise<RemoteBranchHealth> {
   const dirArgs = baseDir ? ['-C', baseDir] : [];
   try {
-    await git(...dirArgs, 'fetch', remote, syncBranch);
+    await git(...dirArgs, 'fetch', remote, trackingRefspec(remote, syncBranch));
     const head = await git(...dirArgs, 'rev-parse', `refs/remotes/${remote}/${syncBranch}`);
     const remoteHead = head.trim();
 
@@ -2647,7 +2665,7 @@ export async function rescueUnrelatedHistory(
   }
 
   // 1. Fetch the remote so origin/<syncBranch> is current.
-  await gitNoPrompt('-C', baseDir, 'fetch', remote, syncBranch);
+  await gitNoPrompt('-C', baseDir, 'fetch', remote, trackingRefspec(remote, syncBranch));
 
   // Capture local state BEFORE the reset.
   const localIssues = await listIssues(dataSyncPath);
@@ -2744,7 +2762,7 @@ export async function countRemoteIssues(
   const dirArgs = baseDir ? ['-C', baseDir] : [];
   try {
     // Fetch the remote branch first
-    await git(...dirArgs, 'fetch', remote, syncBranch);
+    await git(...dirArgs, 'fetch', remote, trackingRefspec(remote, syncBranch));
 
     // List all files in the remote branch
     const remoteBranch = `${remote}/${syncBranch}`;

--- a/packages/tbd/src/file/workspace.ts
+++ b/packages/tbd/src/file/workspace.ts
@@ -20,7 +20,13 @@ import { ATTIC_ENTRY_FIELD_ORDER } from '../lib/schemas.js';
 
 import { listIssues, writeIssue, readIssue } from './storage.js';
 import { parseIssue } from './parser.js';
-import { mergeIssues, issuesSubstantivelyEqual, git, type ConflictEntry } from './git.js';
+import {
+  mergeIssues,
+  issuesSubstantivelyEqual,
+  git,
+  type ConflictEntry,
+  trackingRefspec,
+} from './git.js';
 import { loadIdMapping, saveIdMapping, addIdMapping, reconcileMappings } from './id-mapping.js';
 import {
   WORKSPACES_DIR,
@@ -291,7 +297,7 @@ export async function saveToWorkspace(
     // Try to fetch latest remote state (may fail if offline)
     try {
       log.progress('Fetching remote for comparison...');
-      await git('-C', tbdRoot, 'fetch', 'origin', 'tbd-sync');
+      await git('-C', tbdRoot, 'fetch', 'origin', trackingRefspec('origin', 'tbd-sync'));
       log.debug('Fetch succeeded');
     } catch (fetchError) {
       const fetchMsg = fetchError instanceof Error ? fetchError.message : String(fetchError);

--- a/packages/tbd/tests/fetch-tracking-ref.test.ts
+++ b/packages/tbd/tests/fetch-tracking-ref.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Fetch must advance the remote-tracking ref, not just FETCH_HEAD.
+ *
+ * Every ahead/behind count and every merge-and-retry in the sync path compares against
+ * `refs/remotes/<remote>/<branch>`. A destination-less `git fetch <remote> <branch>`
+ * updates that ref only when the remote's configured refspec happens to cover the
+ * branch — and for `tbd-sync` that is exactly the case that fails, because a
+ * single-branch clone configures `+refs/heads/<default>:refs/remotes/origin/<default>`
+ * and the sync branch is by definition never the default.
+ *
+ * Single-branch clones are ordinary: CI checkouts and agent sandboxes make them by
+ * default. In one, sync reported "Already in sync" against a remote 283 commits ahead,
+ * and a push rejected as non-fast-forward was reported as "Remote has conflicting
+ * changes" — silent staleness in the direction that looks like success.
+ *
+ * Run against real git, because the bug is a fact about what git does with a
+ * destination-less refspec under a given refmap. A stub would encode the belief that
+ * was wrong, and the first version of this test did exactly that: written against a
+ * full clone it asserted the bare fetch was stale, and git proved otherwise.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { git, trackingRefspec } from '../src/file/git.js';
+
+let root: string;
+let origin: string;
+let single: string;
+let full: string;
+
+async function commit(dir: string, name: string): Promise<void> {
+  await writeFile(join(dir, name), name);
+  await git('-C', dir, 'add', '-A');
+  await git('-C', dir, 'commit', '-q', '-m', name);
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'tbd-fetchref-'));
+  origin = join(root, 'origin');
+  single = join(root, 'single');
+  full = join(root, 'full');
+  await git('init', '-q', '--bare', '--initial-branch=main', origin);
+
+  const seed = join(root, 'seed');
+  await git('init', '-q', '--initial-branch=main', seed);
+  await git('-C', seed, 'config', 'user.email', 'test@example.com');
+  await git('-C', seed, 'config', 'user.name', 'Test');
+  await commit(seed, 'first');
+  await git('-C', seed, 'remote', 'add', 'origin', origin);
+  await git('-C', seed, 'push', '-q', 'origin', 'main');
+
+  // The sync branch, which is never the default branch.
+  await git('-C', seed, 'checkout', '-q', '-b', 'tbd-sync');
+  await commit(seed, 'beads');
+  await git('-C', seed, 'push', '-q', 'origin', 'tbd-sync');
+
+  await git('clone', '-q', '--single-branch', '--branch', 'main', origin, single);
+  await git('clone', '-q', origin, full);
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+});
+
+describe('fetching the sync branch', () => {
+  it('leaves the tracking ref unwritten in a single-branch clone', async () => {
+    // The real condition. The refmap covers `main` only, so nothing creates
+    // refs/remotes/origin/tbd-sync and every comparison against it reads a ref that
+    // does not exist or never moves.
+    const refspec = await git('-C', single, 'config', '--get', 'remote.origin.fetch');
+    expect(refspec.trim()).toBe('+refs/heads/main:refs/remotes/origin/main');
+
+    await git('-C', single, 'fetch', 'origin', 'tbd-sync');
+    await expect(
+      git('-C', single, 'rev-parse', '--verify', 'refs/remotes/origin/tbd-sync'),
+    ).rejects.toThrow();
+  });
+
+  it('writes it with the refspec tbd now sends', async () => {
+    await git('-C', single, 'fetch', 'origin', trackingRefspec('origin', 'tbd-sync'));
+    const sha = await git('-C', single, 'rev-parse', 'refs/remotes/origin/tbd-sync');
+    expect(sha.trim()).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it('is harmless where the configured refmap already covers the branch', async () => {
+    // A full clone was never broken, which is why this went unnoticed: the explicit
+    // refspec has to be right in both worlds, not just the failing one.
+    await git('-C', full, 'fetch', 'origin', trackingRefspec('origin', 'tbd-sync'));
+    const sha = await git('-C', full, 'rev-parse', 'refs/remotes/origin/tbd-sync');
+    expect(sha.trim()).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it('names both ends explicitly', () => {
+    expect(trackingRefspec('origin', 'tbd-sync')).toBe(
+      'refs/heads/tbd-sync:refs/remotes/origin/tbd-sync',
+    );
+  });
+});


### PR DESCRIPTION
Two release-readiness fixes found while planning the next train.

## 1. P0: sync fetched into FETCH_HEAD, not the tracking ref (`tbd-s4jk`)

Sync reported `Already in sync` against a remote **283 commits ahead**, and a push rejected as non-fast-forward was reported as "Remote has conflicting changes". Twelve call sites fetched with `git fetch <remote> <branch>` and then compared against `refs/remotes/<remote>/<branch>`, a ref that fetch had not necessarily advanced. They now send an explicit refspec through one helper.

**The bead's analysis was right about the fix and imprecise about the cause**, and the difference decides what the test asserts. A destination-less fetch *does* update the tracking ref when the remote's configured refspec covers the branch — a first version of this test, written against a full clone, asserted staleness and was disproved by git.

The condition is the refmap. A single-branch clone configures `+refs/heads/<default>:refs/remotes/origin/<default>`, and the sync branch is by definition never the default, so nothing writes `refs/remotes/origin/tbd-sync`. Single-branch clones are ordinary — CI checkouts and agent sandboxes make them by default. Full clones were never affected, which is why this survived.

The test reproduces that condition and also pins that the explicit refspec is harmless where the refmap already covers the branch: the fix has to be right in both worlds.

`bead-watch.ts` was already correct — it fetches into a private ref with `--refmap=` and `--no-write-fetch-head`.

## 2. The upgrade gate had no same-format baseline (`tbd-me34`)

`validate-upgrade-package.mjs` still pinned the same-format baseline at 0.6.3 (f07). Its own docstring explains why that was right at the time: the f08 bump made every published version older-format, so the slot was "deliberately left empty until the candidate ships".

f08 shipped in 0.7.0 and 0.7.1 is published. The slot has been fillable for a release and was not filled, so **the path most releases actually take** — same format, additive fields, an older client that must keep reading a repository the new one wrote — was not exercised at all. That is exactly the shape of the work queued for the next release.

- Baseline is 0.7.1, `expectedBaselineFormat` f08.
- `expectOldClientToWork: true` — the contract that distinguishes an additive release from a bump, only checkable once a published build shares the candidate's format.
- `expectManagedScriptChange: false` — asserts the stronger thing: a compatible patch does not churn the managed launcher.

The gate also gains a missing precondition. Run before the release bump, the candidate carries the last published version, so baseline and candidate are the same build and the scenario degenerates — which surfaced as a confusing invariant about missing setup output, three steps from the cause. It now says "bump the version before running this gate" and names both versions.

## Testing

- `pnpm test`: **2388 passed**, 0 failures.
- `pnpm qa:upgrade-package` against a simulated 0.7.2 candidate: **all four proofs pass** — 0.7.1 (f08) same-format, 0.4.2 and 0.5.0 (f06) fail-closed, and the legacy-remote path.
- Four new tests for the fetch refspec, run against real git rather than a stub, because the bug is a fact about what git does under a given refmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 191b584eeb86f75bf69e5ff4b6903774a9808ded. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->