### PR TITLE
chore: release get-tbd v0.8.0

### DIFF
--- a/packages/tbd/CHANGELOG.md
+++ b/packages/tbd/CHANGELOG.md
@@ -1,5 +1,137 @@
 # get-tbd
 
+## 0.8.0
+
+tbd could say that work was open, started, or closed.
+It could not say *how* work ended, *who* is acting on it as distinct from who owns it,
+or that started work is on hold.
+This release adds those three axes, and teaches the Linear integration to project them
+onto a real board. No format change: repositories stay on `f08`, and there is no
+migration step.
+
+### Work can end three ways, not one
+
+`closed` collapsed “we did it”, “we dropped it”, and “this was already filed”.
+Closing now takes a resolution:
+
+```bash
+tbd close tbd-a1b2 --as canceled --reason "approach superseded"
+tbd close tbd-c3d4 --as duplicate --duplicate-of tbd-a1b2
+```
+
+`resolution` is `completed` (the default, so existing scripts are unchanged),
+`canceled`, or `duplicate`; `duplicate_of` is required with `duplicate` and refused
+without it. Both are validated against `status`, so a resolution cannot attach to open
+work.
+
+This matters most where it leaves your repository.
+A canceled bead previously filed in Linear as **Done** with a completion date stamped on
+it, which is wrong data rather than a wrong label.
+Now `canceled` maps to Linear’s Canceled with no completion date, and `duplicate`
+creates the provider-side duplicate relation from the scalar.
+
+### Who is accountable and who is acting are different fields
+
+`assignee` had to mean both, so in agent-driven repositories it usually meant nothing
+and went unused. `delegate` now sits beside it: the human stays accountable, the agent
+acts.
+
+```bash
+tbd update tbd-a1b2 --assignee alice --delegate claude-agent
+tbd start tbd-a1b2            # claims the acting axis, leaving assignee alone
+```
+
+`tbd start` sets `delegate` rather than overwriting `assignee`, and `--as <name>` claims
+under an explicit agent name.
+People resolve through the tracker’s own directory instead of a hand-maintained table,
+so a rename survives; `user_map` is still honored as an override.
+Publishing a delegate to Linear requires naming an installed Linear agent in
+`agent_map`, and an unmapped agent produces a reported skip rather than a silent one.
+
+### Paused work stops erasing that it started
+
+Parking work meant moving it to `deferred`, which discarded the fact that it had ever
+started. `hold` is now its own axis:
+
+```bash
+tbd pause tbd-a1b2 --until 2026-09-15 --reason "waiting on upstream"
+tbd resume tbd-a1b2
+```
+
+`hold` is `blocked` or `paused`, with `hold_until` for an expected lift date, and
+`started_at` is set on first entry to `in_progress` and never cleared—so a paused bead
+still knows it was started.
+`tbd ready` excludes anything on hold.
+Bulk `tbd update --hold` covers a subtree, which previously meant a per-bead loop.
+
+### A board tbd can project onto
+
+`state_map` maps lifecycle slots to Linear states **by name**, not by board position, so
+reordering a board no longer changes what tbd thinks a column means.
+It is optional: omit it and tbd maps states as it did before, creating nothing.
+
+`tbd integration setup` proposes the default map, and on confirmation creates the states
+a repository asked for—and only those—validated against the team’s real states before
+anything is mutated.
+It never renames, deletes, or touches a state outside the map.
+`tbd doctor` prints the resolved slot table offline, so the projection is inspectable
+without a sync.
+
+### Fixes
+
+- **A bead with no assignee no longer clears the assignee in Linear.** An absent
+  assignee pushed outbound as an explicit unassign, so populating `user_map`—the
+  documented prerequisite for assignee sync—was by itself enough to start erasing
+  whoever a human had assigned.
+  Observed as steady state rather than a race: one issue lost its assignee, regained it,
+  and lost it again on the next sync.
+  An absent assignee is now read as no opinion.
+  Affects every repository that adopted the integration after its beads existed.
+- **`.env` credentials resolve from the main worktree.** `.env` is gitignored, so it
+  does not propagate to linked worktrees; a fully configured repository reported
+  `LINEAR_API_KEY not found` from any worktree of it, and status read as “Linear is not
+  set up here”. Resolution now falls back to the main worktree’s `.env` through git,
+  guarded so it cannot read a sibling project under `git init --separate-git-dir`.
+- **A sync that skipped a field says so.** Pushes reported a clean summary over fields
+  they had dropped. Field-level skips are now named, and `--verbose` names each excluded
+  field, distinguishing “not eligible” from “eligible and unchanged”.
+- **`--due` and `--defer` accept the dates people actually type**, not only full ISO
+  8601 timestamps.
+- **`tbd doctor` warns when npm’s global bin directory is not on `PATH`**, and only when
+  that finding is actionable.
+
+### Guidelines and content
+
+- **New `agent-session-bootstrap` guideline** covering session startup for agents.
+- **The tbd skill now says where beads live.** It never stated that beads are stored on
+  the `tbd-sync` branch, and its one branch note pointed the other way, so an agent that
+  found no bead changes in its feature branch could report the work lost.
+  The skill now states that tbd owns that branch—`tbd sync` maintains it,
+  `tbd doctor --fix` repairs it—and that tbd commands, not raw git, are the interface to
+  it. ([#238](https://github.com/jlevy/tbd/issues/238))
+- **`ensure-gh-cli.sh` states the proxied-session consequences it has already proven.**
+  Where it detects that a session proxy intercepts GitHub while direct egress is open,
+  it now reports that tags can 403 through a ref-scoped credential broker while branches
+  succeed, that `git push --dry-run` passes for tags the broker later refuses, and that
+  a GitHub-host 403 with no `x-github-request-id` header is proxy-manufactured rather
+  than an egress denial.
+  The same facts are in the skill.
+  ([#255](https://github.com/jlevy/tbd/issues/255))
+- **`setup-linear` covers Linear’s GitHub app**, including that it is an
+  organization-level decision rather than a per-repository one.
+- **`update-specs-status` gained a dangling `spec_path` sweep** and no longer files
+  never-started specs as finished.
+
+### Security
+
+Lockfile is byte-identical to v0.7.1 and no manifest changed, so the resolved dependency
+tree is unchanged. `pnpm audit --prod` reports no advisories in the shipped tree;
+outstanding advisories are confined to dev tooling (vitest, vite, rollup, postcss and
+their transitives).
+
+**Full commit history**:
+[Compare v0.7.1 to v0.8.0](https://github.com/jlevy/tbd/compare/v0.7.1...v0.8.0)
+
 ## 0.7.1
 
 A patch release about one thing: the first time you point tbd at a tracker, it should be

--- a/packages/tbd/docs/install/ensure-gh-cli.sh
+++ b/packages/tbd/docs/install/ensure-gh-cli.sh
@@ -173,6 +173,18 @@ if [ -n "${GH_TOKEN:-}" ]; then
             echo "[gh] Agent harnesses often reset shell state between tool calls; if the"
             echo "[gh] exports do not stick, prefix each command instead:"
             echo '[gh]   NO_PROXY="'"${GITHUB_DIRECT_HOSTS}"'" no_proxy="'"${GITHUB_DIRECT_HOSTS}"'" gh <command>'
+            # State the consequences here rather than only pointing at the shortcut. This
+            # branch has already proven both halves of the condition (proxy intercepts
+            # GitHub, direct channel is open), and at the moment these facts are needed the
+            # session's own docs say the opposite. An unread pointer loses that argument.
+            echo "[gh] This session's git remote may use a ref-scoped credential broker:"
+            echo "[gh]   - pushes to refs/heads/* succeed; pushes to refs/tags/* fail with HTTP 403."
+            echo "[gh]   - 'git push --dry-run' PASSES for tags the broker later refuses"
+            echo "[gh]     (it refuses at receive-pack, after ref advertisement); it proves nothing."
+            echo "[gh]   - create tags on the direct channel instead:"
+            echo "[gh]       gh api repos/OWNER/REPO/git/refs -f ref=refs/tags/vX.Y.Z -f sha=SHA"
+            echo "[gh]   - a GitHub-host 403 with NO x-github-request-id header is proxy-manufactured,"
+            echo "[gh]     not an egress denial. Run the egress test before reporting a block."
             echo "[gh] Details: tbd shortcut setup-github-cli (Proxied Remote Sessions)"
         else
             echo "[gh] WARNING: GH_TOKEN is set but could not be verified on any channel"

--- a/packages/tbd/docs/shortcuts/system/skill-baseline.md
+++ b/packages/tbd/docs/shortcuts/system/skill-baseline.md
@@ -133,8 +133,18 @@ tbd guidelines general-coding-rules general-comment-rules error-handling-rules g
 
 Run `tbd guidelines --list` to see all available guidelines.
 
-**Note:** Never gitignore `.tbd/workspaces/`; the outbox must be committed to your
-working branch. See `tbd guidelines tbd-sync-troubleshooting` for details.
+**Where beads live:** on the dedicated `tbd-sync` branch, not your working branch.
+Bead changes never appear in your feature branch’s commits or its PR diff.
+That is the design, not lost work: don’t hunt for them there, and don’t claim
+“everything is on this PR” about bead state.
+
+**Let tbd own that branch.** `tbd sync` maintains it and `tbd doctor --fix` repairs it.
+Use tbd commands rather than raw git for anything touching `tbd-sync`; hand checkouts,
+merges, and pushes are how bead state gets tangled.
+
+**Note:** `.tbd/workspaces/` is the exception: never gitignore it; the outbox must be
+committed to your working branch.
+See `tbd guidelines tbd-sync-troubleshooting` for details.
 
 ## CRITICAL: Session Closing Protocol
 
@@ -152,8 +162,20 @@ working branch. See `tbd guidelines tbd-sync-troubleshooting` for details.
 **Work is not done until pushed, CI passes, and tbd is synced.**
 
 **Remote/proxied session where GitHub seems blocked?** If the environment has egress,
-`gh` works through a scoped `NO_PROXY` bypass — run `tbd shortcut setup-github-cli` and
-follow “Proxied Remote Sessions” before concluding gh is unavailable.
+`gh` works through a scoped `NO_PROXY` bypass.
+Three facts decide most of these:
+
+- The git remote may sit behind a **ref-scoped credential broker**: pushes to
+  `refs/heads/*` succeed, pushes to `refs/tags/*` fail with HTTP 403. Create the tag on
+  the direct channel instead:
+  `gh api repos/OWNER/REPO/git/refs -f ref=refs/tags/vX.Y.Z -f sha=SHA`.
+- `git push --dry-run` **passes** for tags the broker then refuses at receive-pack, so a
+  clean dry run proves nothing.
+- A GitHub-host 403 carrying no `x-github-request-id` header is proxy-manufactured, not
+  an organization egress denial.
+
+Run `tbd shortcut setup-github-cli` and follow “Proxied Remote Sessions” before
+concluding gh is unavailable.
 
 ## Bead Tracking Rules
 

--- a/packages/tbd/package.json
+++ b/packages/tbd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-tbd",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Git-native issue tracking for AI agents and humans",
   "license": "MIT",
   "author": "Joshua Levy <joshua@cal.berkeley.edu> (https://github.com/jlevy)",

--- a/skills/tbd/SKILL.md
+++ b/skills/tbd/SKILL.md
@@ -150,8 +150,18 @@ tbd guidelines general-coding-rules general-comment-rules error-handling-rules g
 
 Run `tbd guidelines --list` to see all available guidelines.
 
-**Note:** Never gitignore `.tbd/workspaces/`; the outbox must be committed to your
-working branch. See `tbd guidelines tbd-sync-troubleshooting` for details.
+**Where beads live:** on the dedicated `tbd-sync` branch, not your working branch.
+Bead changes never appear in your feature branch’s commits or its PR diff.
+That is the design, not lost work: don’t hunt for them there, and don’t claim
+“everything is on this PR” about bead state.
+
+**Let tbd own that branch.** `tbd sync` maintains it and `tbd doctor --fix` repairs it.
+Use tbd commands rather than raw git for anything touching `tbd-sync`; hand checkouts,
+merges, and pushes are how bead state gets tangled.
+
+**Note:** `.tbd/workspaces/` is the exception: never gitignore it; the outbox must be
+committed to your working branch.
+See `tbd guidelines tbd-sync-troubleshooting` for details.
 
 ## CRITICAL: Session Closing Protocol
 
@@ -169,8 +179,20 @@ working branch. See `tbd guidelines tbd-sync-troubleshooting` for details.
 **Work is not done until pushed, CI passes, and tbd is synced.**
 
 **Remote/proxied session where GitHub seems blocked?** If the environment has egress,
-`gh` works through a scoped `NO_PROXY` bypass — run `tbd shortcut setup-github-cli` and
-follow “Proxied Remote Sessions” before concluding gh is unavailable.
+`gh` works through a scoped `NO_PROXY` bypass.
+Three facts decide most of these:
+
+- The git remote may sit behind a **ref-scoped credential broker**: pushes to
+  `refs/heads/*` succeed, pushes to `refs/tags/*` fail with HTTP 403. Create the tag on
+  the direct channel instead:
+  `gh api repos/OWNER/REPO/git/refs -f ref=refs/tags/vX.Y.Z -f sha=SHA`.
+- `git push --dry-run` **passes** for tags the broker then refuses at receive-pack, so a
+  clean dry run proves nothing.
+- A GitHub-host 403 carrying no `x-github-request-id` header is proxy-manufactured, not
+  an organization egress denial.
+
+Run `tbd shortcut setup-github-cli` and follow “Proxied Remote Sessions” before
+concluding gh is unavailable.
 
 ## Bead Tracking Rules
 


### PR DESCRIPTION
## 0.8.0

tbd could say that work was open, started, or closed.
It could not say *how* work ended, *who* is acting on it as distinct from who owns it,
or that started work is on hold.
This release adds those three axes, and teaches the Linear integration to project them
onto a real board. No format change: repositories stay on `f08`, and there is no
migration step.

### Work can end three ways, not one

`closed` collapsed “we did it”, “we dropped it”, and “this was already filed”.
Closing now takes a resolution:

```bash
tbd close tbd-a1b2 --as canceled --reason "approach superseded"
tbd close tbd-c3d4 --as duplicate --duplicate-of tbd-a1b2
```

`resolution` is `completed` (the default, so existing scripts are unchanged),
`canceled`, or `duplicate`; `duplicate_of` is required with `duplicate` and refused
without it. Both are validated against `status`, so a resolution cannot attach to open
work.

This matters most where it leaves your repository.
A canceled bead previously filed in Linear as **Done** with a completion date stamped on
it, which is wrong data rather than a wrong label.
Now `canceled` maps to Linear’s Canceled with no completion date, and `duplicate`
creates the provider-side duplicate relation from the scalar.

### Who is accountable and who is acting are different fields

`assignee` had to mean both, so in agent-driven repositories it usually meant nothing
and went unused. `delegate` now sits beside it: the human stays accountable, the agent
acts.

```bash
tbd update tbd-a1b2 --assignee alice --delegate claude-agent
tbd start tbd-a1b2            # claims the acting axis, leaving assignee alone
```

`tbd start` sets `delegate` rather than overwriting `assignee`, and `--as <name>` claims
under an explicit agent name.
People resolve through the tracker’s own directory instead of a hand-maintained table,
so a rename survives; `user_map` is still honored as an override.
Publishing a delegate to Linear requires naming an installed Linear agent in
`agent_map`, and an unmapped agent produces a reported skip rather than a silent one.

### Paused work stops erasing that it started

Parking work meant moving it to `deferred`, which discarded the fact that it had ever
started. `hold` is now its own axis:

```bash
tbd pause tbd-a1b2 --until 2026-09-15 --reason "waiting on upstream"
tbd resume tbd-a1b2
```

`hold` is `blocked` or `paused`, with `hold_until` for an expected lift date, and
`started_at` is set on first entry to `in_progress` and never cleared—so a paused bead
still knows it was started.
`tbd ready` excludes anything on hold.
Bulk `tbd update --hold` covers a subtree, which previously meant a per-bead loop.

### A board tbd can project onto

`state_map` maps lifecycle slots to Linear states **by name**, not by board position, so
reordering a board no longer changes what tbd thinks a column means.
It is optional: omit it and tbd maps states as it did before, creating nothing.

`tbd integration setup` proposes the default map, and on confirmation creates the states
a repository asked for—and only those—validated against the team’s real states before
anything is mutated.
It never renames, deletes, or touches a state outside the map.
`tbd doctor` prints the resolved slot table offline, so the projection is inspectable
without a sync.

### Fixes

- **A bead with no assignee no longer clears the assignee in Linear.** An absent
  assignee pushed outbound as an explicit unassign, so populating `user_map`—the
  documented prerequisite for assignee sync—was by itself enough to start erasing
  whoever a human had assigned.
  Observed as steady state rather than a race: one issue lost its assignee, regained it,
  and lost it again on the next sync.
  An absent assignee is now read as no opinion.
  Affects every repository that adopted the integration after its beads existed.
- **`.env` credentials resolve from the main worktree.** `.env` is gitignored, so it
  does not propagate to linked worktrees; a fully configured repository reported
  `LINEAR_API_KEY not found` from any worktree of it, and status read as “Linear is not
  set up here”. Resolution now falls back to the main worktree’s `.env` through git,
  guarded so it cannot read a sibling project under `git init --separate-git-dir`.
- **A sync that skipped a field says so.** Pushes reported a clean summary over fields
  they had dropped. Field-level skips are now named, and `--verbose` names each excluded
  field, distinguishing “not eligible” from “eligible and unchanged”.
- **`--due` and `--defer` accept the dates people actually type**, not only full ISO
  8601 timestamps.
- **`tbd doctor` warns when npm’s global bin directory is not on `PATH`**, and only when
  that finding is actionable.

### Guidelines and content

- **New `agent-session-bootstrap` guideline** covering session startup for agents.
- **The tbd skill now says where beads live.** It never stated that beads are stored on
  the `tbd-sync` branch, and its one branch note pointed the other way, so an agent that
  found no bead changes in its feature branch could report the work lost.
  The skill now states that tbd owns that branch—`tbd sync` maintains it,
  `tbd doctor --fix` repairs it—and that tbd commands, not raw git, are the interface to
  it. ([#238](https://github.com/jlevy/tbd/issues/238))
- **`ensure-gh-cli.sh` states the proxied-session consequences it has already proven.**
  Where it detects that a session proxy intercepts GitHub while direct egress is open,
  it now reports that tags can 403 through a ref-scoped credential broker while branches
  succeed, that `git push --dry-run` passes for tags the broker later refuses, and that
  a GitHub-host 403 with no `x-github-request-id` header is proxy-manufactured rather
  than an egress denial.
  The same facts are in the skill.
  ([#255](https://github.com/jlevy/tbd/issues/255))
- **`setup-linear` covers Linear’s GitHub app**, including that it is an
  organization-level decision rather than a per-repository one.
- **`update-specs-status` gained a dangling `spec_path` sweep** and no longer files
  never-started specs as finished.

### Security

Lockfile is byte-identical to v0.7.1 and no manifest changed, so the resolved dependency
tree is unchanged. `pnpm audit --prod` reports no advisories in the shipped tree;
outstanding advisories are confined to dev tooling (vitest, vite, rollup, postcss and
their transitives).

**Full commit history**:
[Compare v0.7.1 to v0.8.0](https://github.com/jlevy/tbd/compare/v0.7.1...v0.8.0)

---

## Release validation

Candidate commit: `47108ba0` (branch `claude/tbd-release-prep-bjipak`), on top of `c4dd9f38`.

| Gate | Command | Result |
| --- | --- | --- |
| Build + package lint | `pnpm release:verify` | pass — publint "All good!" at 0.8.0 |
| Unit and integration | `pnpm test` | pass — 157 files, 2408 tests |
| CLI goldens | `tryscript run 'tests/**/*.tryscript.md'` | pass — 1101 goldens |
| Format | `pnpm format:check` | pass |
| Lint + typecheck | `pnpm lint:check` | pass |
| Packed upgrade | `pnpm qa:upgrade-package` | pass — all four proofs |

Packed upgrade baselines (defaults, unchanged):

```
Packed upgrade proof passed: 0.7.0 (f08) -> 0.8.0 (f08)
Packed upgrade proof passed: 0.4.2 (f06) -> 0.8.0 (f08)
Packed upgrade proof passed: 0.5.0 (f06) -> 0.8.0 (f08)
Packed legacy-remote proof passed: 0.4.2 (f06) -> 0.8.0 (f08)
```

No downstream first-party checkout was exercised: this release does not change setup,
generated launchers, installation, fallback selection, format migration, or upgrade
recovery. `CURRENT_FORMAT` is unchanged at `f08`.

### Supply chain

Lockfile is byte-identical to `v0.7.1` (`sha256 79c2ed08…98055`) and no `package.json`
changed, so the resolved dependency tree is unchanged and no new package entered the
tree. `pnpm audit --prod` reports no advisories. The 32 advisories from a full
`pnpm audit` are all dev tooling (vitest, vite, rollup, postcss, minimatch,
brace-expansion, nanoid and their transitives) and none are newly introduced here.
`pnpm check:package-age` passes: 0 violations across 31 pins.

### Changelog extraction

`release.yml` builds the GitHub Release body from the `## 0.8.0` heading. Verified
locally that the extractor returns the full 133-line section rather than the
`Release vX.Y.Z` fallback that shipped with v0.1.30 and v0.2.0.

### Issues addressed

- #238 — the tbd skill now states that beads live on `tbd-sync` and that tbd owns that
  branch.
- #255 — `ensure-gh-cli.sh` and the skill now state the ref-scoped broker consequences
  where the proxy condition is already proven.

#244 and #246 are substantively delivered by the state and actor axes in this release;
their specs still carry open engine and dogfooding items, so they are not closed here.
#254 is deliberately deferred — the generated-hook `PATH` reorder carries a named
trade-off and should land as its own change.

---
_Generated by [Claude Code](https://claude.ai/code)_
