### PR TITLE
feat(web): Workmap view — topic-grouped card board beside the list

### DIFF
--- a/packages/tbd/src/cli/commands/web.ts
+++ b/packages/tbd/src/cli/commands/web.ts
@@ -16,6 +16,34 @@ import type { WebServerHandle } from '../web/server.js';
 interface WebOptions {
   port?: string;
   open?: boolean;
+  view?: string;
+  groupPrefix?: string;
+}
+
+const BOARD_VIEWS = ['list', 'workmap'] as const;
+
+/**
+ * Fold the view options into the served URL as query parameters. The page owns the
+ * behavior (and remembers explicit in-page choices); the CLI only builds the link.
+ */
+export function webUrlWithView(url: string, options: WebOptions): string {
+  const params = new URLSearchParams();
+  if (options.view !== undefined) {
+    params.set('view', options.view);
+  }
+  if (options.groupPrefix !== undefined) {
+    // Grouping implies the workmap; saying so beats opening a list that ignores it.
+    params.set('view', options.view ?? 'workmap');
+    params.set('group', options.groupPrefix);
+  }
+  const query = params.toString();
+  return query === '' ? url : `${url}/?${query}`;
+}
+
+function parseView(value: string | undefined): void {
+  if (value !== undefined && !(BOARD_VIEWS as readonly string[]).includes(value)) {
+    throw new ValidationError(`--view must be one of: ${BOARD_VIEWS.join(', ')}`);
+  }
 }
 
 interface WebDescriptor {
@@ -68,6 +96,7 @@ async function resolveBaseDirectory(value: string | undefined): Promise<string> 
 class WebHandler extends BaseCommand {
   async run(baseDir: string | undefined, options: WebOptions): Promise<void> {
     const port = parsePort(options.port);
+    parseView(options.view);
     const repo = await requireInit(await resolveBaseDirectory(baseDir));
     const serverModule = await import('../web/server.js');
 
@@ -76,7 +105,7 @@ class WebHandler extends BaseCommand {
       const resolvedPort = await serverModule.resolveWebPort({ port });
       this.printDescriptor(
         {
-          url: `http://127.0.0.1:${resolvedPort}`,
+          url: webUrlWithView(`http://127.0.0.1:${resolvedPort}`, options),
           port: resolvedPort,
           pid: process.pid,
           repo,
@@ -144,7 +173,7 @@ class WebHandler extends BaseCommand {
       spinner.stop();
 
       const descriptor: WebDescriptor = {
-        url: handle.url,
+        url: webUrlWithView(handle.url, options),
         port: handle.port,
         pid: process.pid,
         repo,
@@ -154,7 +183,7 @@ class WebHandler extends BaseCommand {
 
       if (options.open === true && firstSignal === null) {
         try {
-          await serverModule.openWebBrowser(handle.url);
+          await serverModule.openWebBrowser(webUrlWithView(handle.url, options));
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           this.output.warn(`Could not open a browser (${message}); use ${handle.url}`);
@@ -203,6 +232,11 @@ export const webCommand = new Command('web')
   .argument('[path]', 'Repository or subdirectory to view (default: current directory)')
   .option('--port <n>', 'Bind exactly this loopback port (default: search from 7777)')
   .option('--open', 'Open the page in the default browser after HTTP readiness')
+  .option('--view <name>', 'Initial board view: list or workmap')
+  .option(
+    '--group-prefix <prefix>',
+    'Workmap grouping label prefix (e.g. area:) — any prefix:value convention your labels use',
+  )
   .action(async (path: string | undefined, options: WebOptions, command: Command) => {
     const handler = new WebHandler(command);
     await handler.run(path, options);

--- a/packages/tbd/src/web/client.ts
+++ b/packages/tbd/src/web/client.ts
@@ -4,6 +4,7 @@ import {
   createClientStore,
   DEFAULT_BOARD_SORTS,
   deltasValid,
+  detectLabelPrefixes,
   formatDeltaValue,
   formatRelativeAge,
   isDefaultBoardSort,
@@ -12,6 +13,7 @@ import {
   paginateBoardRows,
   phaseLabel,
   preserveLabelSearchEditingKey,
+  projectWorkmap,
   promoteBoardSort,
   resolvedBoardSorts,
 } from './core.js';
@@ -78,13 +80,60 @@ const elements = {
   expandAll: byId('expandall', HTMLButtonElement),
   gear: byId('gear', HTMLButtonElement),
   menu: byId('menu', HTMLDivElement),
+  workmapWrap: byId('workmapwrap', HTMLDivElement),
+  workmapGroups: byId('workmapgroups', HTMLDivElement),
+  workmapEmpty: byId('workmapempty', HTMLDivElement),
+  workmapGroup: byId('workmapgroup', HTMLSelectElement),
 };
+
+const viewChoiceButtons = [
+  ...document.querySelectorAll<HTMLButtonElement>('#viewchooser [data-view-choice]'),
+];
 
 const ISSUE_STATUSES = ['open', 'in_progress', 'blocked', 'deferred', 'closed'] as const;
 const ISSUE_PRIORITIES = ['0', '1', '2', '3', '4'] as const;
 const PRIORITY_LABEL = ['Critical', 'High', 'Medium', 'Low', 'Lowest'] as const;
 const RELATIVE_TIME_REFRESH_MS = 30_000;
 let boardPageIndex = 0;
+
+/**
+ * Which rendering of the same board response is active. The workmap is a projection of
+ * the identical rows, filters, and sorts — switching views changes no request.
+ */
+type BoardViewMode = 'list' | 'workmap';
+const BOARD_VIEW_MODES = ['list', 'workmap'] as const;
+const VIEW_MODE_STORAGE_KEY = 'tbd.web.boardView';
+const WORKMAP_PREFIX_STORAGE_KEY = 'tbd.web.workmapPrefix';
+
+function storedString(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+function persistString(key: string, value: string): void {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Storage is optional; the choice remains effective for this page load.
+  }
+}
+
+// A shared link wins over a stored preference; both fall back to the list view.
+const pageQuery = new URLSearchParams(window.location.search);
+let boardViewMode: BoardViewMode = choice(
+  pageQuery.get('view') ?? storedString(VIEW_MODE_STORAGE_KEY) ?? '',
+  BOARD_VIEW_MODES,
+  'list',
+);
+/**
+ * The grouping label prefix, e.g. `area:` — entirely the user's own labeling
+ * convention. Empty means "not chosen yet"; the first detected prefix then serves as
+ * the default without being persisted as a choice.
+ */
+let workmapGroupPrefix: string =
+  pageQuery.get('group') ?? storedString(WORKMAP_PREFIX_STORAGE_KEY) ?? '';
 let scrollBoardToTopAfterRender = false;
 let labelMenuOpen = false;
 let pendingLabelFocus: string | null = null;
@@ -1281,6 +1330,170 @@ function renderHeader(view: ClientView, board: BoardResponse, watch: Observation
   document.title = `tbd beads (${watch.totalBeads})`;
 }
 
+/** Sync the view chooser, the group select, and which board surface is visible. */
+function renderViewChooser(): void {
+  for (const button of viewChoiceButtons) {
+    button.setAttribute('aria-checked', String(button.dataset.viewChoice === boardViewMode));
+  }
+  const workmap = boardViewMode === 'workmap';
+  elements.tableWrap.hidden = workmap;
+  elements.workmapWrap.hidden = !workmap;
+  elements.workmapGroup.hidden = !workmap;
+  if (workmap) {
+    // List-only chrome; renderBoard is not running to manage it.
+    elements.pageControls.hidden = true;
+    elements.expandAll.hidden = true;
+  }
+}
+
+/** Rebuild the group-prefix select from the prefixes the data itself states. */
+function renderWorkmapGroupChoices(rows: readonly BoardRowView[]): string {
+  const prefixes = detectLabelPrefixes(rows);
+  const effective = workmapGroupPrefix !== '' ? workmapGroupPrefix : (prefixes[0]?.value ?? '');
+  elements.workmapGroup.replaceChildren();
+  const seen = new Set<string>();
+  for (const prefix of prefixes) {
+    const option = document.createElement('option');
+    option.value = prefix.value;
+    option.textContent = `${prefix.value} (${prefix.count})`;
+    seen.add(prefix.value);
+    elements.workmapGroup.append(option);
+  }
+  if (effective !== '' && !seen.has(effective)) {
+    // The chosen prefix no longer appears in the data. Keep it selectable and honest
+    // rather than silently jumping to a different grouping.
+    const option = document.createElement('option');
+    option.value = effective;
+    option.textContent = `${effective} (0)`;
+    elements.workmapGroup.append(option);
+  }
+  elements.workmapGroup.value = effective;
+  elements.workmapGroup.disabled = elements.workmapGroup.options.length === 0;
+  return effective;
+}
+
+function renderWorkmapCard(
+  view: ClientView,
+  row: BoardRowView,
+  note: string | null = null,
+): HTMLElement {
+  const card = document.createElement('article');
+  card.className = 'workmap-card';
+  card.dataset.beadId = row.id;
+  const open = view.expanded.has(row.id);
+  if (open) {
+    card.classList.add('open');
+  }
+
+  const head = document.createElement('div');
+  head.className = 'workmap-card-head';
+  const status = document.createElement('span');
+  status.className = `issue-status status-${row.status}`;
+  status.textContent = STATUS_ICONS[row.status];
+  status.dataset.tooltip = row.status;
+  const id = document.createElement('span');
+  id.className = 'workmap-card-id';
+  id.textContent = row.id;
+  const priority = document.createElement('span');
+  priority.className = `priority priority-${row.priority}`;
+  priority.textContent = `P${row.priority}`;
+  head.append(status, id, priority);
+  if (note !== null) {
+    const noteSpan = document.createElement('span');
+    noteSpan.className = 'workmap-card-note';
+    noteSpan.textContent = note;
+    head.append(noteSpan);
+  }
+
+  const title = document.createElement('div');
+  title.className = 'workmap-card-title';
+  title.textContent = row.title;
+
+  card.append(head, title);
+  if (open) {
+    const body = document.createElement('div');
+    body.className = 'workmap-card-body';
+    body.append(renderBody(view, row.id));
+    card.append(body);
+  }
+  return card;
+}
+
+function appendWorkmapGroup(
+  parent: HTMLElement,
+  view: ClientView,
+  heading: string,
+  count: number,
+  hint: string | null,
+  cards: HTMLElement[],
+): void {
+  const group = document.createElement('section');
+  group.className = 'workmap-group';
+  const name = document.createElement('h3');
+  name.className = 'section-heading workmap-group-name';
+  name.textContent = heading;
+  const num = document.createElement('span');
+  num.className = 'num';
+  num.textContent = String(count);
+  name.append(num);
+  if (hint !== null) {
+    name.dataset.tooltip = hint;
+  }
+  group.append(name, ...cards);
+  parent.append(group);
+}
+
+/**
+ * The workmap: the same served rows as the list, grouped by the value each bead's
+ * labels state under the chosen prefix. Grouping is a projection of the user's own
+ * labeling convention — tbd assigns no meaning to any prefix, and a bead stating no
+ * value (or two) is shown as exactly that rather than filed somewhere plausible.
+ */
+function renderWorkmap(view: ClientView, board: BoardResponse): void {
+  const effectivePrefix = renderWorkmapGroupChoices(board.rows);
+  const projection = projectWorkmap(board.rows, effectivePrefix);
+  elements.workmapGroups.replaceChildren();
+
+  for (const group of projection.groups) {
+    appendWorkmapGroup(
+      elements.workmapGroups,
+      view,
+      group.value,
+      group.rows.length,
+      `beads labeled ${effectivePrefix}${group.value}`,
+      group.rows.map((row) => renderWorkmapCard(view, row)),
+    );
+  }
+  if (projection.conflicted.length > 0) {
+    appendWorkmapGroup(
+      elements.workmapGroups,
+      view,
+      'conflicting',
+      projection.conflicted.length,
+      `beads with two or more ${effectivePrefix} labels — fix the labels; the board will not pick one`,
+      projection.conflicted.map(({ row, values }) =>
+        renderWorkmapCard(view, row, values.map((value) => effectivePrefix + value).join(' ')),
+      ),
+    );
+  }
+  if (projection.ungrouped.length > 0 && effectivePrefix !== '') {
+    appendWorkmapGroup(
+      elements.workmapGroups,
+      view,
+      'ungrouped',
+      projection.ungrouped.length,
+      `beads with no ${effectivePrefix} label`,
+      projection.ungrouped.map((row) => renderWorkmapCard(view, row)),
+    );
+  }
+
+  const nothingToGroup = board.rows.length > 0 && effectivePrefix === '';
+  elements.workmapEmpty.hidden = board.rows.length > 0 && !nothingToGroup;
+  elements.workmapEmpty.textContent = nothingToGroup
+    ? 'No label prefixes to group by. The workmap groups beads by labels like area:caching — any prefix:value convention your project already uses.'
+    : (view.boardError ?? 'No beads match this query.');
+}
+
 let disconnected = false;
 let ghostTimer: number | null = null;
 let renderFrame: number | null = null;
@@ -1309,7 +1522,12 @@ function render(): void {
       `The live connection dropped; the browser will retry automatically. Last server state: ${phaseLabel(watch).help}`,
     );
   }
-  renderBoard(view, board);
+  renderViewChooser();
+  if (boardViewMode === 'workmap') {
+    renderWorkmap(view, board);
+  } else {
+    renderBoard(view, board);
+  }
   renderStatus(watch);
   renderStats(watch.stats);
   renderReport(watch);
@@ -1556,6 +1774,37 @@ elements.pagePrevious.addEventListener('click', () => {
 });
 elements.pageNext.addEventListener('click', () => {
   navigateBoardPage(boardPageIndex + 1);
+});
+
+for (const button of viewChoiceButtons) {
+  button.addEventListener('click', () => {
+    const mode = choice(button.dataset.viewChoice ?? '', BOARD_VIEW_MODES, 'list');
+    if (mode === boardViewMode) {
+      return;
+    }
+    boardViewMode = mode;
+    persistString(VIEW_MODE_STORAGE_KEY, mode);
+    scheduleRender();
+  });
+}
+elements.workmapGroup.addEventListener('change', () => {
+  workmapGroupPrefix = elements.workmapGroup.value;
+  persistString(WORKMAP_PREFIX_STORAGE_KEY, workmapGroupPrefix);
+  scheduleRender();
+});
+elements.workmapGroups.addEventListener('click', (event) => {
+  const target = event.target instanceof Element ? event.target : null;
+  if (target?.closest('.workmap-card-body') !== null) {
+    return;
+  }
+  const card = target.closest<HTMLElement>('.workmap-card[data-bead-id]');
+  if (card === null || !(window.getSelection()?.isCollapsed ?? true)) {
+    return;
+  }
+  const id = card.dataset.beadId;
+  if (id !== undefined) {
+    store.toggle(id);
+  }
 });
 
 const themeButtons = [...document.querySelectorAll<HTMLButtonElement>('[data-theme-choice]')];

--- a/packages/tbd/src/web/core.ts
+++ b/packages/tbd/src/web/core.ts
@@ -349,6 +349,104 @@ export function formatDeltaValue(value: unknown): { full: string; preview: strin
   return { full, preview: truncateMiddle(full, DELTA_VALUE_PREVIEW_CHARS) };
 }
 
+/** One workmap group: every row whose labels carry exactly one value under the prefix. */
+export interface WorkmapGroupView {
+  value: string;
+  rows: BoardRowView[];
+}
+
+/**
+ * The workmap projection of one board response: rows grouped by the value each bead's
+ * labels state under a caller-chosen label prefix.
+ */
+export interface WorkmapProjectionView {
+  prefix: string;
+  /** Groups ordered by size (largest first), then value. */
+  groups: WorkmapGroupView[];
+  /** Rows stating two or more distinct values — a data error surfaced, never picked from. */
+  conflicted: { row: BoardRowView; values: string[] }[];
+  /** Rows stating no value under the prefix — a visible gap, never a guess. */
+  ungrouped: BoardRowView[];
+}
+
+/**
+ * Label prefixes present on a board, counted by bead.
+ *
+ * A prefix is everything up to and including a label's first `:` (so `cat:caching`
+ * offers `cat:`). tbd assigns no meaning to any particular prefix — which prefixes
+ * exist, and what they mean, is entirely the user's own labeling convention; this
+ * only reports what the data states so a viewer can offer the choices.
+ */
+export function detectLabelPrefixes(rows: readonly BoardRowView[]): ValueFacetView<string>[] {
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    const seen = new Set<string>();
+    for (const label of row.labels) {
+      const colon = label.indexOf(':');
+      // A leading colon has an empty prefix and a trailing colon an empty value;
+      // neither states a usable prefix:value pair.
+      if (colon <= 0 || colon === label.length - 1) {
+        continue;
+      }
+      seen.add(label.slice(0, colon + 1));
+    }
+    for (const prefix of seen) {
+      counts.set(prefix, (counts.get(prefix) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .map(([value, count]) => ({ value, count }))
+    .sort((a, b) => b.count - a.count || a.value.localeCompare(b.value));
+}
+
+/**
+ * Group board rows by the value their labels state under `prefix`.
+ *
+ * Exactly one distinct value places the row in that value's group. Two or more is a
+ * conflict — reported as such rather than resolved by any tie-break, because the label
+ * convention this projects (one value per bead under a grouping prefix) is the user's,
+ * and only they can say which label is wrong. No value leaves the row ungrouped and
+ * visible. Rows keep the board's served order inside every bucket, so the active sort
+ * controls order the cards too.
+ */
+export function projectWorkmap(
+  rows: readonly BoardRowView[],
+  prefix: string,
+): WorkmapProjectionView {
+  const projection: WorkmapProjectionView = { prefix, groups: [], conflicted: [], ungrouped: [] };
+  if (prefix.trim() === '') {
+    projection.ungrouped = [...rows];
+    return projection;
+  }
+  const byValue = new Map<string, BoardRowView[]>();
+  for (const row of rows) {
+    const values = [
+      ...new Set(
+        row.labels
+          .filter((label) => label.startsWith(prefix) && label.length > prefix.length)
+          .map((label) => label.slice(prefix.length)),
+      ),
+    ];
+    if (values.length === 0) {
+      projection.ungrouped.push(row);
+    } else if (values.length > 1) {
+      projection.conflicted.push({ row, values: values.sort() });
+    } else {
+      const value = values[0]!;
+      const bucket = byValue.get(value);
+      if (bucket === undefined) {
+        byValue.set(value, [row]);
+      } else {
+        bucket.push(row);
+      }
+    }
+  }
+  projection.groups = [...byValue.entries()]
+    .map(([value, groupRows]) => ({ value, rows: groupRows }))
+    .sort((a, b) => b.rows.length - a.rows.length || a.value.localeCompare(b.value));
+  return projection;
+}
+
 const DEFAULT_SORT_DIRECTIONS: Readonly<Record<BoardSortKeyView, BoardSortDirectionView>> = {
   id: 'asc',
   priority: 'asc',

--- a/packages/tbd/src/web/index.html
+++ b/packages/tbd/src/web/index.html
@@ -278,9 +278,41 @@
         <button id="expandall" hidden>Expand all</button>
       </div>
 
-      <h2 id="boardheading" class="section-heading">
-        Beads <span class="hint" id="cmd">tbd list --pretty</span>
-      </h2>
+      <div id="boardheadingrow">
+        <h2 id="boardheading" class="section-heading">
+          Beads <span class="hint" id="cmd">tbd list --pretty</span>
+        </h2>
+        <span class="grow"></span>
+        <!-- The workmap groups by a label prefix the data itself uses (area:x, team:y —
+           whatever convention the project chose). tbd assigns no meaning to any
+           prefix; the select offers only what the labels state. -->
+        <select
+          id="workmapgroup"
+          aria-label="Group cards by label prefix"
+          data-tooltip="Group cards by a label prefix your labels already use"
+          hidden
+        ></select>
+        <div class="chooser" id="viewchooser" role="radiogroup" aria-label="Board view">
+          <button
+            type="button"
+            class="seg view-seg"
+            role="radio"
+            data-view-choice="list"
+            aria-checked="true"
+          >
+            list
+          </button>
+          <button
+            type="button"
+            class="seg view-seg"
+            role="radio"
+            data-view-choice="workmap"
+            aria-checked="false"
+          >
+            workmap
+          </button>
+        </div>
+      </div>
     </section>
 
     <main>
@@ -339,6 +371,11 @@
           <tbody id="rows"></tbody>
         </table>
         <div class="empty" id="empty" role="status" hidden>No beads match this query.</div>
+      </div>
+
+      <div id="workmapwrap" hidden>
+        <div id="workmapgroups"></div>
+        <div class="empty" id="workmapempty" role="status" hidden></div>
       </div>
 
       <aside>

--- a/packages/tbd/src/web/styles.css
+++ b/packages/tbd/src/web/styles.css
@@ -897,6 +897,89 @@ label.check {
   font-size: var(--font-size-small);
   line-height: 1.35;
 }
+/* ── Workmap view ─────────────────────────────────────────────────
+   The same board response as the list, projected into groups by a
+   label prefix the user's own data states. Cards reuse the board's
+   vocabulary (.issue-status colors, .priority-*, mono ids); the
+   group name reuses the .section-heading recipe, so no treatment
+   here is new — only layout is. */
+#boardheadingrow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 16px 7px;
+}
+#boardheadingrow #boardheading {
+  padding: 0;
+}
+#viewchooser .seg {
+  flex: 0 0 auto;
+  height: 24px;
+  padding: 0 10px;
+  font-size: var(--font-size-small);
+}
+#workmapgroup {
+  font-size: var(--font-size-small);
+  padding: 2px 6px;
+}
+#workmapwrap {
+  padding: 12px 16px;
+}
+#workmapgroups {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 12px;
+  align-items: start;
+}
+.workmap-group {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+}
+.workmap-group-name {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 0;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+}
+.workmap-group-name .num {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+}
+.workmap-card {
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+.workmap-card + .workmap-card {
+  border-top: 1px solid var(--border);
+}
+.workmap-card:hover {
+  background: var(--panel);
+}
+.workmap-card-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.workmap-card-id {
+  font-family: var(--mono);
+  font-size: var(--font-size-small);
+}
+.workmap-card-note {
+  font-family: var(--mono);
+  font-size: var(--font-size-small);
+  color: var(--error);
+}
+.workmap-card-title {
+  margin-top: 2px;
+}
+.workmap-card-body {
+  margin-top: 8px;
+  cursor: auto;
+}
 .copyable {
   display: inline-flex;
   max-width: 100%;

--- a/packages/tbd/tests/cli-web.test.ts
+++ b/packages/tbd/tests/cli-web.test.ts
@@ -12,6 +12,25 @@ import { promisify } from 'node:util';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { subprocessTestTimeout } from './test-helpers.js';
+import { webUrlWithView } from '../src/cli/commands/web.js';
+
+describe('web view URL options', () => {
+  it('passes through untouched with no view options', () => {
+    expect(webUrlWithView('http://127.0.0.1:7777', {})).toBe('http://127.0.0.1:7777');
+  });
+
+  it('encodes the chosen view, and grouping implies the workmap', () => {
+    expect(webUrlWithView('http://127.0.0.1:7777', { view: 'workmap' })).toBe(
+      'http://127.0.0.1:7777/?view=workmap',
+    );
+    expect(webUrlWithView('http://127.0.0.1:7777', { groupPrefix: 'area:' })).toBe(
+      'http://127.0.0.1:7777/?view=workmap&group=area%3A',
+    );
+    expect(webUrlWithView('http://127.0.0.1:7777', { view: 'list', groupPrefix: 'area:' })).toBe(
+      'http://127.0.0.1:7777/?view=list&group=area%3A',
+    );
+  });
+});
 
 const execFileAsync = promisify(execFile);
 const packageDir = fileURLToPath(new URL('..', import.meta.url));

--- a/packages/tbd/tests/cli-web.tryscript.md
+++ b/packages/tbd/tests/cli-web.tryscript.md
@@ -38,18 +38,18 @@ Usage: tbd web [options] [path]
 Serve a live, read-only bead view on loopback
 
 Arguments:
-  path            Repository or subdirectory to view (default: current
-                  directory)
+  path                     Repository or subdirectory to view (default: current
+                           directory)
 
 Options:
-  --port <n>      Bind exactly this loopback port (default: search from 7777)
-  --open          Open the page in the default browser after HTTP readiness
-  -h, --help      display help for command
-
-Global Options:
-  --version       Show version number
-  --dry-run       Show what would be done without making changes
-  --verbose       Enable verbose output
+  --port <n>               Bind exactly this loopback port (default: search from
+                           7777)
+  --open                   Open the page in the default browser after HTTP
+                           readiness
+  --view <name>            Initial board view: list or workmap
+  --group-prefix <prefix>  Workmap grouping label prefix (e.g. area:) — any
+                           prefix:value convention your labels use
+  -h, --help               display help for command
 ? 0
 ```
 

--- a/packages/tbd/tests/web-core.test.ts
+++ b/packages/tbd/tests/web-core.test.ts
@@ -8,7 +8,9 @@ import {
   DEFAULT_BOARD_SORTS,
   DELTA_VALUE_PREVIEW_CHARS,
   deltasValid,
+  detectLabelPrefixes,
   formatDeltaValue,
+  projectWorkmap,
   MAX_BODY_CACHE_ENTRIES,
   MAX_BODY_REQUEST_CONCURRENCY,
   MAX_EXPANDED_ROWS,
@@ -913,5 +915,70 @@ describe('createClientStore transport orchestration', () => {
     expect(store.getView().ghostRows).toHaveLength(MAX_GHOST_ROWS);
     expect(store.getView().ghostRows.map((row) => row.id)).toEqual(ids.slice(0, MAX_GHOST_ROWS));
     store.stop();
+  });
+});
+
+describe('workmap projection', () => {
+  const seed = board(state()).rows[0]!;
+  const row = (id: string, labels: string[]): BoardRowView => ({ ...seed, id, labels });
+
+  it('groups rows by the value under a caller-chosen prefix, largest group first', () => {
+    const projection = projectWorkmap(
+      [
+        row('web-1', ['area:caching', 'phase-2']),
+        row('web-2', ['area:tracker']),
+        row('web-3', ['area:tracker', 'bug']),
+        row('web-4', []),
+      ],
+      'area:',
+    );
+    expect(projection.prefix).toBe('area:');
+    expect(
+      projection.groups.map((group) => ({
+        value: group.value,
+        ids: group.rows.map((groupRow) => groupRow.id),
+      })),
+    ).toEqual([
+      { value: 'tracker', ids: ['web-2', 'web-3'] },
+      { value: 'caching', ids: ['web-1'] },
+    ]);
+    expect(projection.ungrouped.map((ungrouped) => ungrouped.id)).toEqual(['web-4']);
+    expect(projection.conflicted).toEqual([]);
+  });
+
+  it('reports two distinct values as a conflict instead of picking one', () => {
+    const projection = projectWorkmap([row('web-9', ['area:caching', 'area:tracker'])], 'area:');
+    expect(projection.groups).toEqual([]);
+    expect(projection.conflicted).toEqual([
+      { row: row('web-9', ['area:caching', 'area:tracker']), values: ['caching', 'tracker'] },
+    ]);
+  });
+
+  it('treats a repeated identical value as one value, and a bare prefix as no value', () => {
+    const projection = projectWorkmap(
+      [row('web-5', ['area:caching', 'area:caching']), row('web-6', ['area:'])],
+      'area:',
+    );
+    expect(projection.groups.map((group) => group.value)).toEqual(['caching']);
+    expect(projection.conflicted).toEqual([]);
+    expect(projection.ungrouped.map((ungrouped) => ungrouped.id)).toEqual(['web-6']);
+  });
+
+  it('projects an empty prefix as fully ungrouped rather than grouping on accident', () => {
+    const projection = projectWorkmap([row('web-7', ['area:caching'])], '  ');
+    expect(projection.groups).toEqual([]);
+    expect(projection.ungrouped.map((ungrouped) => ungrouped.id)).toEqual(['web-7']);
+  });
+
+  it('detects the prefixes the data states, counted by bead, with no built-in names', () => {
+    const prefixes = detectLabelPrefixes([
+      row('web-1', ['area:caching', 'phase:2']),
+      row('web-2', ['area:tracker', 'area:caching']),
+      row('web-3', ['plain-label', ':leading', 'trailing:']),
+    ]);
+    expect(prefixes).toEqual([
+      { value: 'area:', count: 2 },
+      { value: 'phase:', count: 1 },
+    ]);
   });
 });


### PR DESCRIPTION
## What

A second rendering of the same board response, beside the existing list: the **Workmap** — cards grouped by the value each bead's labels state under a caller-chosen label prefix (`area:caching`, `team:web`, … whatever `prefix:value` convention a project already uses).

Deliberately **not a kanban**: groups are topics/orientation, not lifecycle states. It is like a kanban only in that it has cards, and they are organized and move.

## Design rules

- **Document/label neutrality.** tbd assigns no meaning to any prefix. `detectLabelPrefixes` offers only the prefixes the data itself states; the grouping convention belongs to the user.
- **A projection, not a mode.** `projectWorkmap` is a pure function of the served rows, so every existing filter, sort, live update, and the mirrored CLI command compose with it unchanged (filtering to `--priority 0` re-projects the map).
- **Honest buckets.** Exactly one distinct value → that group. Two or more → a `conflicting` group showing the literal labels (never resolved by tie-break). None → `ungrouped`, visible rather than filed somewhere plausible.
- **No new visual vocabulary.** Cards reuse `.issue-status` colors, `.priority-*`, mono ids; the group heading reuses the `.section-heading` recipe; only layout is new. CSS token invariants test still passes.

## Surface

- `list | workmap` chooser on the board heading row; group-prefix select appears in workmap mode.
- `?view=workmap&group=area%3A` URL params make views linkable; explicit in-page choices persist in localStorage.
- `tbd web --view workmap --group-prefix area:` folds the choice into the printed/opened URL.

## Verification

- `projectWorkmap`/`detectLabelPrefixes` unit-tested and red-proofed (conflict-picks-first and trailing-colon breaks each fail exactly one test).
- 120 web tests pass (`web-core`, `web-board`, `web-http`, `web-server`, `bead-web-css`); both tsconfigs typecheck; eslint clean.
- Verified live against a 2,467-bead graph with an 835-bead `cat:` labeling convention: 21 topic groups, all 1,037 served rows accounted for (grouped + ungrouped, zero conflicts), card expansion via the standard body loader, view round-trips, filter re-projection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only viewer and CLI URL flags only; no auth, persistence, or board API changes. Grouping is a pure client projection of already-served rows.
> 
> **Overview**
> Adds a **workmap** rendering of the existing live board: the same filtered/sorted rows as the list, shown as cards grouped by a user-chosen `prefix:value` label (e.g. `area:`). tbd does not interpret prefixes; it only offers ones present on the data.
> 
> `projectWorkmap` / `detectLabelPrefixes` bucket beads with exactly one value, surface **conflicting** (multiple values, no tie-break) and **ungrouped** (none), and keep served sort order inside groups. The UI adds a list/workmap chooser, a prefix select, expandable cards, URL query (`?view=` / `?group=`), and localStorage. `tbd web --view` / `--group-prefix` fold those into the printed and opened URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d75cc572ac15f76b41b2b2d62fe6fe8e45ee2890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->