### PR TITLE
docs: cover Linear's GitHub app in setup, drop the real-time disclaimers

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ The web view and Linear sync complete the picture: agents and humans share one d
 git-native task layer, visible from the terminal, the browser, and your tracker.
 
 On multi-agent style: unstructured agent loops like
-[Gas Town](https://github.com/steveyegge/gastown) and
 [Ralph Wiggum](https://github.com/anthropics/claude-code/tree/main/plugins/ralph-wiggum)
 seem great for rapid prototyping, but so far, for code where quality or scale matters,
 I’ve not fully embraced unstructured automation (e.g. 20+ concurrent agents or Ralph
@@ -681,15 +680,11 @@ merge conflicts, and multi-agent workflows.
 If you already use Beads, `tbd setup --from-beads` migrates you to `tbd`. This imports
 and sets up your `.tbd` directory and preserves the IDs of all issues.
 
-**Scope:** `tbd` focuses on the *durable layer*—issue tracking, specs, and knowledge
-that persist across sessions and live in git—and builds coordination on top of it:
-`tbd watch` wakes agents when bead state changes, `tbd web` shows the board live, and
-`tbd integration sync` keeps an external tracker current.
-Sub-second messaging and atomic claims are a separate problem; tools like
-[Agent Mail](https://github.com/Dicklesworthstone/mcp_agent_mail) and
-[Gas Town](https://github.com/steveyegge/gastown) address that space and are
-complementary to `tbd`. See the [design doc](packages/tbd/docs/tbd-design.md) for a
-detailed comparison.
+**Scope:** `tbd` focuses on the *durable layer*, meaning issue tracking, specs, and
+knowledge that persist across sessions and live in git, and builds coordination on top
+of it: `tbd watch` wakes agents when bead state changes, `tbd web` shows the board live,
+and `tbd integration sync` keeps an external tracker current.
+See the [design doc](packages/tbd/docs/tbd-design.md) for a detailed comparison.
 
 ### Can my team see beads without using the CLI?
 

--- a/packages/tbd/docs/shortcuts/standard/setup-linear.md
+++ b/packages/tbd/docs/shortcuts/standard/setup-linear.md
@@ -239,12 +239,71 @@ If you hit it, re-read the dry run before adding `--yes`.
 After the first sync, plain `tbd sync` includes enabled trackers automatically, so a
 session-end `tbd sync` keeps Linear current with no extra command.
 
+## Step 6 (optional): Linear’s own GitHub app
+
+Everything above is complete without this step.
+tbd’s sync needs one credential, `LINEAR_API_KEY`, and never speaks to GitHub.
+
+Linear’s own GitHub app changes what a mirrored issue can do, not how tbd syncs.
+With it installed, a pull request whose title, branch, or body names a Linear issue
+(`Fixes FIN-123`) links itself to that issue, and the team’s pull request automation
+moves the issue as the pull request opens, is reviewed, and merges.
+Since tbd already maps a completed Linear state back onto the bead, a merge can travel
+all the way to a closed bead without anyone touching either tracker.
+
+**It sits on a different axis from tbd’s configuration:**
+
+| Aspect | tbd’s Linear sync | Linear’s GitHub app |
+| --- | --- | --- |
+| Scope | One repository | One **GitHub organization** |
+| Set up by | Whoever configures the repo | A GitHub org owner |
+| Credential | `LINEAR_API_KEY`, personal | None; an app installation |
+| Repeat per repo? | Yes | **No** |
+
+The scope row is the one people get wrong.
+The app is installed once per GitHub organization, granting either all repositories or a
+chosen subset, so a second tbd repository in the same organization needs no second
+install and no second decision.
+A repository administrator can install it for a single repository when org-wide access
+is not wanted.
+
+**You cannot complete this step for the user.** Installing a GitHub app is a browser
+flow that ends in an org owner approving the permissions.
+Linear does expose `integrationGithubConnect`, but its `code` and `installationId`
+arguments are outputs of that browser flow, so there is nothing to script ahead of it.
+Point the user at Linear’s [GitHub integration settings](https://linear.app/docs/github)
+and let them approve it.
+
+**Checking whether it is already installed is scriptable, and worth doing before you ask
+anyone for anything.** Either side answers:
+
+```bash
+# Linear's side: an entry with service "github" means a workspace is connected
+# (query { integrations { nodes { service createdAt } } } against api.linear.app/graphql)
+
+# GitHub's side, if the user's gh token can read the org:
+gh api /orgs/<org>/installations --jq '.installations[] | select(.app_slug|startswith("linear")) | {app_slug, repository_selection}'
+```
+
+A `repository_selection` of `all` means every repository in that organization is already
+covered, including any repository you are about to configure.
+
+**One warning that matters when tbd is mirroring.** The same settings page offers
+**GitHub Issues sync**, which creates Linear issues from GitHub issues.
+Leave it off for any team tbd mirrors into.
+tbd is already an issue writer for that team, and a second writer on one issue set
+produces duplicates and fights over state.
+Pull request linking and issue sync are separate features; this step is only the first.
+
 ## What to tell the user when you are done
 
 - Which case it was, and what you changed (config, `.env`, or nothing).
 - That the config is committed and shared, but their key is personal and stays local.
 - That `tbd sync` now covers Linear too.
 - For case A: that `.tbd/config.yml` needs committing so teammates inherit it.
+- Whether Linear’s GitHub app is already installed for their organization, and if it is
+  not, that pull request linking is available whenever an org owner wants it.
+  Say plainly that it is optional and that sync works without it.
 
 ## Troubleshooting
 
@@ -257,9 +316,10 @@ session-end `tbd sync` keeps Linear current with no extra command.
 | A teammate reports “This repository requires a newer version of tbd” | Working as intended: their tbd predates `f07` and would strip the block | Have them upgrade: `npm install -g get-tbd@latest` |
 | Sync says `nothing to do` but Linear looks stale | The policy does not select those beads | Check `policy.outbound` against what the user expects; `--dry-run integration sync --push` lists the selected set |
 | A bead reports malformed managed-block markers | A human edited inside the `⟦tbd⟧` … `⟦/tbd⟧` region in Linear | Repair the region in Linear (one `⟦tbd⟧` and one `⟦/tbd⟧`, in that order) or delete it entirely; the next sync rewrites it |
-
 | A reopened bead stops syncing, warning that its item is archived | Under the default `policy.archive: manual` the tracker’s archive is yours to manage | Restore the issue in Linear, or set `policy.archive: on_close` to let tbd own the lifecycle |
 | Newly mirrored issues all show today’s dates | A tbd older than 0.7.0 stamped them at sync time instead of sending the bead’s own | Upgrade; dates are sent on create, so already-mirrored issues keep their original stamps |
+| A pull request merged but its Linear issue did not move | Step 6 is not done, or the pull request never named the issue, or it used a non-closing word like `part of` | Confirm the app is installed for the organization, then check the pull request body for a closing word and the issue identifier |
+| Duplicate Linear issues appear for the same work | GitHub Issues sync is enabled on a team tbd already mirrors into | Turn Issues sync off for that team; tbd is the issue writer there |
 
 Full reference: the External Tracker Integrations section of `tbd docs`.
 

--- a/packages/tbd/docs/tbd-design.md
+++ b/packages/tbd/docs/tbd-design.md
@@ -269,11 +269,7 @@ The **issue tracking layer** has four core principles:
 Coordination and visibility build on that durable core: `tbd watch` (§4.14) wakes a
 process when selected bead state changes on the remote, `tbd web` (§4.15) serves a live
 read-only view, and `tbd integration` (§8.7) synchronizes beads with external trackers
-such as Linear. Git works best when latency is seconds, not milliseconds, and volume is
-thousands of issues, not millions, so sub-second messaging and atomic claim enforcement
-(as provided by [Agent Mail](https://github.com/Dicklesworthstone/mcp_agent_mail) and
-[Gas Town](https://github.com/steveyegge/gastown)) remain separate problems—ones that
-can be layered on top of tbd or handled by other tools.
+such as Linear.
 
 **Key characteristics:**
 
@@ -310,10 +306,6 @@ can be layered on top of tbd or handled by other tools.
 
 - [Beads](https://github.com/steveyegge/beads)—The original git-backed issue tracker tbd
   is designed to replace
-- [Agent Mail](https://github.com/Dicklesworthstone/mcp_agent_mail)—Real-time agent
-  messaging via MCP (complementary to tbd for coordination)
-- [Gas Town](https://github.com/steveyegge/gastown)—Multi-agent orchestration platform
-  (complementary to tbd for real-time coordination)
 - [ticket](https://github.com/wedow/ticket)—Bash-based Markdown+YAML tracker (~1900
   tickets in production)
 - [git-bug](https://github.com/git-bug/git-bug)—Issues stored as git objects
@@ -339,7 +331,7 @@ tbd and Beads serve different use cases:
 
 | Scenario | Why Beads |
 | --- | --- |
-| Multi-agent requiring real-time coordination | Agent Mail, daemon-based sync, atomic claims |
+| Multi-agent requiring atomic claim enforcement | Daemon-based sync with atomic claims |
 | Complex workflow orchestration | Molecules, wisps, formulas, bonding |
 | Need ephemeral work tracking | Wisps (never synced, squash to digest) |
 | High-performance queries on 10K+ issues | SQLite with indexes is faster than file scan |
@@ -355,7 +347,6 @@ tbd and Beads serve different use cases:
 | Storage | Markdown and YAML files | SQLite and JSONL |
 | Coordination | Advisory claims, polling | Atomic claims, real-time |
 | Workflow templates | Not supported | Molecules, wisps, protos |
-| Agent messaging | Not supported | Agent Mail |
 | Debugging | Inspect files directly | Requires SQLite queries |
 
 **tbd is NOT:**
@@ -365,12 +356,7 @@ tbd and Beads serve different use cases:
 
 - A replacement for Beads’ advanced orchestration features (molecules, wisps, formulas)
 
-- A replacement for Agent Mail or other real-time messaging layers
-
 - A workflow automation engine with templates
-
-For atomic claims or sub-second messaging, pair tbd with a real-time layer such as Agent
-Mail.
 
 ### 1.3 Why Replace Beads? (Architecture Comparison)
 
@@ -6008,7 +5994,7 @@ simplifying the architecture:
 | Data locations | 4 (SQLite, local JSONL, sync branch, main) | 2 (files on sync branch, config on main) |
 | Storage | SQLite + JSONL | Markdown + YAML (file-per-entity) |
 | Daemon | Required (recommended) | Not required |
-| Agent coordination | External (Agent Mail) | `tbd watch` wake-ups; atomic claims deferred |
+| Agent coordination | External daemon | `tbd watch` wake-ups; atomic claims deferred |
 | Comments | Embedded in issue | Deferred |
 | Conflict resolution | 3-way merge | Git-based detection + field-level LWW + attic |
 
@@ -6378,7 +6364,6 @@ Real-time agent coordination is deferred:
 | `bd agent register` | Agent registry - future |
 | `bd agent heartbeat` | Presence tracking - future |
 | `bd agent claim` | Atomic claims - future |
-| Agent Mail | Real-time messaging - future |
 
 ### B.4 Advanced Data Operations
 

--- a/packages/tbd/docs/tbd-docs.md
+++ b/packages/tbd/docs/tbd-docs.md
@@ -1565,6 +1565,14 @@ Issue sync is separate and automatic.
 not clone the repo can see the work.
 Linear is the first provider; GitHub is planned.
 
+That refers to GitHub as a *tracker tbd writes to*, and it is not the only way GitHub
+reaches a bead.
+A repository whose Linear workspace has Linear’s own GitHub app installed
+already gets pull request linking and state automation on mirrored issues, so a merged
+pull request can move its Linear issue and the next `tbd sync` carries that onto the
+bead. That path needs nothing from tbd beyond the Linear integration described here.
+See Step 6 of `tbd shortcut setup-linear`.
+
 The **mirror** is one-way: beads are the source of truth and nothing is imported back,
 which is what makes it safe to run from any agent at any time.
 Full **bidirectional synchronization** (`tbd integration sync`) is also available and is


### PR DESCRIPTION
## Summary

Two docs changes that came out of connecting a repository to Linear and then watching a merge travel all the way to a closed bead.

## 1. The setup walkthrough never mentioned GitHub

`setup-linear` had zero GitHub coverage, so an agent could follow it end to end and never learn that pull request linking exists, or that it is an **organization-level** decision rather than a per-repository one. That scope confusion is the expensive kind: someone configures a second repository and starts looking for a second install that does not exist.

Step 6 is added after the first sync, framed as optional because sync is genuinely complete without it. It carries:

- A table contrasting the two axes. tbd's config is per repository with a personal credential; the app is installed once per GitHub organization by an org owner and covers every repository it grants.
- Why an agent cannot finish the step. Linear does expose `integrationGithubConnect`, but its `code` and `installationId` arguments are outputs of GitHub's browser install flow, so there is nothing to call ahead of it.
- Two verified commands for checking whether it is already installed, which is the part that *is* scriptable and worth doing before asking anyone for anything.
- A warning against enabling GitHub Issues sync on a team tbd mirrors into, since that puts a second issue writer on one issue set.

Plus two troubleshooting rows, and a fix for a stray blank line that was splitting the troubleshooting table into two tables.

## 2. Dropping the real-time coordination disclaimers

The README and design doc described sub-second messaging and live coordination as a separate problem handled by other tools. tbd does that work now: `tbd watch` wakes agents on bead changes, `tbd web` serves a live board, and `tbd integration` synchronizes an external tracker.

The Agent Mail and Gas Town references are removed throughout, in the README, the coordination paragraph, Related Projects, both comparison tables, the "tbd is NOT" list, and two appendix rows. The affected Beads comparison rows are reworded so the remaining contrast is about atomic claim enforcement rather than real-time versus not.

One accurate limitation is deliberately kept: `tbd watch` provides poll-latency wake-ups, not atomic claims or push messaging.

## Notes

- `packages/tbd/README.md` is gitignored and generated from the root README, so only the root copy is tracked here.
- `npm run format:md:check` passes with the pinned `flowmark-rs@0.3.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, auth, or sync behavior changes.
> 
> **Overview**
> Documents how Linear’s own GitHub app complements tbd sync, and stops framing real-time coordination as something tbd does not do.
> 
> **Linear setup** (`setup-linear`) adds optional **Step 6**: PR linking and state automation live on Linear’s org-level GitHub app, not in tbd. Agents cannot complete the install (browser/org-owner flow), but they can check whether it is already installed. Warns against enabling GitHub Issues sync on a team tbd already writes to. CLI reference notes that a merge can close a bead via Linear without extra tbd GitHub work.
> 
> **Positioning:** README and design doc drop Agent Mail / Gas Town as complementary real-time layers. Remaining Beads contrast is **atomic claims**, not “no live coordination.” `tbd watch` is still described as poll-latency, not push messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bed816dca101de6e646c8573a292884064652b6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->