### PR TITLE
Add Rust guideline group and cross-cutting topic routing

### DIFF
--- a/docs/project/specs/active/plan-2026-08-23-rust-quality-floor-and-guideline-mapping.md
+++ b/docs/project/specs/active/plan-2026-08-23-rust-quality-floor-and-guideline-mapping.md
@@ -1,6 +1,6 @@
 ---
 title: Rust Quality Floor and Guideline Mapping
-description: Add a strict Rust guideline family to tbd by migrating the Rust Porting Playbook suite, extracting its language-neutral core into shared guidelines, and setting the floor at the strictest of tbd's enforced config, the playbook, and the TypeScript family
+description: Add a strict Rust guideline family to tbd by migrating the Rust Porting Playbook suite, extract the undocumented practices from tbd's enforced config, and split the language-neutral core into shared guidelines
 author: Joshua Levy (github.com/jlevy) with LLM assistance
 category: general
 ---
@@ -12,26 +12,27 @@ category: general
 
 ## Overview
 
-tbd guidelines exist to give agents the *non-obvious* practices that raise code quality:
-strict type-checker flags, high lint floors, and atypical-but-better conventions a model
-will not produce from its priors.
-The TypeScript family does this well.
-tbd has no Rust coverage at all, and the Rust suite that exists in the Rust Porting
-Playbook stops short of defining an enforceable floor.
+tbd guidelines give agents the non-obvious practices that raise code quality: strict
+type-checker flags, high lint floors, and conventions a model will not produce from its
+priors. The TypeScript family does this well.
+tbd has no Rust coverage at all.
 
-This spec plans the migration: which documents move, what each becomes, what gets
-extracted into language-neutral guidelines that all three families share, and how tbd
-routes an agent to the right document for each scenario.
+Three bodies of material feed the fix.
+The Rust Porting Playbook holds a seven-document Rust suite.
+tbd’s own enforced config holds practices that are executable but undocumented.
+tbd’s `docs/general/` holds guideline-grade material that was never bundled.
+Extracting all three, and splitting out what is not language-specific, produces a Rust
+family and closes four coverage gaps that affect every language.
 
 ## Goals
 
-- Ship a Rust guideline family in tbd with the same flavor and structure as the Python
-  and TypeScript families.
-- Set the Rust floor at the *strictest* of the three sources available, with no menu of
-  lax alternatives.
-- Extract the language-neutral core of the playbook’s Rust documents into shared
-  guidelines, so the same rule is written once instead of once per language — and so
-  four real gaps in tbd’s own coverage get closed along the way.
+- Ship a Rust guideline family in tbd with the same shape as the Python and TypeScript
+  families.
+- Set the Rust floor at the strictest of the available sources, with no menu of lax
+  alternatives.
+- Extract the undocumented practices from tbd’s enforced config into guidelines.
+- Extract the language-neutral core of the Rust documents into shared guidelines, so
+  each rule is written once rather than once per language.
 - Keep coverage identical after extraction, with explicit routing from every scenario to
   the documents that own it.
 
@@ -40,184 +41,154 @@ routes an agent to the right document for each scenario.
 - Upstreaming the porting layer.
   Construct mappings, parity evidence, differential testing, and upstream-sync workflows
   stay in the playbook.
-- Rewriting the Python or TypeScript families beyond the edits needed to route them at
-  newly shared guidelines.
-- Retuning tbd’s own ESLint or tsconfig settings.
-  This spec documents and transfers what is already enforced.
-- Porting tbd itself to Rust; that is tracked in the playbook’s active TypeScript plans.
+- Retuning tbd’s ESLint or tsconfig settings.
+  This work documents what is already enforced.
+- Porting tbd itself to Rust, tracked in the playbook’s active TypeScript plans.
 
 ## Background
 
-**Confirmed: tbd has zero Rust coverage today.** No `rust-*` guideline, no
-`review-code-rust` shortcut, no `category: rust`. The 31 bundled guidelines carry five
-categories — `general` (15), `typescript` (8), `python` (3), `desktop` (3), `convex`
-(2). The only mentions of Rust anywhere in `packages/tbd/docs/` are incidental (a
-`ripgrep` reference, a tooling aside).
+**tbd has zero Rust coverage today.** No `rust-*` guideline, no `review-code-rust`
+shortcut, no `category: rust`. The 31 bundled guidelines carry five categories:
+`general` (15), `typescript` (8), `python` (3), `desktop` (3), `convex` (2). The only
+mentions of Rust in `packages/tbd/docs/` are incidental.
 
-The playbook holds 1,765 lines across seven general Rust guidelines, produced by the
+The playbook holds 1,765 lines across seven Rust guidelines, produced by the
 [2026-08-08 reuse review](https://github.com/jlevy/rust-porting-playbook/blob/main/docs/reviews/rust-guideline-reuse-review-2026-08-08.md),
-which already recommends upstreaming them in two waves and tracks it as `rpp-u657`. They
-were written to tbd’s shape — correct frontmatter, actionable rules, related links,
-common footer — so the migration is real but mechanical.
+which recommends upstreaming them in two waves and tracks it as `rpp-u657`. They were
+written to tbd’s shape, so the migration is mechanical.
+The playbook already consumes tbd guidelines through `internal:` docrefs, so
+distribution works in one direction already.
 
-The playbook already consumes tbd guidelines through `internal:` docrefs in its
-`.tbd/config.yml`, so the distribution path is proven in one direction.
+### Four Gaps in tbd’s Own Coverage
 
-### Gaps This Exposes in tbd Itself
-
-Auditing the playbook’s Rust documents against tbd’s catalog turned up four topics tbd
-has no guideline for, in any language:
+Auditing the playbook’s Rust documents against tbd’s catalog found four topics tbd has
+no guideline for, in any language:
 
 | Topic | tbd today | Consequence |
 | --- | --- | --- |
 | Filesystem behavior | Nothing | `eslint.config.js` forbids `fs.writeFile` in favor of `atomically`, and no guideline explains why. The rule is enforced but not taught. |
-| Release engineering | `release-notes-guidelines` only, which is about *notes* | Nothing states release identity, pre-release gates, least-privilege publishing, or artifact smoke tests. |
-| Code review rules | Four `review-code*` shortcuts | The shortcuts are procedures with no rules document to load; severity vocabulary lives only in dated review artifacts. |
-| CI and gate wiring | Scattered across `pnpm-monorepo-patterns`, `typescript-lint-format-rules` §Hooks and Gates, `supply-chain-hardening` | No single answer to “how is a quality gate wired, and how do you prove it is live?” |
+| Release engineering | `release-notes-guidelines`, which covers notes | Nothing states release identity, pre-release gates, least-privilege publishing, or artifact smoke tests. |
+| Code review rules | Four `review-code*` shortcuts | The shortcuts are procedures with no rules document to load. Severity vocabulary lives only in dated review artifacts. |
+| CI and gate wiring | Scattered across `pnpm-monorepo-patterns`, `typescript-lint-format-rules`, and `supply-chain-hardening` | No single answer to how a quality gate is wired and how you prove it is live. |
 
-The playbook has strong material on all four.
-Extracting it serves both repositories at once.
+### Unbundled Material in This Repo
+
+`docs/general/` holds 752 lines of guideline-grade material that `tbd guidelines` does
+not serve, so no tbd user receives it:
+
+| Document | Lines | Content |
+| --- | ---: | --- |
+| `agent-rules/tool-development-rules.md` | 323 | Patterns for LLM-usable tools: registry pattern, testing requirements, pitfalls. Overlaps `cli-agent-skill-patterns`. |
+| `agent-guidelines/typescript-dependency-injection-guidelines.md` | 293 | Dependency injection for testability. |
+| `agent-guidelines/typescript-testing-guidelines.md` | 136 | Testing real system interactions rather than mock existence, integration points, error scenarios, contract compliance. Mostly language-neutral. |
 
 ## Design
 
 ### How the Floor Is Set
 
-The Rust floor is the **strictest of three sources**, not a merge of their averages:
+The Rust floor is the strictest of three sources, not a merge of their averages:
 
-1. **This repo’s enforced config** — `eslint.config.js`, `tsconfig.base.json`,
-   `lefthook.yml`, `scripts/check-eslint-contract.mjs`. The highest bar, because it is
+1. **This repo’s enforced config.** `eslint.config.js`, `tsconfig.base.json`,
+   `lefthook.yml`, `vitest.config.ts`, `scripts/`. The highest bar, because it is
    executable and has survived iteration.
-2. **The playbook’s Rust guidelines** — broadest Rust-specific surface coverage.
-3. **tbd’s TypeScript family** — the structural model, and the source of rules that are
-   really about strictness rather than about TypeScript.
+2. **The playbook’s Rust guidelines.** The broadest Rust-specific surface coverage.
+3. **tbd’s TypeScript family.** The structural model, and the source of rules that are
+   about strictness rather than about TypeScript.
 
 Where they disagree, the strictest wins.
-Where a source has a mechanism the others lack, it is adopted rather than averaged away.
+Where one source has a mechanism the others lack, it is adopted rather than averaged
+away.
 
 **No menus.** A guideline states one default and the conditions for departing from it.
-It does not offer ranked alternatives, because an agent handed options takes the
-cheapest one. `rust-project-setup.md` §"Define a Clippy Policy" currently violates this:
+An agent handed ranked alternatives takes the cheapest one.
+`rust-project-setup.md` §"Define a Clippy Policy" currently offers three lint strategies
+whose first option, default lints plus `-D warnings`, is materially weaker than the
+other two. That menu is deleted and replaced by the floor below.
+Across the seven Rust documents there are 19 instances of choose, may, either, and
+one-of phrasing to resolve the same way.
 
-> Choose and document one lint strategy: 1. default Clippy lints plus `-D warnings`; 2.
-> a curated set of additional lints; or 3. `clippy::pedantic` with explicit, reviewed
-> exceptions.
+### Extraction From This Repo
 
-Option 1 is materially weaker than the other two.
-This menu is deleted and replaced by the floor below.
+Each practice below is enforced in this repo and documented nowhere, or documented only
+inside a TypeScript-specific document.
+The destination column names where it lands.
+
+| Source | Practice | Destination |
+| --- | --- | --- |
+| `eslint.config.js` `no-restricted-imports` | Lint config enforces a correctness invariant—no code path writes a file non-atomically—rather than trusting review to catch it | `filesystem-rules` for the rationale; `rust-lint-format-rules` for the `disallowed-methods` form |
+| `eslint.config.js` and `tsconfig.base.json` ratchet comments | An off-switch carries a tracker ID and a re-enable condition (`tbd-s9vn`, `tbd-tdh3`). A suppression with a tracker ID is debt; one without is decay | `ci-and-gates-rules` |
+| `eslint.config.js` `.claude/worktrees/**` ignore | Agent worktrees hold a nested, mid-edit copy of the repo outside the tsconfig project. Linting them reports another agent’s work as your failures | `ci-and-gates-rules` |
+| `scripts/check-eslint-contract.mjs` | Assert the *effective* config: compute severity for a probe file and require the floor rules at error. A gate that is not itself tested is not a gate | `ci-and-gates-rules` |
+| `scripts/scrub-git-env.mjs`, `tests/scrub-git-env.ts`, `vitest.config.ts` `setupFiles` | Git exports `GIT_DIR` into hook environments, redirecting subprocesses onto the real repository and letting fixtures rewrite real refs (`tbd-a1lc`). Scrub in both the hook wrapper and the test setup; neither layer alone is sufficient | `ci-and-gates-rules`, with a pointer from `general-testing-rules` |
+| `vitest.config.ts` platform-conditional timeouts | Raise a timeout only on the platform where it is genuinely tight, and record the measurement that forced it (`bridge-merge` at 5472ms against a 5000ms budget). A global raise masks hangs everywhere else | `general-testing-rules` |
+| `lefthook.yml` `parallel: false` with priorities | `stage_fixed` jobs each run `git add` and contend on `.git/index.lock`; lefthook honors priority only when not parallel | `ci-and-gates-rules` |
+| `lefthook.yml` `pnpm exec` over `npx` | Hook commands call a pinned local binary and fail if it is missing. A download-capable runner would fetch an unreviewed tool inside the gate | `ci-and-gates-rules` and `supply-chain-hardening` |
+| `lefthook.yml` generated-file excludes | A formatter and a generator must never both own a file. Generated files are formatter-excluded and drift-tested | `ci-and-gates-rules` |
+| `lefthook.yml` flowmark pin | A cool-off exception is recorded inline at the point of use: exact pin, scoped date override, reason, and a named reviewer | `supply-chain-hardening` |
+| `package.json` `lint` versus `lint:check` | Fix mode and verify mode are separate scripts. CI runs the verify one and never commits | `ci-and-gates-rules` |
+| `.github/workflows/ci.yml` | Jobs split so failures answer different questions; `pnpm audit --prod` in the gate; `astral-sh/setup-uv@v8.3.2` pinned to a full tag because that action publishes no floating major | `ci-and-gates-rules` |
+| `docs/general/agent-guidelines/typescript-testing-guidelines.md` | Test real system interactions, not mock existence. Test integration points, error scenarios, and contract compliance | Neutral sections to `general-testing-rules`; bundle the TypeScript remainder |
+| `docs/general/agent-rules/tool-development-rules.md` | LLM-usable tool design | Reconcile with `cli-agent-skill-patterns`, then bundle what survives |
+| `docs/general/agent-guidelines/typescript-dependency-injection-guidelines.md` | Dependency injection for testability | Bundle as a `typescript` guideline |
+| `docs/project/retrospectives/`, `docs/project/reviews/` | Dated project evidence | Cite, never copy |
+
+### Extraction From the Playbook
+
+Every Rust document, what it becomes, and where it lands.
+“Neutral core” means the sections move into a shared guideline that Python and
+TypeScript also use, and the Rust document keeps only what is Rust-specific.
+
+| Playbook document | Lines | Disposition | tbd destination | Wave |
+| --- | ---: | --- | --- | --- |
+| `rust-rules.md` | 287 | Move as-is | `rust-rules` (`globs: "*.rs"`, `alwaysApply: true`) | 1 |
+| *(new)* `rust-lint-format-rules.md` | — | Author, per the floor below | `rust-lint-format-rules` (`globs: "*.rs"`, `alwaysApply: true`) | 1 |
+| `rust-project-setup.md` | 327 | Split; 4 of 12 content sections are neutral | `rust-project-setup` keeps Cargo shape, features, toolchain, rustfmt; CI, local-command parity, automation review, and dependency policy go to `ci-and-gates-rules` | 1 |
+| `rust-cli-rules.md` | 290 | Move; drop the porting-parity pointer | `rust-cli-rules` | 1 |
+| `rust-testing-rules.md` | 201 | Move; route generic assertions at `general-testing-rules` | `rust-testing-rules` | 1 |
+| `rust-filesystem-rules.md` | 234 | Split; 9 of 10 content sections are neutral | `filesystem-rules` takes planning versus mutation, atomic visibility versus crash durability, backup and collision policy, cross-device moves, deterministic traversal, symlink boundaries, honest partial failure, state-machine testing; `rust-filesystem-rules` keeps `Path` and `OsStr` types and platform metadata | 2 |
+| `rust-release-rules.md` | 267 | Split; 13 of 15 content sections are neutral | `release-engineering-rules` takes release identity, pre-release gate, automation choice, workflow authority, tooling cool-off, build-once, packaging, smoke tests, channel selection, multi-channel coordination, release-logic tests, incident preparation; `rust-release-rules` keeps crates.io trusted publishing and maturin wheels | 2 |
+| `rust-code-review-rules.md` | 159 | Split; 6 of 7 content sections are neutral | `code-review-rules` takes severity, rule loading, baseline, risk ordering, actionable findings, quick scan; `rust-code-review-rules` keeps unsafe and FFI review | 2 |
+| *(new)* `review-code-rust.md` | — | Author, mirroring `review-code-typescript` | `shortcuts/standard/review-code-rust.md` | 2 |
+| `porting-principles-and-antipatterns.md`, `python-to-rust-*.md`, `filesystem-heavy-cli-porting.md`, `test-coverage-for-porting.md` | 1,674 | Stays in the playbook | — | — |
+
+Result in tbd: 8 `rust-*` guidelines and 1 shortcut, plus 4 shared guidelines the
+TypeScript and Python families also gain.
 
 ### The Rust Floor
 
-New guideline `rust-lint-format-rules`, mirroring `typescript-lint-format-rules`
-section-for-section: The Floor → The `[lints]` Floor → Hooks and Gates → Verifying the
-Floor. Every floor rule is derived from something already enforced, not invented:
+`rust-lint-format-rules` mirrors `typescript-lint-format-rules` section for section: The
+Floor, The `[lints]` Floor, Hooks and Gates, Verifying the Floor.
+Every rule is derived from something already enforced.
 
 | Source rule | Rust analogue | Mechanism |
 | --- | --- | --- |
 | Everything auto-formattable is auto-formatted | `cargo fmt --all`; `taplo fmt` for TOML; flowmark for Markdown; `--check` in CI | `rustfmt.toml`, CI |
 | Zero-tolerance, verify-only lint gate | `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`; never `--fix` in CI | CI job |
-| Type checking is a separate strict gate | `[lints.rust] unsafe_code = "forbid"`; `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` as the doc-link gate | `Cargo.toml`, CI |
-| Strictest standard preset plus named rules | `clippy::pedantic` at `warn` with `priority = -1`, plus the named picks below | `[lints.clippy]` |
-| `noUncheckedIndexedAccess` | `clippy::indexing_slicing` — forces `.get()` over `[i]` | `[lints.clippy]` |
-| Exhaustiveness checks | `clippy::wildcard_enum_match_arm` — a new variant becomes an error, not a silent `_ =>` | `[lints.clippy]` |
+| Type checking is a separate strict gate | `[lints.rust] unsafe_code = "forbid"`; `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` | `Cargo.toml`, CI |
+| Strictest standard preset plus named rules | `clippy::pedantic` at `warn` with `priority = -1`, plus the picks below | `[lints.clippy]` |
+| `noUncheckedIndexedAccess` | `clippy::indexing_slicing`, forcing `.get()` over `[i]` | `[lints.clippy]` |
+| Exhaustiveness checks | `clippy::wildcard_enum_match_arm`, so a new variant is an error rather than a silent `_ =>` | `[lints.clippy]` |
 | `no-floating-promises` | `clippy::let_underscore_future`, `#[must_use]` discipline, `unused_must_use` at deny | `[lints.clippy]`, `[lints.rust]` |
 | `no-restricted-imports` forcing atomic writes | `disallowed-methods` naming `std::fs::write` and `std::fs::File::create`, directing to `tempfile::NamedTempFile::persist` | `clippy.toml` |
 | Strict-preset tuning with a stated reason | `clippy::unwrap_used` and `expect_used` denied outside tests; `panic` denied in library code | `[lints.clippy]` |
 | Exceptions are narrow and file-scoped | `#[expect(lint, reason = "...")]` at the narrowest scope | attribute |
-| Legacy ratchets toward strict | per-crate `[lints]` overrides, each off-switch carrying a tracker ID in a comment | `Cargo.toml` |
+| Legacy ratchets toward strict | Per-crate `[lints]` overrides, each off-switch carrying a tracker ID | `Cargo.toml` |
 
-Two entries carry most of the value:
+Two entries carry most of the value.
+`disallowed-methods` is the Rust `no-restricted-imports`: the playbook states the
+atomic-replacement rule in prose without wiring it to enforcement, and `clippy.toml`
+supports exactly this.
+`#[expect]` improves on the TypeScript equivalent, because it warns once the suppression
+is unnecessary, so exceptions expire on their own; the TypeScript floor needs a written
+rule to remove obsolete exceptions because its tooling cannot.
+Where Rust has the better mechanism, the Rust document uses it rather than mirroring.
 
-- **`disallowed-methods` is the Rust `no-restricted-imports`.** tbd uses lint config to
-  enforce a *correctness invariant* — that no code path writes a file non-atomically —
-  rather than trusting reviewers to notice.
-  `clippy.toml` supports exactly this, and the playbook’s filesystem rules state the
-  atomic-replacement rule in prose without wiring it to enforcement.
-- **`#[expect]` beats the TypeScript equivalent.** It warns once the suppression is
-  unnecessary, so exceptions expire on their own.
-  The TypeScript floor needs a written “remove obsolete exceptions” rule because its
-  tooling cannot do this.
-  Where Rust has the better mechanism, the Rust document uses it rather than mirroring.
-
-The floor table is a design proposal, not a validated configuration.
+This table is a design proposal.
 Phase 3 validates it against a real Rust codebase before it ships.
-
-### Document Migration Map
-
-Every playbook Rust document, what it becomes, and where it lands.
-“Neutral core” means the sections move into a shared guideline that Python and
-TypeScript also use; the Rust document keeps only what is genuinely Rust-specific and
-routes to the shared one.
-
-| Playbook document | Lines | Disposition | tbd destination(s) | Wave |
-| --- | ---: | --- | --- | --- |
-| `rust-rules.md` | 287 | Move as-is | `guidelines/rust-rules.md` (`category: rust`, `globs: "*.rs"`, `alwaysApply: true`) | 1 |
-| *(new)* `rust-lint-format-rules.md` | — | Author new, per the floor above | `guidelines/rust-lint-format-rules.md` (`globs: "*.rs"`, `alwaysApply: true`) | 1 |
-| `rust-project-setup.md` | 327 | Split: 4 of 12 content sections are neutral | `guidelines/rust-project-setup.md` (Cargo, features, toolchain, rustfmt) + `guidelines/ci-and-gates-rules.md` (new, general) | 1 |
-| `rust-cli-rules.md` | 290 | Move; drop the porting-parity pointer | `guidelines/rust-cli-rules.md` | 1 |
-| `rust-testing-rules.md` | 201 | Move; route generic assertions at `general-testing-rules` | `guidelines/rust-testing-rules.md` | 1 |
-| `rust-filesystem-rules.md` | 234 | Split: 9 of 10 content sections are neutral | `guidelines/filesystem-rules.md` (new, general) + thin `guidelines/rust-filesystem-rules.md` (`Path`/`OsStr` types, `walkdir`, platform metadata) | 2 |
-| `rust-release-rules.md` | 267 | Split: 13 of 15 content sections are neutral | `guidelines/release-engineering-rules.md` (new, general) + thin `guidelines/rust-release-rules.md` (crates.io trusted publishing, maturin wheels) | 2 |
-| `rust-code-review-rules.md` | 159 | Split: 6 of 7 content sections are neutral | `guidelines/code-review-rules.md` (new, general) + thin `guidelines/rust-code-review-rules.md` (unsafe and FFI review) | 2 |
-| *(new)* `review-code-rust.md` | — | Author new, mirroring `review-code-typescript` | `shortcuts/standard/review-code-rust.md` | 2 |
-| `porting-principles-and-antipatterns.md`, `python-to-rust-*.md`, `filesystem-heavy-cli-porting.md`, `test-coverage-for-porting.md` | 1,674 | **Stays in the playbook** | — | — |
-
-Result in tbd: 8 `rust-*` documents and 1 shortcut, plus 4 new `general` guidelines that
-the TypeScript and Python families also gain.
-
-### New Language-Neutral Guidelines
-
-Each absorbs material from more than one source, which is what makes the extraction pay
-for itself:
-
-**`filesystem-rules`** (general) — planning vs.
-mutation, atomic visibility vs.
-crash durability, backup and collision policy, cross-device moves as copies,
-deterministic traversal with error propagation, symlink and root boundaries, honest
-partial failure, testing the state machine rather than final bytes.
-Absorbs the rationale behind tbd’s `atomically` enforcement, which is currently an
-unexplained ESLint rule.
-Routes to `rust-filesystem-rules` and (new) a short TypeScript section in
-`typescript-rules` §File Operations.
-
-**`release-engineering-rules`** (general) — one release identity, clean pre-release
-gate, deliberate automation, minimal workflow authority, cool-off for release tooling,
-build once per target, predictable packaging, smoke-test the packaged artifact, channels
-chosen by audience, multi-channel coordination without rebuilding, release logic tested
-outside the workflow, incident preparation.
-Absorbs tbd’s own practice (`release.yml`, `publint`, `release:verify`, the packed
-upgrade proof in CI). Complements, does not replace, `release-notes-guidelines`.
-
-**`code-review-rules`** (general) — Blocker/High/Medium/Low severity, loading the rules
-that own the changed surface, establishing the review baseline, reviewing highest-risk
-boundaries first, findings that can be acted on, the quick scan.
-Gives the four existing `review-code*` shortcuts a rules document to load; they
-currently have none.
-
-**`ci-and-gates-rules`** (general) — one local command matching CI, CI jobs as
-independent evidence, reviewable development automation, dependency and supply-chain
-policy at the gate. Absorbs the neutral half of `typescript-lint-format-rules` §"Hooks
-and Gates Reference" and becomes the home for the four cross-language practices
-currently trapped in tbd’s config comments:
-
-1. **Tracked ratchets.** tbd disables `@typescript-eslint/no-unnecessary-condition` and
-   omits `exactOptionalPropertyTypes`, each off-switch carrying a bead ID (`tbd-s9vn`,
-   `tbd-tdh3`) and a re-enable condition.
-   A suppression with a tracker ID is debt; one without is decay.
-2. **Config-contract checks.** `scripts/check-eslint-contract.mjs` computes the
-   *effective* config and asserts floor rules are live at error severity, catching the
-   case where the gate stays green while the floor is silently off.
-   A quality gate that is not itself tested is not a gate.
-3. **Hostile hook environments.** `scripts/scrub-git-env.mjs` exists because git exports
-   `GIT_DIR` into hook environments, redirecting every git subprocess the test suite
-   spawned onto the real repository and letting fixtures rewrite real refs and tbd data
-   (`tbd-a1lc`). Any tool whose tests shell out to git hits this.
-4. **Generator versus formatter ownership.** Generated files are formatter-excluded and
-   drift-tested; a formatter and a generator must never both own a file.
 
 ### Routing
 
 Extraction only works if an agent still lands on the right document.
-Four routing mechanisms, all already used by tbd:
 
 | Scenario | Loads |
 | --- | --- |
@@ -226,42 +197,47 @@ Four routing mechanisms, all already used by tbd:
 | Rust CLI work | `rust-cli-rules`, `error-handling-rules` |
 | Any filesystem mutation | `filesystem-rules`, plus `rust-filesystem-rules` in Rust |
 | Any release | `release-engineering-rules`, `release-notes-guidelines`, plus `rust-release-rules` in Rust |
-| Reviewing Rust | `tbd shortcut review-code-rust` → `code-review-rules`, `rust-code-review-rules`, and the topic guidelines matching the diff |
+| Reviewing Rust | `review-code-rust`, which loads `code-review-rules`, `rust-code-review-rules`, and the topic guidelines matching the diff |
 | Wiring or debugging a quality gate | `ci-and-gates-rules`, plus the language floor document |
 
-Enforced by: `globs`/`alwaysApply` frontmatter; a `**Related**:` block under each H1;
-`description` text that makes `tbd guidelines --list` self-routing; and
+Enforced by `globs` and `alwaysApply` frontmatter, a `**Related**:` block under each H1,
+`description` text that makes `tbd guidelines --list` self-routing, and
 `docs_cache.files` entries so every new name is served.
 
-### Mechanical Conversion Checklist
+### Conversion Checklist
 
 Applies to every migrated document.
-The current state was measured, not assumed:
+Current state was measured, not assumed:
 
-- [ ] **Relative links → bare guideline names.** All seven documents cross-link as
-  `](rust-rules.md)`. These break once served from `.tbd/docs/`. Convert to
-  `` `rust-rules` `` per the `new-guideline` shortcut.
-- [ ] **Anchor links dropped or rewritten.** Three documents use section anchors
-  (`rust-testing-rules.md#test-filesystem-behavior-in-isolated-roots` and two more);
-  anchors do not survive the split.
+- [ ] **Relative links to bare names.** All seven documents cross-link as
+  `](rust-rules.md)`, which breaks once served from `.tbd/docs/`.
+- [ ] **Anchors rewritten.** Three documents use section anchors that do not survive the
+  split.
 - [ ] **Repo-local links resolved.** `rust-project-setup` and `rust-release-rules` link
-  to `../SUPPLY-CHAIN-SECURITY.md`; `rust-release-rules` also links to
-  `../docs/project/research/research-rust-cli-pypi-distribution.md`. Retarget at
-  `supply-chain-hardening` or a full public URL.
+  to `../SUPPLY-CHAIN-SECURITY.md`; `rust-release-rules` also links to a research
+  document under `../docs/`.
 - [ ] **Porting pointers removed.** `rust-cli-rules`, `rust-filesystem-rules`, and
-  `rust-testing-rules` link to playbook porting documents that will not exist in tbd.
+  `rust-testing-rules` link to playbook documents that will not exist in tbd.
 - [ ] **Frontmatter completed.** Add `globs: "*.rs"` and `alwaysApply: true` to
-  `rust-rules` and `rust-lint-format-rules`, matching their TypeScript counterparts.
-  `category: rust` is a new category; confirm `tbd guidelines --list` groups it.
-- [ ] **`**Related**:` block added under the H1.** All seven put related links in a
-  trailing H2 only. Keep that section, add the header block, matching Python and
+  `rust-rules` and `rust-lint-format-rules`. `category: rust` is a new category.
+- [ ] **Related block added under the H1.** All seven put related links in a trailing H2
+  only. Keep that section and add the bolded `Related` header block, matching Python and
   TypeScript.
-- [ ] **Optionality removed.** Seven documents contain 19 instances of
-  choose/may/either/one-of phrasing.
-  Each becomes one default plus the conditions for departing from it.
-- [ ] **Tracker language generalized.** “tracking issue or bead”, never “bead”.
-- [ ] **Severity vocabulary** is Blocker / High / Medium / Low.
-- [ ] **Footer and formatting.** `common-doc-guidelines` footer; flowmark-clean.
+- [ ] **Optionality removed**, per the no-menus rule.
+- [ ] **Tracker language generalized** to “tracking issue or bead”.
+- [ ] **Severity vocabulary** is Blocker, High, Medium, Low.
+- [ ] **`common-doc-guidelines` followed**, including the footer and flowmark-clean
+  formatting.
+
+### Execution
+
+The playbook is checked out with push access at `/home/user/rust-porting-playbook`; the
+copy under `attic/` stays read-only for reference.
+Playbook changes (the new floor document, the no-menus edits, the structural
+regressions) land there on their own branch.
+tbd changes (the shared guidelines, the migrated Rust family, the shortcut) land on a
+tbd branch. Each side gets its own pull request so the review venues stay separate, as
+the reuse review recommended.
 
 ## Implementation Plan
 
@@ -271,76 +247,79 @@ The current state was measured, not assumed:
 - [ ] Confirm `category: rust` renders correctly in `tbd guidelines --list`.
 - [ ] Record per-document deltas against the conversion checklist.
 
-### Phase 2: Extract the Neutral Guidelines
+### Phase 2: Extract the Shared Guidelines
 
 - [ ] Author `ci-and-gates-rules`, `code-review-rules`, `filesystem-rules`, and
-  `release-engineering-rules` in `packages/tbd/docs/guidelines/`.
+  `release-engineering-rules` in `packages/tbd/docs/guidelines/`, absorbing the
+  extraction table above.
+- [ ] Expand `general-testing-rules` with the neutral half of
+  `typescript-testing-guidelines`, the platform-conditional timeout rule, and the
+  hostile-environment pointer.
 - [ ] Point `typescript-lint-format-rules` §Hooks and Gates and floor rules 6 and 8 at
-  `ci-and-gates-rules` instead of restating them.
-- [ ] Add the `filesystem-rules` pointer to `typescript-rules` §File Operations, so the
-  `atomically` ESLint rule finally has a documented rationale.
+  `ci-and-gates-rules` rather than restating them.
+- [ ] Add the `filesystem-rules` pointer to `typescript-rules` §File Operations, giving
+  the `atomically` rule a documented rationale.
 - [ ] Have the `review-code*` shortcuts load `code-review-rules`.
+- [ ] Bundle or retire the three unbundled `docs/general/` documents.
 
 ### Phase 3: Author and Validate the Rust Floor
 
-- [ ] Draft `rust-lint-format-rules` in the playbook, mirroring the TypeScript document.
-- [ ] Validate the `[lints]` block and `clippy.toml` against a real Rust codebase —
+- [ ] Draft `rust-lint-format-rules` in the playbook.
+- [ ] Validate the `[lints]` block and `clippy.toml` against a real Rust codebase.
   flowmark-rs is the natural target, being first-party and the playbook’s primary case
-  study. Record which lints fire, which are noise, and which need a project exception.
+  study. Record which lints fire, which are noise, and which need an exception.
 - [ ] Build the Rust config-contract check: a probe fixture the lint gate must reject,
   wired into CI.
-- [ ] Reduce `rust-project-setup` §"Define a Clippy Policy" to a pointer, deleting the
-  three-option menu.
+- [ ] Reduce `rust-project-setup` §"Define a Clippy Policy" to a pointer.
 
 ### Phase 4: Migrate
 
 - [ ] Wave 1: `rust-rules`, `rust-lint-format-rules`, `rust-project-setup`,
-  `rust-cli-rules`, `rust-testing-rules` — applying the conversion checklist.
+  `rust-cli-rules`, `rust-testing-rules`, applying the conversion checklist.
 - [ ] Wave 2: the three split documents plus `review-code-rust`.
 - [ ] Register every new name in `docs_cache.files` as an `internal:` docref.
-- [ ] Repoint the playbook’s `.tbd/config.yml` at `internal:guidelines/rust-*.md` so it
-  consumes them as it consumes the TypeScript family, and stops being their home.
+- [ ] Repoint the playbook’s `.tbd/config.yml` at `internal:guidelines/rust-*.md`, so it
+  consumes them as it consumes the TypeScript family.
 - [ ] Record the outcome in the playbook’s `_meta/playbook-improvement-log.md`.
 
 ## Testing Strategy
 
 - Extend the playbook’s `tests/test_rust_guidelines.py` to assert the conversion
-  checklist, so structure regressions fail there before migration.
-- Validate the Rust floor empirically in Phase 3 against flowmark-rs, not by inspection.
+  checklist, so structure regressions fail before migration.
+- Validate the Rust floor against flowmark-rs, not by inspection.
 - The config-contract probe is the test for the floor itself.
-- tbd-side: `pnpm ci:quality` plus the forkable-docs tests cover new bundled guidelines;
-  confirm `tbd docs sync` serves each new name and `tbd guidelines <name>` resolves it.
-- Coverage check after extraction: every H2 section in the seven source documents maps
-  to a section in some destination document.
+- tbd side: `pnpm ci:quality` and the forkable-docs tests cover new bundled guidelines.
+  Confirm `tbd docs sync` serves each new name and `tbd guidelines <name>` resolves it.
+- After extraction, every H2 section in the source documents maps to a section in some
+  destination document.
   No section is dropped silently.
 
 ## Open Questions
 
 - **Does the Rust floor need a profile layer?** Probably not.
   `typescript-lint-format-rules` needs profiles because ESLint and Biome are genuine
-  alternatives; Rust has one formatter and one linter, so the Rust document should be
-  shorter than its model, with a single configuration and no branches.
+  alternatives. Rust has one formatter and one linter, so the Rust document should be
+  shorter than its model, with a single configuration.
 - **Is `clippy::indexing_slicing` tolerable codebase-wide,** or does it need test-file
-  scoping the way tbd scopes its `no-unsafe-*` relaxations to tests?
+  scoping the way tbd scopes its `no-unsafe-*` relaxations?
   Phase 3 answers this with evidence.
 - **Where is `rust-lint-format-rules` authored?** Drafting in the playbook keeps one
-  review venue and one validation target; drafting directly in tbd avoids a second
-  migration. Leaning playbook, since Phase 3 validation happens there.
-- **Do the four new neutral guidelines need Python counterparts filed?** The Python
-  family has no filesystem or release document either.
-  Extraction makes them available, but Python-specific companions are out of scope here.
+  review venue and one validation target; drafting in tbd avoids a second migration.
+  Leaning playbook, since Phase 3 validation happens there.
+- **Do the shared guidelines need Python counterparts?** The Python family has no
+  filesystem or release document either.
+  Extraction makes the shared ones available; Python-specific companions are out of
+  scope here.
 
 ## References
 
-- [`typescript-lint-format-rules`](https://github.com/jlevy/tbd/blob/main/packages/tbd/docs/guidelines/typescript-lint-format-rules.md)
-  — the model document
-- [`general-eng-agent-principles`](https://github.com/jlevy/tbd/blob/main/packages/tbd/docs/guidelines/general-eng-agent-principles.md)
-- [`supply-chain-hardening`](https://github.com/jlevy/tbd/blob/main/packages/tbd/docs/guidelines/supply-chain-hardening.md)
-- [Rust guideline reuse review, 2026-08-08](https://github.com/jlevy/rust-porting-playbook/blob/main/docs/reviews/rust-guideline-reuse-review-2026-08-08.md)
-  — prior art and the two-wave recommendation
+- `typescript-lint-format-rules`, the model document
+- `general-eng-agent-principles`, `common-doc-guidelines`, `supply-chain-hardening`
+- [Rust guideline reuse review, 2026-08-08](https://github.com/jlevy/rust-porting-playbook/blob/main/docs/reviews/rust-guideline-reuse-review-2026-08-08.md),
+  prior art and the two-wave recommendation
 - [Playbook guidelines index](https://github.com/jlevy/rust-porting-playbook/blob/main/guidelines/README.md)
-- tbd enforcement config: `eslint.config.js`, `tsconfig.base.json`, `lefthook.yml`,
-  `scripts/check-eslint-contract.mjs`, `scripts/scrub-git-env.mjs`,
+- This repo’s enforced config: `eslint.config.js`, `tsconfig.base.json`, `lefthook.yml`,
+  `vitest.config.ts`, `scripts/check-eslint-contract.mjs`, `scripts/scrub-git-env.mjs`,
   `scripts/check-package-age.mjs`
 
 <!-- This document follows common-doc-guidelines.md.

--- a/docs/project/specs/active/plan-2026-08-23-rust-quality-floor-and-guideline-mapping.md
+++ b/docs/project/specs/active/plan-2026-08-23-rust-quality-floor-and-guideline-mapping.md
@@ -1,0 +1,311 @@
+---
+title: Rust Quality Floor and Guideline Mapping
+description: Map the quality insights accumulated in tbd and the Rust Porting Playbook, extract the non-obvious enforcement practices into a Rust guideline suite, and make the Rust family consistent with the Python and TypeScript families
+author: Joshua Levy (github.com/jlevy) with LLM assistance
+category: general
+---
+# Feature: Rust Quality Floor and Guideline Mapping
+
+**Date:** 2026-08-23 (last updated 2026-08-23)
+
+**Status:** Draft
+
+## Overview
+
+tbd guidelines exist to give agents the *non-obvious* practices that raise code quality:
+strict type-checker flags, high lint floors, and atypical-but-better conventions that a
+model will not produce from its priors.
+The TypeScript family does this well.
+The Rust suite in the Rust Porting Playbook covers a large surface but stops short of
+defining an enforceable floor, and none of it is distributed through tbd.
+
+This spec inventories where every kind of insight currently lives across both
+repositories, identifies which insights are portable, and plans the two-way transfer:
+playbook Rust guidelines up into tbd, and tbd’s enforcement practices across into Rust.
+
+## Goals
+
+- Produce a single map of insight *kinds* and their current homes across tbd and the
+  playbook, so later passes stop rediscovering the same material.
+- Define a real Rust lint and type-strictness floor (`rust-lint-format-rules`) modeled
+  section-for-section on `typescript-lint-format-rules`, replacing the current “choose
+  one of three Clippy strategies” optionality.
+- Extract the enforcement practices that exist in tbd only as executable config
+  (`eslint.config.js`, `tsconfig.base.json`, `lefthook.yml`, `scripts/`) into
+  documented, language-neutral or Rust-specific rules.
+- Bring the seven existing Rust guidelines up to the tbd frontmatter and cross-reference
+  contract so they can ship as bundled tbd guidelines.
+- Add `review-code-rust` so the Rust family has the same shortcut coverage as Python and
+  TypeScript.
+
+## Non-Goals
+
+- Upstreaming the porting layer.
+  Construct mappings, parity evidence, differential testing, and upstream-sync workflows
+  stay in the playbook; only source-language-independent Rust guidance moves to tbd.
+- Rewriting the Python or TypeScript families.
+  They are the reference shape here, changed only where a genuinely cross-language rule
+  is being lifted out of them.
+- Changing tbd’s own ESLint or tsconfig settings.
+  This spec documents and transfers what is already enforced; it does not retune it.
+- Porting tbd itself to Rust.
+  That is tracked separately in the playbook’s active TypeScript-to-Rust plans.
+
+## Background
+
+Two repositories hold the relevant material:
+
+- **tbd** (this repo, TypeScript): 31 bundled guidelines in
+  `packages/tbd/docs/guidelines/`, plus a decade’s worth of enforcement decisions baked
+  into executable config at the repo root.
+  The config layer is where the highest-value, least-documented practices live.
+- **Rust Porting Playbook** (`attic/rust-porting-playbook/`, cloned for this review):
+  seven general Rust guidelines plus five porting guidelines, produced by the
+  [2026-08-08 reuse review](https://github.com/jlevy/rust-porting-playbook/blob/main/docs/reviews/rust-guideline-reuse-review-2026-08-08.md),
+  which already recommends upstreaming the reusable suite to tbd in two waves and tracks
+  it as `rpp-u657`.
+
+The playbook already consumes tbd guidelines through `internal:` docrefs in its
+`.tbd/config.yml`, so the distribution mechanism for the reverse direction exists and is
+proven. What is missing is a `rust-*` set on tbd’s side to point at.
+
+## Design
+
+### Insight Taxonomy
+
+Insights fall into five kinds.
+The kind determines both where a rule belongs and whether it can travel.
+
+| Kind | What it is | Where it lives in tbd | Where it lives in the playbook | Portable? |
+| --- | --- | --- | --- | --- |
+| A. Enforced config | Settings that make a rule unskippable | `eslint.config.js`, `tsconfig.base.json`, `lefthook.yml`, `package.json` scripts, `.github/workflows/ci.yml`, `scripts/*.mjs` | `.github/workflows/docs-quality.yml`, `scripts/check_*.py` | Concept yes, syntax no |
+| B. Codified guidelines | Prose rules an agent loads on demand | `packages/tbd/docs/guidelines/` (general, python, typescript families) | `guidelines/` (rust + porting families) | Directly |
+| C. Process assets | Shortcuts, templates, references | `packages/tbd/docs/{shortcuts,templates,references}/` | `playbooks/`, `references/`, `_meta/*-template.md` | Directly |
+| D. Project evidence | Dated findings tied to one codebase | `docs/project/{specs,reviews,retrospectives,research}/` | `case-studies/`, `docs/reviews/`, `_meta/playbook-improvement-log.md` | No — cite, never copy |
+| E. Distribution | How a doc reaches an agent | `.tbd/config.yml` `docs_cache`, `tbd docs fork`, `docs_cache.local_dirs`, `tbd guidelines --add=<url>` | consumes tbd via `internal:` docrefs | N/A |
+
+Kind A is the priority.
+It holds the practices the user is asking for and it is the least documented, because a
+config file is the enforcement, not the explanation.
+
+### Finding: Floor Versus Optionality
+
+`typescript-lint-format-rules.md` states a floor — “These rules are the minimum for
+every project.
+A project may add rules; it may not drop these” — then gives per-toolchain
+profiles that implement it and a
+[Verifying the Floor](https://github.com/jlevy/tbd/blob/main/packages/tbd/docs/guidelines/typescript-lint-format-rules.md)
+section that proves the floor is live.
+
+`rust-project-setup.md` §"Define a Clippy Policy" instead says:
+
+> Choose and document one lint strategy: 1. default Clippy lints plus `-D warnings`; 2.
+> a curated set of additional lints; or 3. `clippy::pedantic` with explicit, reviewed
+> exceptions.
+
+Option 1 is materially weaker than the other two, and an agent handed three options will
+take the cheapest. This is the single largest quality gap between the families, and
+closing it is the highest-value item in this spec.
+
+### The Proposed Rust Floor
+
+New guideline `rust-lint-format-rules.md`, mirroring the TypeScript document’s
+structure: The Floor → The `[lints]` Floor → profiles → Hooks and Gates → Verifying the
+Floor.
+
+Each floor rule is derived from an existing tbd rule, not invented:
+
+| tbd floor rule (source) | Rust analogue | Mechanism |
+| --- | --- | --- |
+| Everything auto-formattable is auto-formatted | `cargo fmt --all`; `taplo fmt` for TOML; flowmark for Markdown; `--check` variants in CI | `rustfmt.toml`, CI |
+| Zero-tolerance, verify-only lint gate | `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`; never `--fix` in CI | CI job |
+| Type checking is a separate strict gate | `[lints.rust] unsafe_code = "forbid"`; `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` as the doc-link gate | `Cargo.toml`, CI |
+| Strictest standard preset plus named rules | `clippy::pedantic` at `warn` with `priority = -1`, plus the named restriction picks below | `[lints.clippy]` |
+| `noUncheckedIndexedAccess` | `clippy::indexing_slicing` — forces `.get()` over `[i]` | `[lints.clippy]` |
+| Exhaustiveness checks / `noFallthroughCasesInSwitch` | `clippy::wildcard_enum_match_arm` — a new enum variant becomes a compile error, not a silent `_ =>` | `[lints.clippy]` |
+| `no-floating-promises` | `clippy::let_underscore_future` plus `#[must_use]` discipline; `unused_must_use` at deny | `[lints.clippy]`, `[lints.rust]` |
+| `no-restricted-imports` forcing atomic writes | `disallowed-methods` naming `std::fs::write` and `std::fs::File::create`, directing to `tempfile::NamedTempFile::persist` | `clippy.toml` |
+| Strict-preset tuning with a stated reason | `clippy::unwrap_used` and `expect_used` denied outside tests; `panic` denied in library code | `[lints.clippy]` |
+| Exceptions are narrow and file-scoped | `#[expect(lint, reason = "...")]` at the narrowest scope | attribute |
+| Legacy ratchets toward strict | per-crate `[lints]` overrides, each off-switch carrying a tracker ID in a comment | `Cargo.toml` |
+
+Two of these deserve emphasis because they are the ones an agent will not reach for on
+its own:
+
+- **`disallowed-methods` is the Rust `no-restricted-imports`.** tbd uses lint config to
+  enforce a *correctness invariant* — that no code path writes a file non-atomically —
+  rather than trusting reviewers to notice.
+  `clippy.toml` supports exactly this, and `rust-filesystem-rules.md` already states the
+  atomic-replacement rule in prose without wiring it to enforcement.
+- **`#[expect]` is strictly better than the TypeScript equivalent.** It warns when the
+  suppression is no longer needed, so exceptions expire on their own.
+  The TypeScript floor has to say “remove obsolete exceptions” as a rule because the
+  tooling cannot. This is a case where the Rust guideline should not merely mirror the
+  TypeScript one.
+
+The floor table above is a design proposal, not a validated configuration.
+Phase 3 validates it against a real Rust codebase before it ships.
+
+### Cross-Language Rules to Lift Out
+
+Four practices are currently trapped in TypeScript-specific documents or in tbd’s config
+comments, but are language-neutral.
+They should move to the `general-*` family so the Rust suite inherits them instead of
+restating them:
+
+1. **The tracked ratchet.** tbd disables `@typescript-eslint/no-unnecessary-condition`
+   and omits `exactOptionalPropertyTypes`, and each off-switch carries a bead ID
+   (`tbd-s9vn`, `tbd-tdh3`) and a re-enable condition in a comment.
+   A suppression with a tracker ID is debt; one without is decay.
+   Currently only floor rule 8 of the TypeScript document says this.
+2. **The config-contract check.** `scripts/check-eslint-contract.mjs` computes the
+   *effective* config and asserts the floor rules are live at error severity, catching
+   the case where the gate stays green while the floor is silently off.
+   The rule generalizes: a quality gate that is not itself tested is not a gate.
+   Its Rust form is a probe fixture that lint must reject.
+3. **Hook subprocesses inherit a hostile environment.** `scripts/scrub-git-env.mjs`
+   exists because git exports `GIT_DIR` into hook environments, which redirected every
+   git subprocess the test suite spawned onto the real repository and let fixtures
+   rewrite real refs and tbd data (`tbd-a1lc`). Any tool whose tests shell out to git
+   hits this; it is not a TypeScript concern, and it is directly relevant to Rust ports
+   of git-touching CLIs.
+4. **Generated files are formatter-excluded and drift-tested.** tbd excludes `.tbd/`,
+   `.claude/skills/`, `.agents/skills/` and `AGENTS.md` from the Markdown formatter
+   because they must match their generator byte-for-byte, and guards that with drift
+   tests. The general rule — a formatter and a generator must never both own a file —
+   applies everywhere.
+
+### Direction: Playbook to tbd
+
+Per the reuse review’s two-wave recommendation, extended with the new floor document and
+the missing shortcut:
+
+- **Wave 1 (common floor):** `rust-rules`, `rust-lint-format-rules` (new),
+  `rust-project-setup`, `rust-cli-rules`, `rust-testing-rules`.
+- **Wave 2 (specialized):** `rust-filesystem-rules`, `rust-release-rules`,
+  `rust-code-review-rules`, plus a `review-code-rust` shortcut that loads
+  `rust-code-review-rules` and only the topic guidelines matching the diff.
+
+Three playbook assets are valuable to tbd independent of Rust:
+
+- The reuse review’s **section classification rule** (classify every section by the
+  question it answers: general / porting / evidence / navigation) is a reusable
+  doc-architecture technique.
+  It belongs in `common-doc-guidelines` or the `new-guideline` shortcut.
+- The `_meta/` **observation → triage → improvement-log loop** is a working mechanism
+  for turning project experience into guideline changes.
+  tbd has retrospectives but no structured loop; this is a candidate template.
+- `scripts/check_docs.py` validates local links, anchors, code fences, and forbidden
+  invisible Unicode across all tracked text.
+  tbd runs flowmark but has no anchor or hidden-Unicode validation.
+
+### Consistency Contract
+
+Every Rust guideline must satisfy this before it ships in tbd.
+Derived from the Python and TypeScript families as they actually are, not from the
+template:
+
+- [ ] Frontmatter: `title`, `description`, `author`, `category: rust`.
+- [ ] `globs: "*.rs"` and `alwaysApply: true` on the always-on documents (`rust-rules`,
+  `rust-lint-format-rules`), matching `typescript-rules` and
+  `typescript-lint-format-rules`.
+- [ ] A `**Related**:` block directly under the H1, as Python and TypeScript do.
+  The Rust suite currently puts related links in a trailing H2 only; keep that section
+  but add the header block so the links load with the first screen.
+- [ ] A scope statement answering “use this when…” in the opening paragraph.
+- [ ] Rules stated as actionable imperatives with a named benefit
+  (`general-eng-agent-principles` §10: no ceremony without a named benefit).
+- [ ] Guideline cross-references by bare name (`rust-testing-rules`), never by relative
+  path — relative links break once the doc is served from `.tbd/docs/`.
+- [ ] External references as full public URLs, per the `new-guideline` shortcut.
+- [ ] Severity vocabulary is Blocker / High / Medium / Low.
+- [ ] No source-language assumptions, no repo-specific tracker prefixes, and “tracking
+  issue or bead” rather than “bead”.
+- [ ] The `common-doc-guidelines` footer, and flowmark-clean formatting.
+
+## Implementation Plan
+
+### Phase 1: Map and Verify
+
+- [ ] Confirm `rpp-u657` is still the tracking item for upstreaming, and file a tbd-side
+  bead for the receiving work.
+- [ ] Diff each of the seven Rust guidelines against the consistency contract above and
+  record the per-document deltas.
+- [ ] Confirm no `rust-*` name collides with an existing bundled tbd guideline.
+
+### Phase 2: Extract the Cross-Language Rules
+
+- [ ] Add a “Tracked Ratchets” section to `general-coding-rules`, with the tbd config
+  comments as the worked example.
+- [ ] Add “verify the gate itself” to `general-testing-rules`, citing
+  `check-eslint-contract.mjs`.
+- [ ] Add the hostile-environment rule (`GIT_DIR` and friends) to
+  `general-testing-rules`.
+- [ ] Add the generator-versus-formatter ownership rule to `common-doc-guidelines`.
+- [ ] Update `typescript-lint-format-rules` floor rules 6 and 8 to reference the new
+  general homes rather than restating them.
+
+### Phase 3: Author and Validate the Rust Floor
+
+- [ ] Draft `rust-lint-format-rules.md` in the playbook, mirroring the TypeScript
+  document’s section order.
+- [ ] Validate the proposed `[lints]` block and `clippy.toml` against a real Rust
+  codebase — flowmark-rs is the natural target, since it is first-party and already the
+  playbook’s primary case study.
+  Record which lints fire, which are noise, and which need a project-level exception.
+- [ ] Build the Rust config-contract check: a probe fixture that the lint gate must
+  reject, wired into CI so a config regression fails.
+- [ ] Cut `rust-project-setup.md` §"Define a Clippy Policy" down to a pointer at the new
+  floor document, removing the three-option menu.
+
+### Phase 4: Upstream
+
+- [ ] Wave 1 into `packages/tbd/docs/guidelines/`, registered in `docs_cache.files` as
+  `internal:` docrefs.
+- [ ] Wave 2, plus the `review-code-rust` shortcut.
+- [ ] Point the playbook’s `.tbd/config.yml` at the now-bundled
+  `internal:guidelines/rust-*.md` so the playbook consumes them the same way it consumes
+  the TypeScript family, and the playbook stops being their home.
+- [ ] Record the outcome in `_meta/playbook-improvement-log.md`.
+
+## Testing Strategy
+
+- Guideline structure regressions belong in the playbook’s existing
+  `tests/test_rust_guidelines.py`; extend it to assert the consistency contract.
+- The Rust floor is validated empirically in Phase 3 by running it against flowmark-rs,
+  not by inspection.
+- The config-contract probe is the test for the floor itself.
+- tbd-side: `pnpm ci:quality` plus the forkable-docs tests already cover a new bundled
+  guideline; confirm `tbd docs sync` serves each new name.
+
+## Open Questions
+
+- Should `rust-lint-format-rules` be authored in the playbook first and then upstreamed
+  (matching how the other seven were developed), or authored directly in tbd since it
+  has no porting content?
+  Authoring in the playbook keeps one review venue and one validation target; authoring
+  in tbd avoids a second migration.
+- Does the Rust floor need profiles at all?
+  The TypeScript document needs them because ESLint and Biome are genuine alternatives.
+  Rust has one formatter and one linter, so the profile layer may collapse into a single
+  configuration — which would make the Rust document shorter than its model, not longer.
+- Is `clippy::indexing_slicing` tolerable across a whole codebase, or does it need to be
+  scoped to library code with tests exempted, as tbd scopes its unsafe-* relaxations to
+  test files? Phase 3 answers this with evidence.
+
+## References
+
+- [`typescript-lint-format-rules`](https://github.com/jlevy/tbd/blob/main/packages/tbd/docs/guidelines/typescript-lint-format-rules.md)
+  — the model document
+- [`general-eng-agent-principles`](https://github.com/jlevy/tbd/blob/main/packages/tbd/docs/guidelines/general-eng-agent-principles.md)
+- [`supply-chain-hardening`](https://github.com/jlevy/tbd/blob/main/packages/tbd/docs/guidelines/supply-chain-hardening.md)
+- [Rust guideline reuse review, 2026-08-08](https://github.com/jlevy/rust-porting-playbook/blob/main/docs/reviews/rust-guideline-reuse-review-2026-08-08.md)
+  — prior art and the two-wave upstream recommendation
+- [Playbook guidelines index](https://github.com/jlevy/rust-porting-playbook/blob/main/guidelines/README.md)
+- tbd enforcement config: `eslint.config.js`, `tsconfig.base.json`, `lefthook.yml`,
+  `scripts/check-eslint-contract.mjs`, `scripts/scrub-git-env.mjs`,
+  `scripts/check-package-age.mjs`
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/docs/project/specs/active/plan-2026-08-23-rust-quality-floor-and-guideline-mapping.md
+++ b/docs/project/specs/active/plan-2026-08-23-rust-quality-floor-and-guideline-mapping.md
@@ -82,6 +82,31 @@ not serve, so no tbd user receives it:
 | `agent-guidelines/typescript-dependency-injection-guidelines.md` | 293 | Dependency injection for testability. |
 | `agent-guidelines/typescript-testing-guidelines.md` | 136 | Testing real system interactions rather than mock existence, integration points, error scenarios, contract compliance. Mostly language-neutral. |
 
+### Consistency Fixes tbd Needs First
+
+Registering a Rust family exposes defects in how tbd serves guidelines.
+These block the migration and are fixed before it:
+
+- **`GUIDELINE_GROUPS` has no Rust group.** `packages/tbd/src/file/doc-cache.ts` assigns
+  each guideline to the first group whose `match` returns true, matching on the
+  guideline *name* rather than its `category` frontmatter.
+  Every `rust-*` document would fall through to the catch-all “Docs, process and
+  tooling” group.
+- **`rust-testing-rules` would be misrouted.** The `General engineering` group matches
+  `n.includes('testing')` and is checked first, so a Rust-only document would land in
+  the group whose note reads “Read all of these for any engineering work”, and would be
+  served to Python and TypeScript sessions.
+  The same pattern catches any future `<lang>-testing-rules`.
+- **`GUIDELINE_GROUPS` has no test.** Nothing asserts that a guideline lands in the
+  intended group, which is why the misrouting above is invisible today.
+- **Generated skill files drift.** `.claude/skills/tbd/SKILL.md`,
+  `.agents/skills/tbd/SKILL.md`, `skills/tbd/SKILL.md`, and `AGENTS.md` embed the
+  generated directory between `BEGIN SHORTCUT DIRECTORY` markers.
+  A guideline added without regenerating them is invisible to agents; `tbd-o732`
+  recorded exactly this failure on an earlier guideline addition.
+- **New names need `docs_cache.files` entries** in `.tbd/config.yml`, or `tbd docs sync`
+  does not serve them.
+
 ## Design
 
 ### How the Floor Is Set
@@ -246,6 +271,9 @@ the reuse review recommended.
 - [ ] Confirm `rpp-u657` still tracks upstreaming; file the tbd-side receiving bead.
 - [ ] Confirm `category: rust` renders correctly in `tbd guidelines --list`.
 - [ ] Record per-document deltas against the conversion checklist.
+- [ ] Add a Rust group to `GUIDELINE_GROUPS`, ordered ahead of `General engineering` so
+  `rust-testing-rules` is not captured by its `includes('testing')` match.
+- [ ] Add a test asserting each guideline lands in its intended group.
 
 ### Phase 2: Extract the Shared Guidelines
 
@@ -278,9 +306,35 @@ the reuse review recommended.
   `rust-cli-rules`, `rust-testing-rules`, applying the conversion checklist.
 - [ ] Wave 2: the three split documents plus `review-code-rust`.
 - [ ] Register every new name in `docs_cache.files` as an `internal:` docref.
+- [ ] Regenerate the skill files and `AGENTS.md`, so the new guidelines are visible to
+  agents rather than only present on disk.
 - [ ] Repoint the playbook’s `.tbd/config.yml` at `internal:guidelines/rust-*.md`, so it
   consumes them as it consumes the TypeScript family.
 - [ ] Record the outcome in the playbook’s `_meta/playbook-improvement-log.md`.
+
+### Phase 5: Simplify the Playbook
+
+Once tbd serves the Rust family, the playbook should consume it rather than keep a
+second copy. This phase is what makes the migration a consolidation instead of a fork.
+
+- [ ] Replace each migrated guideline in `guidelines/` with an `internal:` docref in
+  `.tbd/config.yml`, so the playbook loads tbd’s copy the way it already loads the
+  TypeScript family.
+- [ ] Record the disposition of every moved document in
+  `_meta/playbook-improvement-log.md`: which file moved, to which tbd name, and at which
+  commit. Git history holds the content; the log holds the mapping.
+- [ ] Rewrite `guidelines/README.md` so the general Rust table points at tbd names and
+  the porting table stays local.
+  The index stops being the home of the Rust suite and becomes a router.
+- [ ] Repoint the playbooks, mapping references, and case studies at the tbd names.
+- [ ] Reduce `tests/test_rust_guidelines.py` to what still lives in the repository, and
+  keep the porting-layer structure assertions.
+- [ ] Confirm the porting layer still reads correctly with the general layer external:
+  every target-side rule it relies on resolves through tbd.
+
+The porting documents stay in the playbook permanently.
+They exist only when another implementation is authoritative, which is the boundary the
+2026-08-08 reuse review drew and this phase preserves.
 
 ## Testing Strategy
 

--- a/docs/project/specs/active/plan-2026-08-23-rust-quality-floor-and-guideline-mapping.md
+++ b/docs/project/specs/active/plan-2026-08-23-rust-quality-floor-and-guideline-mapping.md
@@ -1,6 +1,6 @@
 ---
 title: Rust Quality Floor and Guideline Mapping
-description: Map the quality insights accumulated in tbd and the Rust Porting Playbook, extract the non-obvious enforcement practices into a Rust guideline suite, and make the Rust family consistent with the Python and TypeScript families
+description: Add a strict Rust guideline family to tbd by migrating the Rust Porting Playbook suite, extracting its language-neutral core into shared guidelines, and setting the floor at the strictest of tbd's enforced config, the playbook, and the TypeScript family
 author: Joshua Levy (github.com/jlevy) with LLM assistance
 category: general
 ---
@@ -13,285 +13,322 @@ category: general
 ## Overview
 
 tbd guidelines exist to give agents the *non-obvious* practices that raise code quality:
-strict type-checker flags, high lint floors, and atypical-but-better conventions that a
-model will not produce from its priors.
+strict type-checker flags, high lint floors, and atypical-but-better conventions a model
+will not produce from its priors.
 The TypeScript family does this well.
-The Rust suite in the Rust Porting Playbook covers a large surface but stops short of
-defining an enforceable floor, and none of it is distributed through tbd.
+tbd has no Rust coverage at all, and the Rust suite that exists in the Rust Porting
+Playbook stops short of defining an enforceable floor.
 
-This spec inventories where every kind of insight currently lives across both
-repositories, identifies which insights are portable, and plans the two-way transfer:
-playbook Rust guidelines up into tbd, and tbd’s enforcement practices across into Rust.
+This spec plans the migration: which documents move, what each becomes, what gets
+extracted into language-neutral guidelines that all three families share, and how tbd
+routes an agent to the right document for each scenario.
 
 ## Goals
 
-- Produce a single map of insight *kinds* and their current homes across tbd and the
-  playbook, so later passes stop rediscovering the same material.
-- Define a real Rust lint and type-strictness floor (`rust-lint-format-rules`) modeled
-  section-for-section on `typescript-lint-format-rules`, replacing the current “choose
-  one of three Clippy strategies” optionality.
-- Extract the enforcement practices that exist in tbd only as executable config
-  (`eslint.config.js`, `tsconfig.base.json`, `lefthook.yml`, `scripts/`) into
-  documented, language-neutral or Rust-specific rules.
-- Bring the seven existing Rust guidelines up to the tbd frontmatter and cross-reference
-  contract so they can ship as bundled tbd guidelines.
-- Add `review-code-rust` so the Rust family has the same shortcut coverage as Python and
-  TypeScript.
+- Ship a Rust guideline family in tbd with the same flavor and structure as the Python
+  and TypeScript families.
+- Set the Rust floor at the *strictest* of the three sources available, with no menu of
+  lax alternatives.
+- Extract the language-neutral core of the playbook’s Rust documents into shared
+  guidelines, so the same rule is written once instead of once per language — and so
+  four real gaps in tbd’s own coverage get closed along the way.
+- Keep coverage identical after extraction, with explicit routing from every scenario to
+  the documents that own it.
 
 ## Non-Goals
 
 - Upstreaming the porting layer.
   Construct mappings, parity evidence, differential testing, and upstream-sync workflows
-  stay in the playbook; only source-language-independent Rust guidance moves to tbd.
-- Rewriting the Python or TypeScript families.
-  They are the reference shape here, changed only where a genuinely cross-language rule
-  is being lifted out of them.
-- Changing tbd’s own ESLint or tsconfig settings.
-  This spec documents and transfers what is already enforced; it does not retune it.
-- Porting tbd itself to Rust.
-  That is tracked separately in the playbook’s active TypeScript-to-Rust plans.
+  stay in the playbook.
+- Rewriting the Python or TypeScript families beyond the edits needed to route them at
+  newly shared guidelines.
+- Retuning tbd’s own ESLint or tsconfig settings.
+  This spec documents and transfers what is already enforced.
+- Porting tbd itself to Rust; that is tracked in the playbook’s active TypeScript plans.
 
 ## Background
 
-Two repositories hold the relevant material:
+**Confirmed: tbd has zero Rust coverage today.** No `rust-*` guideline, no
+`review-code-rust` shortcut, no `category: rust`. The 31 bundled guidelines carry five
+categories — `general` (15), `typescript` (8), `python` (3), `desktop` (3), `convex`
+(2). The only mentions of Rust anywhere in `packages/tbd/docs/` are incidental (a
+`ripgrep` reference, a tooling aside).
 
-- **tbd** (this repo, TypeScript): 31 bundled guidelines in
-  `packages/tbd/docs/guidelines/`, plus a decade’s worth of enforcement decisions baked
-  into executable config at the repo root.
-  The config layer is where the highest-value, least-documented practices live.
-- **Rust Porting Playbook** (`attic/rust-porting-playbook/`, cloned for this review):
-  seven general Rust guidelines plus five porting guidelines, produced by the
-  [2026-08-08 reuse review](https://github.com/jlevy/rust-porting-playbook/blob/main/docs/reviews/rust-guideline-reuse-review-2026-08-08.md),
-  which already recommends upstreaming the reusable suite to tbd in two waves and tracks
-  it as `rpp-u657`.
+The playbook holds 1,765 lines across seven general Rust guidelines, produced by the
+[2026-08-08 reuse review](https://github.com/jlevy/rust-porting-playbook/blob/main/docs/reviews/rust-guideline-reuse-review-2026-08-08.md),
+which already recommends upstreaming them in two waves and tracks it as `rpp-u657`. They
+were written to tbd’s shape — correct frontmatter, actionable rules, related links,
+common footer — so the migration is real but mechanical.
 
 The playbook already consumes tbd guidelines through `internal:` docrefs in its
-`.tbd/config.yml`, so the distribution mechanism for the reverse direction exists and is
-proven. What is missing is a `rust-*` set on tbd’s side to point at.
+`.tbd/config.yml`, so the distribution path is proven in one direction.
+
+### Gaps This Exposes in tbd Itself
+
+Auditing the playbook’s Rust documents against tbd’s catalog turned up four topics tbd
+has no guideline for, in any language:
+
+| Topic | tbd today | Consequence |
+| --- | --- | --- |
+| Filesystem behavior | Nothing | `eslint.config.js` forbids `fs.writeFile` in favor of `atomically`, and no guideline explains why. The rule is enforced but not taught. |
+| Release engineering | `release-notes-guidelines` only, which is about *notes* | Nothing states release identity, pre-release gates, least-privilege publishing, or artifact smoke tests. |
+| Code review rules | Four `review-code*` shortcuts | The shortcuts are procedures with no rules document to load; severity vocabulary lives only in dated review artifacts. |
+| CI and gate wiring | Scattered across `pnpm-monorepo-patterns`, `typescript-lint-format-rules` §Hooks and Gates, `supply-chain-hardening` | No single answer to “how is a quality gate wired, and how do you prove it is live?” |
+
+The playbook has strong material on all four.
+Extracting it serves both repositories at once.
 
 ## Design
 
-### Insight Taxonomy
+### How the Floor Is Set
 
-Insights fall into five kinds.
-The kind determines both where a rule belongs and whether it can travel.
+The Rust floor is the **strictest of three sources**, not a merge of their averages:
 
-| Kind | What it is | Where it lives in tbd | Where it lives in the playbook | Portable? |
-| --- | --- | --- | --- | --- |
-| A. Enforced config | Settings that make a rule unskippable | `eslint.config.js`, `tsconfig.base.json`, `lefthook.yml`, `package.json` scripts, `.github/workflows/ci.yml`, `scripts/*.mjs` | `.github/workflows/docs-quality.yml`, `scripts/check_*.py` | Concept yes, syntax no |
-| B. Codified guidelines | Prose rules an agent loads on demand | `packages/tbd/docs/guidelines/` (general, python, typescript families) | `guidelines/` (rust + porting families) | Directly |
-| C. Process assets | Shortcuts, templates, references | `packages/tbd/docs/{shortcuts,templates,references}/` | `playbooks/`, `references/`, `_meta/*-template.md` | Directly |
-| D. Project evidence | Dated findings tied to one codebase | `docs/project/{specs,reviews,retrospectives,research}/` | `case-studies/`, `docs/reviews/`, `_meta/playbook-improvement-log.md` | No — cite, never copy |
-| E. Distribution | How a doc reaches an agent | `.tbd/config.yml` `docs_cache`, `tbd docs fork`, `docs_cache.local_dirs`, `tbd guidelines --add=<url>` | consumes tbd via `internal:` docrefs | N/A |
+1. **This repo’s enforced config** — `eslint.config.js`, `tsconfig.base.json`,
+   `lefthook.yml`, `scripts/check-eslint-contract.mjs`. The highest bar, because it is
+   executable and has survived iteration.
+2. **The playbook’s Rust guidelines** — broadest Rust-specific surface coverage.
+3. **tbd’s TypeScript family** — the structural model, and the source of rules that are
+   really about strictness rather than about TypeScript.
 
-Kind A is the priority.
-It holds the practices the user is asking for and it is the least documented, because a
-config file is the enforcement, not the explanation.
+Where they disagree, the strictest wins.
+Where a source has a mechanism the others lack, it is adopted rather than averaged away.
 
-### Finding: Floor Versus Optionality
-
-`typescript-lint-format-rules.md` states a floor — “These rules are the minimum for
-every project.
-A project may add rules; it may not drop these” — then gives per-toolchain
-profiles that implement it and a
-[Verifying the Floor](https://github.com/jlevy/tbd/blob/main/packages/tbd/docs/guidelines/typescript-lint-format-rules.md)
-section that proves the floor is live.
-
-`rust-project-setup.md` §"Define a Clippy Policy" instead says:
+**No menus.** A guideline states one default and the conditions for departing from it.
+It does not offer ranked alternatives, because an agent handed options takes the
+cheapest one. `rust-project-setup.md` §"Define a Clippy Policy" currently violates this:
 
 > Choose and document one lint strategy: 1. default Clippy lints plus `-D warnings`; 2.
 > a curated set of additional lints; or 3. `clippy::pedantic` with explicit, reviewed
 > exceptions.
 
-Option 1 is materially weaker than the other two, and an agent handed three options will
-take the cheapest. This is the single largest quality gap between the families, and
-closing it is the highest-value item in this spec.
+Option 1 is materially weaker than the other two.
+This menu is deleted and replaced by the floor below.
 
-### The Proposed Rust Floor
+### The Rust Floor
 
-New guideline `rust-lint-format-rules.md`, mirroring the TypeScript document’s
-structure: The Floor → The `[lints]` Floor → profiles → Hooks and Gates → Verifying the
-Floor.
+New guideline `rust-lint-format-rules`, mirroring `typescript-lint-format-rules`
+section-for-section: The Floor → The `[lints]` Floor → Hooks and Gates → Verifying the
+Floor. Every floor rule is derived from something already enforced, not invented:
 
-Each floor rule is derived from an existing tbd rule, not invented:
-
-| tbd floor rule (source) | Rust analogue | Mechanism |
+| Source rule | Rust analogue | Mechanism |
 | --- | --- | --- |
-| Everything auto-formattable is auto-formatted | `cargo fmt --all`; `taplo fmt` for TOML; flowmark for Markdown; `--check` variants in CI | `rustfmt.toml`, CI |
+| Everything auto-formattable is auto-formatted | `cargo fmt --all`; `taplo fmt` for TOML; flowmark for Markdown; `--check` in CI | `rustfmt.toml`, CI |
 | Zero-tolerance, verify-only lint gate | `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`; never `--fix` in CI | CI job |
 | Type checking is a separate strict gate | `[lints.rust] unsafe_code = "forbid"`; `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` as the doc-link gate | `Cargo.toml`, CI |
-| Strictest standard preset plus named rules | `clippy::pedantic` at `warn` with `priority = -1`, plus the named restriction picks below | `[lints.clippy]` |
+| Strictest standard preset plus named rules | `clippy::pedantic` at `warn` with `priority = -1`, plus the named picks below | `[lints.clippy]` |
 | `noUncheckedIndexedAccess` | `clippy::indexing_slicing` — forces `.get()` over `[i]` | `[lints.clippy]` |
-| Exhaustiveness checks / `noFallthroughCasesInSwitch` | `clippy::wildcard_enum_match_arm` — a new enum variant becomes a compile error, not a silent `_ =>` | `[lints.clippy]` |
-| `no-floating-promises` | `clippy::let_underscore_future` plus `#[must_use]` discipline; `unused_must_use` at deny | `[lints.clippy]`, `[lints.rust]` |
+| Exhaustiveness checks | `clippy::wildcard_enum_match_arm` — a new variant becomes an error, not a silent `_ =>` | `[lints.clippy]` |
+| `no-floating-promises` | `clippy::let_underscore_future`, `#[must_use]` discipline, `unused_must_use` at deny | `[lints.clippy]`, `[lints.rust]` |
 | `no-restricted-imports` forcing atomic writes | `disallowed-methods` naming `std::fs::write` and `std::fs::File::create`, directing to `tempfile::NamedTempFile::persist` | `clippy.toml` |
 | Strict-preset tuning with a stated reason | `clippy::unwrap_used` and `expect_used` denied outside tests; `panic` denied in library code | `[lints.clippy]` |
 | Exceptions are narrow and file-scoped | `#[expect(lint, reason = "...")]` at the narrowest scope | attribute |
 | Legacy ratchets toward strict | per-crate `[lints]` overrides, each off-switch carrying a tracker ID in a comment | `Cargo.toml` |
 
-Two of these deserve emphasis because they are the ones an agent will not reach for on
-its own:
+Two entries carry most of the value:
 
 - **`disallowed-methods` is the Rust `no-restricted-imports`.** tbd uses lint config to
   enforce a *correctness invariant* — that no code path writes a file non-atomically —
   rather than trusting reviewers to notice.
-  `clippy.toml` supports exactly this, and `rust-filesystem-rules.md` already states the
+  `clippy.toml` supports exactly this, and the playbook’s filesystem rules state the
   atomic-replacement rule in prose without wiring it to enforcement.
-- **`#[expect]` is strictly better than the TypeScript equivalent.** It warns when the
-  suppression is no longer needed, so exceptions expire on their own.
-  The TypeScript floor has to say “remove obsolete exceptions” as a rule because the
-  tooling cannot. This is a case where the Rust guideline should not merely mirror the
-  TypeScript one.
+- **`#[expect]` beats the TypeScript equivalent.** It warns once the suppression is
+  unnecessary, so exceptions expire on their own.
+  The TypeScript floor needs a written “remove obsolete exceptions” rule because its
+  tooling cannot do this.
+  Where Rust has the better mechanism, the Rust document uses it rather than mirroring.
 
-The floor table above is a design proposal, not a validated configuration.
+The floor table is a design proposal, not a validated configuration.
 Phase 3 validates it against a real Rust codebase before it ships.
 
-### Cross-Language Rules to Lift Out
+### Document Migration Map
 
-Four practices are currently trapped in TypeScript-specific documents or in tbd’s config
-comments, but are language-neutral.
-They should move to the `general-*` family so the Rust suite inherits them instead of
-restating them:
+Every playbook Rust document, what it becomes, and where it lands.
+“Neutral core” means the sections move into a shared guideline that Python and
+TypeScript also use; the Rust document keeps only what is genuinely Rust-specific and
+routes to the shared one.
 
-1. **The tracked ratchet.** tbd disables `@typescript-eslint/no-unnecessary-condition`
-   and omits `exactOptionalPropertyTypes`, and each off-switch carries a bead ID
-   (`tbd-s9vn`, `tbd-tdh3`) and a re-enable condition in a comment.
+| Playbook document | Lines | Disposition | tbd destination(s) | Wave |
+| --- | ---: | --- | --- | --- |
+| `rust-rules.md` | 287 | Move as-is | `guidelines/rust-rules.md` (`category: rust`, `globs: "*.rs"`, `alwaysApply: true`) | 1 |
+| *(new)* `rust-lint-format-rules.md` | — | Author new, per the floor above | `guidelines/rust-lint-format-rules.md` (`globs: "*.rs"`, `alwaysApply: true`) | 1 |
+| `rust-project-setup.md` | 327 | Split: 4 of 12 content sections are neutral | `guidelines/rust-project-setup.md` (Cargo, features, toolchain, rustfmt) + `guidelines/ci-and-gates-rules.md` (new, general) | 1 |
+| `rust-cli-rules.md` | 290 | Move; drop the porting-parity pointer | `guidelines/rust-cli-rules.md` | 1 |
+| `rust-testing-rules.md` | 201 | Move; route generic assertions at `general-testing-rules` | `guidelines/rust-testing-rules.md` | 1 |
+| `rust-filesystem-rules.md` | 234 | Split: 9 of 10 content sections are neutral | `guidelines/filesystem-rules.md` (new, general) + thin `guidelines/rust-filesystem-rules.md` (`Path`/`OsStr` types, `walkdir`, platform metadata) | 2 |
+| `rust-release-rules.md` | 267 | Split: 13 of 15 content sections are neutral | `guidelines/release-engineering-rules.md` (new, general) + thin `guidelines/rust-release-rules.md` (crates.io trusted publishing, maturin wheels) | 2 |
+| `rust-code-review-rules.md` | 159 | Split: 6 of 7 content sections are neutral | `guidelines/code-review-rules.md` (new, general) + thin `guidelines/rust-code-review-rules.md` (unsafe and FFI review) | 2 |
+| *(new)* `review-code-rust.md` | — | Author new, mirroring `review-code-typescript` | `shortcuts/standard/review-code-rust.md` | 2 |
+| `porting-principles-and-antipatterns.md`, `python-to-rust-*.md`, `filesystem-heavy-cli-porting.md`, `test-coverage-for-porting.md` | 1,674 | **Stays in the playbook** | — | — |
+
+Result in tbd: 8 `rust-*` documents and 1 shortcut, plus 4 new `general` guidelines that
+the TypeScript and Python families also gain.
+
+### New Language-Neutral Guidelines
+
+Each absorbs material from more than one source, which is what makes the extraction pay
+for itself:
+
+**`filesystem-rules`** (general) — planning vs.
+mutation, atomic visibility vs.
+crash durability, backup and collision policy, cross-device moves as copies,
+deterministic traversal with error propagation, symlink and root boundaries, honest
+partial failure, testing the state machine rather than final bytes.
+Absorbs the rationale behind tbd’s `atomically` enforcement, which is currently an
+unexplained ESLint rule.
+Routes to `rust-filesystem-rules` and (new) a short TypeScript section in
+`typescript-rules` §File Operations.
+
+**`release-engineering-rules`** (general) — one release identity, clean pre-release
+gate, deliberate automation, minimal workflow authority, cool-off for release tooling,
+build once per target, predictable packaging, smoke-test the packaged artifact, channels
+chosen by audience, multi-channel coordination without rebuilding, release logic tested
+outside the workflow, incident preparation.
+Absorbs tbd’s own practice (`release.yml`, `publint`, `release:verify`, the packed
+upgrade proof in CI). Complements, does not replace, `release-notes-guidelines`.
+
+**`code-review-rules`** (general) — Blocker/High/Medium/Low severity, loading the rules
+that own the changed surface, establishing the review baseline, reviewing highest-risk
+boundaries first, findings that can be acted on, the quick scan.
+Gives the four existing `review-code*` shortcuts a rules document to load; they
+currently have none.
+
+**`ci-and-gates-rules`** (general) — one local command matching CI, CI jobs as
+independent evidence, reviewable development automation, dependency and supply-chain
+policy at the gate. Absorbs the neutral half of `typescript-lint-format-rules` §"Hooks
+and Gates Reference" and becomes the home for the four cross-language practices
+currently trapped in tbd’s config comments:
+
+1. **Tracked ratchets.** tbd disables `@typescript-eslint/no-unnecessary-condition` and
+   omits `exactOptionalPropertyTypes`, each off-switch carrying a bead ID (`tbd-s9vn`,
+   `tbd-tdh3`) and a re-enable condition.
    A suppression with a tracker ID is debt; one without is decay.
-   Currently only floor rule 8 of the TypeScript document says this.
-2. **The config-contract check.** `scripts/check-eslint-contract.mjs` computes the
-   *effective* config and asserts the floor rules are live at error severity, catching
-   the case where the gate stays green while the floor is silently off.
-   The rule generalizes: a quality gate that is not itself tested is not a gate.
-   Its Rust form is a probe fixture that lint must reject.
-3. **Hook subprocesses inherit a hostile environment.** `scripts/scrub-git-env.mjs`
-   exists because git exports `GIT_DIR` into hook environments, which redirected every
-   git subprocess the test suite spawned onto the real repository and let fixtures
-   rewrite real refs and tbd data (`tbd-a1lc`). Any tool whose tests shell out to git
-   hits this; it is not a TypeScript concern, and it is directly relevant to Rust ports
-   of git-touching CLIs.
-4. **Generated files are formatter-excluded and drift-tested.** tbd excludes `.tbd/`,
-   `.claude/skills/`, `.agents/skills/` and `AGENTS.md` from the Markdown formatter
-   because they must match their generator byte-for-byte, and guards that with drift
-   tests. The general rule — a formatter and a generator must never both own a file —
-   applies everywhere.
+2. **Config-contract checks.** `scripts/check-eslint-contract.mjs` computes the
+   *effective* config and asserts floor rules are live at error severity, catching the
+   case where the gate stays green while the floor is silently off.
+   A quality gate that is not itself tested is not a gate.
+3. **Hostile hook environments.** `scripts/scrub-git-env.mjs` exists because git exports
+   `GIT_DIR` into hook environments, redirecting every git subprocess the test suite
+   spawned onto the real repository and letting fixtures rewrite real refs and tbd data
+   (`tbd-a1lc`). Any tool whose tests shell out to git hits this.
+4. **Generator versus formatter ownership.** Generated files are formatter-excluded and
+   drift-tested; a formatter and a generator must never both own a file.
 
-### Direction: Playbook to tbd
+### Routing
 
-Per the reuse review’s two-wave recommendation, extended with the new floor document and
-the missing shortcut:
+Extraction only works if an agent still lands on the right document.
+Four routing mechanisms, all already used by tbd:
 
-- **Wave 1 (common floor):** `rust-rules`, `rust-lint-format-rules` (new),
-  `rust-project-setup`, `rust-cli-rules`, `rust-testing-rules`.
-- **Wave 2 (specialized):** `rust-filesystem-rules`, `rust-release-rules`,
-  `rust-code-review-rules`, plus a `review-code-rust` shortcut that loads
-  `rust-code-review-rules` and only the topic guidelines matching the diff.
+| Scenario | Loads |
+| --- | --- |
+| Writing Rust | `rust-rules`, `rust-lint-format-rules` (both `alwaysApply: true`, `globs: "*.rs"`) |
+| Starting a Rust project | `rust-project-setup`, `rust-lint-format-rules`, `ci-and-gates-rules` |
+| Rust CLI work | `rust-cli-rules`, `error-handling-rules` |
+| Any filesystem mutation | `filesystem-rules`, plus `rust-filesystem-rules` in Rust |
+| Any release | `release-engineering-rules`, `release-notes-guidelines`, plus `rust-release-rules` in Rust |
+| Reviewing Rust | `tbd shortcut review-code-rust` → `code-review-rules`, `rust-code-review-rules`, and the topic guidelines matching the diff |
+| Wiring or debugging a quality gate | `ci-and-gates-rules`, plus the language floor document |
 
-Three playbook assets are valuable to tbd independent of Rust:
+Enforced by: `globs`/`alwaysApply` frontmatter; a `**Related**:` block under each H1;
+`description` text that makes `tbd guidelines --list` self-routing; and
+`docs_cache.files` entries so every new name is served.
 
-- The reuse review’s **section classification rule** (classify every section by the
-  question it answers: general / porting / evidence / navigation) is a reusable
-  doc-architecture technique.
-  It belongs in `common-doc-guidelines` or the `new-guideline` shortcut.
-- The `_meta/` **observation → triage → improvement-log loop** is a working mechanism
-  for turning project experience into guideline changes.
-  tbd has retrospectives but no structured loop; this is a candidate template.
-- `scripts/check_docs.py` validates local links, anchors, code fences, and forbidden
-  invisible Unicode across all tracked text.
-  tbd runs flowmark but has no anchor or hidden-Unicode validation.
+### Mechanical Conversion Checklist
 
-### Consistency Contract
+Applies to every migrated document.
+The current state was measured, not assumed:
 
-Every Rust guideline must satisfy this before it ships in tbd.
-Derived from the Python and TypeScript families as they actually are, not from the
-template:
-
-- [ ] Frontmatter: `title`, `description`, `author`, `category: rust`.
-- [ ] `globs: "*.rs"` and `alwaysApply: true` on the always-on documents (`rust-rules`,
-  `rust-lint-format-rules`), matching `typescript-rules` and
-  `typescript-lint-format-rules`.
-- [ ] A `**Related**:` block directly under the H1, as Python and TypeScript do.
-  The Rust suite currently puts related links in a trailing H2 only; keep that section
-  but add the header block so the links load with the first screen.
-- [ ] A scope statement answering “use this when…” in the opening paragraph.
-- [ ] Rules stated as actionable imperatives with a named benefit
-  (`general-eng-agent-principles` §10: no ceremony without a named benefit).
-- [ ] Guideline cross-references by bare name (`rust-testing-rules`), never by relative
-  path — relative links break once the doc is served from `.tbd/docs/`.
-- [ ] External references as full public URLs, per the `new-guideline` shortcut.
-- [ ] Severity vocabulary is Blocker / High / Medium / Low.
-- [ ] No source-language assumptions, no repo-specific tracker prefixes, and “tracking
-  issue or bead” rather than “bead”.
-- [ ] The `common-doc-guidelines` footer, and flowmark-clean formatting.
+- [ ] **Relative links → bare guideline names.** All seven documents cross-link as
+  `](rust-rules.md)`. These break once served from `.tbd/docs/`. Convert to
+  `` `rust-rules` `` per the `new-guideline` shortcut.
+- [ ] **Anchor links dropped or rewritten.** Three documents use section anchors
+  (`rust-testing-rules.md#test-filesystem-behavior-in-isolated-roots` and two more);
+  anchors do not survive the split.
+- [ ] **Repo-local links resolved.** `rust-project-setup` and `rust-release-rules` link
+  to `../SUPPLY-CHAIN-SECURITY.md`; `rust-release-rules` also links to
+  `../docs/project/research/research-rust-cli-pypi-distribution.md`. Retarget at
+  `supply-chain-hardening` or a full public URL.
+- [ ] **Porting pointers removed.** `rust-cli-rules`, `rust-filesystem-rules`, and
+  `rust-testing-rules` link to playbook porting documents that will not exist in tbd.
+- [ ] **Frontmatter completed.** Add `globs: "*.rs"` and `alwaysApply: true` to
+  `rust-rules` and `rust-lint-format-rules`, matching their TypeScript counterparts.
+  `category: rust` is a new category; confirm `tbd guidelines --list` groups it.
+- [ ] **`**Related**:` block added under the H1.** All seven put related links in a
+  trailing H2 only. Keep that section, add the header block, matching Python and
+  TypeScript.
+- [ ] **Optionality removed.** Seven documents contain 19 instances of
+  choose/may/either/one-of phrasing.
+  Each becomes one default plus the conditions for departing from it.
+- [ ] **Tracker language generalized.** “tracking issue or bead”, never “bead”.
+- [ ] **Severity vocabulary** is Blocker / High / Medium / Low.
+- [ ] **Footer and formatting.** `common-doc-guidelines` footer; flowmark-clean.
 
 ## Implementation Plan
 
-### Phase 1: Map and Verify
+### Phase 1: Confirm and Prepare
 
-- [ ] Confirm `rpp-u657` is still the tracking item for upstreaming, and file a tbd-side
-  bead for the receiving work.
-- [ ] Diff each of the seven Rust guidelines against the consistency contract above and
-  record the per-document deltas.
-- [ ] Confirm no `rust-*` name collides with an existing bundled tbd guideline.
+- [ ] Confirm `rpp-u657` still tracks upstreaming; file the tbd-side receiving bead.
+- [ ] Confirm `category: rust` renders correctly in `tbd guidelines --list`.
+- [ ] Record per-document deltas against the conversion checklist.
 
-### Phase 2: Extract the Cross-Language Rules
+### Phase 2: Extract the Neutral Guidelines
 
-- [ ] Add a “Tracked Ratchets” section to `general-coding-rules`, with the tbd config
-  comments as the worked example.
-- [ ] Add “verify the gate itself” to `general-testing-rules`, citing
-  `check-eslint-contract.mjs`.
-- [ ] Add the hostile-environment rule (`GIT_DIR` and friends) to
-  `general-testing-rules`.
-- [ ] Add the generator-versus-formatter ownership rule to `common-doc-guidelines`.
-- [ ] Update `typescript-lint-format-rules` floor rules 6 and 8 to reference the new
-  general homes rather than restating them.
+- [ ] Author `ci-and-gates-rules`, `code-review-rules`, `filesystem-rules`, and
+  `release-engineering-rules` in `packages/tbd/docs/guidelines/`.
+- [ ] Point `typescript-lint-format-rules` §Hooks and Gates and floor rules 6 and 8 at
+  `ci-and-gates-rules` instead of restating them.
+- [ ] Add the `filesystem-rules` pointer to `typescript-rules` §File Operations, so the
+  `atomically` ESLint rule finally has a documented rationale.
+- [ ] Have the `review-code*` shortcuts load `code-review-rules`.
 
 ### Phase 3: Author and Validate the Rust Floor
 
-- [ ] Draft `rust-lint-format-rules.md` in the playbook, mirroring the TypeScript
-  document’s section order.
-- [ ] Validate the proposed `[lints]` block and `clippy.toml` against a real Rust
-  codebase — flowmark-rs is the natural target, since it is first-party and already the
-  playbook’s primary case study.
-  Record which lints fire, which are noise, and which need a project-level exception.
-- [ ] Build the Rust config-contract check: a probe fixture that the lint gate must
-  reject, wired into CI so a config regression fails.
-- [ ] Cut `rust-project-setup.md` §"Define a Clippy Policy" down to a pointer at the new
-  floor document, removing the three-option menu.
+- [ ] Draft `rust-lint-format-rules` in the playbook, mirroring the TypeScript document.
+- [ ] Validate the `[lints]` block and `clippy.toml` against a real Rust codebase —
+  flowmark-rs is the natural target, being first-party and the playbook’s primary case
+  study. Record which lints fire, which are noise, and which need a project exception.
+- [ ] Build the Rust config-contract check: a probe fixture the lint gate must reject,
+  wired into CI.
+- [ ] Reduce `rust-project-setup` §"Define a Clippy Policy" to a pointer, deleting the
+  three-option menu.
 
-### Phase 4: Upstream
+### Phase 4: Migrate
 
-- [ ] Wave 1 into `packages/tbd/docs/guidelines/`, registered in `docs_cache.files` as
-  `internal:` docrefs.
-- [ ] Wave 2, plus the `review-code-rust` shortcut.
-- [ ] Point the playbook’s `.tbd/config.yml` at the now-bundled
-  `internal:guidelines/rust-*.md` so the playbook consumes them the same way it consumes
-  the TypeScript family, and the playbook stops being their home.
-- [ ] Record the outcome in `_meta/playbook-improvement-log.md`.
+- [ ] Wave 1: `rust-rules`, `rust-lint-format-rules`, `rust-project-setup`,
+  `rust-cli-rules`, `rust-testing-rules` — applying the conversion checklist.
+- [ ] Wave 2: the three split documents plus `review-code-rust`.
+- [ ] Register every new name in `docs_cache.files` as an `internal:` docref.
+- [ ] Repoint the playbook’s `.tbd/config.yml` at `internal:guidelines/rust-*.md` so it
+  consumes them as it consumes the TypeScript family, and stops being their home.
+- [ ] Record the outcome in the playbook’s `_meta/playbook-improvement-log.md`.
 
 ## Testing Strategy
 
-- Guideline structure regressions belong in the playbook’s existing
-  `tests/test_rust_guidelines.py`; extend it to assert the consistency contract.
-- The Rust floor is validated empirically in Phase 3 by running it against flowmark-rs,
-  not by inspection.
+- Extend the playbook’s `tests/test_rust_guidelines.py` to assert the conversion
+  checklist, so structure regressions fail there before migration.
+- Validate the Rust floor empirically in Phase 3 against flowmark-rs, not by inspection.
 - The config-contract probe is the test for the floor itself.
-- tbd-side: `pnpm ci:quality` plus the forkable-docs tests already cover a new bundled
-  guideline; confirm `tbd docs sync` serves each new name.
+- tbd-side: `pnpm ci:quality` plus the forkable-docs tests cover new bundled guidelines;
+  confirm `tbd docs sync` serves each new name and `tbd guidelines <name>` resolves it.
+- Coverage check after extraction: every H2 section in the seven source documents maps
+  to a section in some destination document.
+  No section is dropped silently.
 
 ## Open Questions
 
-- Should `rust-lint-format-rules` be authored in the playbook first and then upstreamed
-  (matching how the other seven were developed), or authored directly in tbd since it
-  has no porting content?
-  Authoring in the playbook keeps one review venue and one validation target; authoring
-  in tbd avoids a second migration.
-- Does the Rust floor need profiles at all?
-  The TypeScript document needs them because ESLint and Biome are genuine alternatives.
-  Rust has one formatter and one linter, so the profile layer may collapse into a single
-  configuration — which would make the Rust document shorter than its model, not longer.
-- Is `clippy::indexing_slicing` tolerable across a whole codebase, or does it need to be
-  scoped to library code with tests exempted, as tbd scopes its unsafe-* relaxations to
-  test files? Phase 3 answers this with evidence.
+- **Does the Rust floor need a profile layer?** Probably not.
+  `typescript-lint-format-rules` needs profiles because ESLint and Biome are genuine
+  alternatives; Rust has one formatter and one linter, so the Rust document should be
+  shorter than its model, with a single configuration and no branches.
+- **Is `clippy::indexing_slicing` tolerable codebase-wide,** or does it need test-file
+  scoping the way tbd scopes its `no-unsafe-*` relaxations to tests?
+  Phase 3 answers this with evidence.
+- **Where is `rust-lint-format-rules` authored?** Drafting in the playbook keeps one
+  review venue and one validation target; drafting directly in tbd avoids a second
+  migration. Leaning playbook, since Phase 3 validation happens there.
+- **Do the four new neutral guidelines need Python counterparts filed?** The Python
+  family has no filesystem or release document either.
+  Extraction makes them available, but Python-specific companions are out of scope here.
 
 ## References
 
@@ -300,7 +337,7 @@ template:
 - [`general-eng-agent-principles`](https://github.com/jlevy/tbd/blob/main/packages/tbd/docs/guidelines/general-eng-agent-principles.md)
 - [`supply-chain-hardening`](https://github.com/jlevy/tbd/blob/main/packages/tbd/docs/guidelines/supply-chain-hardening.md)
 - [Rust guideline reuse review, 2026-08-08](https://github.com/jlevy/rust-porting-playbook/blob/main/docs/reviews/rust-guideline-reuse-review-2026-08-08.md)
-  — prior art and the two-wave upstream recommendation
+  — prior art and the two-wave recommendation
 - [Playbook guidelines index](https://github.com/jlevy/rust-porting-playbook/blob/main/guidelines/README.md)
 - tbd enforcement config: `eslint.config.js`, `tsconfig.base.json`, `lefthook.yml`,
   `scripts/check-eslint-contract.mjs`, `scripts/scrub-git-env.mjs`,

--- a/packages/tbd/src/file/doc-cache.ts
+++ b/packages/tbd/src/file/doc-cache.ts
@@ -412,6 +412,11 @@ const SHORTCUT_DIRECTORY_END = '<!-- END SHORTCUT DIRECTORY -->';
  * Grouping is inferred from the guideline name so new guidelines are placed
  * automatically. A guideline is assigned to the first group whose `match`
  * returns true, so the final catch-all group must stay last.
+ *
+ * Language-neutral groups match on exact names, never on a substring. A
+ * substring match silently captures language-prefixed guidelines: an earlier
+ * `n.includes('testing')` here put `rust-testing-rules` in the group whose note
+ * tells agents to read every entry for any engineering work.
  */
 interface GuidelineGroup {
   heading: string;
@@ -419,18 +424,27 @@ interface GuidelineGroup {
   match: (name: string) => boolean;
 }
 
+/** Always-load guidelines that are not covered by the `general-` prefix. */
+const GENERAL_ENGINEERING_NAMES = new Set([
+  'backward-compatibility-rules',
+  'commit-conventions',
+  'error-handling-rules',
+  'golden-testing-guidelines',
+]);
+
+/** Language-neutral guidelines loaded when the work touches their topic. */
+const CROSS_CUTTING_NAMES = new Set([
+  'ci-and-gates-rules',
+  'code-review-rules',
+  'filesystem-rules',
+  'release-engineering-rules',
+]);
+
 const GUIDELINE_GROUPS: GuidelineGroup[] = [
   {
     heading: 'General engineering',
     note: 'Read all of these for any engineering work (writing or reviewing code).',
-    match: (n) =>
-      n.startsWith('general-') ||
-      n === 'error-handling-rules' ||
-      n === 'backward-compatibility-rules' ||
-      n === 'commit-conventions' ||
-      n.includes('tdd') ||
-      n.includes('testing') ||
-      n.includes('golden'),
+    match: (n) => n.startsWith('general-') || GENERAL_ENGINEERING_NAMES.has(n),
   },
   {
     heading: 'TypeScript & JS ecosystem',
@@ -444,9 +458,19 @@ const GUIDELINE_GROUPS: GuidelineGroup[] = [
     match: (n) => n.startsWith('python-'),
   },
   {
+    heading: 'Rust',
+    note: 'Also load these when working in Rust.',
+    match: (n) => n.startsWith('rust-'),
+  },
+  {
     heading: 'Convex',
     note: 'Also load these when working with Convex.',
     match: (n) => n.startsWith('convex-'),
+  },
+  {
+    heading: 'Cross-cutting engineering topics',
+    note: 'Load these when the work touches the topic, in any language.',
+    match: (n) => CROSS_CUTTING_NAMES.has(n),
   },
   {
     // Catch-all, must stay last.
@@ -454,6 +478,19 @@ const GUIDELINE_GROUPS: GuidelineGroup[] = [
     match: () => true,
   },
 ];
+
+/**
+ * Heading of the group a guideline is filed under.
+ *
+ * Exported so group assignment is directly testable: the generated directory is
+ * the only other place this logic surfaces, and a misfiled guideline there is
+ * easy to miss.
+ */
+export function guidelineGroupFor(name: string): string {
+  const group = GUIDELINE_GROUPS.find((g) => g.match(name));
+  // The catch-all matches everything, so this fallback is unreachable in practice.
+  return group?.heading ?? GUIDELINE_GROUPS[GUIDELINE_GROUPS.length - 1]!.heading;
+}
 
 /**
  * Build table rows from docs (shared helper for shortcuts and guidelines).
@@ -543,7 +580,8 @@ export function generateShortcutDirectory(
     const grouped = GUIDELINE_GROUPS.map((group) => ({ group, docs: [] as CachedDoc[] }));
     const catchAll = grouped[grouped.length - 1];
     for (const doc of guidelines) {
-      const entry = grouped.find((g) => g.group.match(doc.name)) ?? catchAll;
+      const heading = guidelineGroupFor(doc.name);
+      const entry = grouped.find((g) => g.group.heading === heading) ?? catchAll;
       entry?.docs.push(doc);
     }
 

--- a/packages/tbd/tests/guideline-groups.test.ts
+++ b/packages/tbd/tests/guideline-groups.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { guidelineGroupFor } from '../src/file/doc-cache.js';
+
+/**
+ * Group assignment decides which guidelines an agent is told to always load.
+ * A language-specific document filed under "General engineering" is served to
+ * every session regardless of language, so each group's boundary is asserted
+ * here rather than left to the generated directory.
+ */
+describe('guidelineGroupFor', () => {
+  it('files general-prefixed and named always-load guidelines under General engineering', () => {
+    for (const name of [
+      'general-coding-rules',
+      'general-testing-rules',
+      'general-tdd-guidelines',
+      'error-handling-rules',
+      'backward-compatibility-rules',
+      'commit-conventions',
+      'golden-testing-guidelines',
+    ]) {
+      expect(guidelineGroupFor(name), name).toBe('General engineering');
+    }
+  });
+
+  it('files language guidelines under their own language group', () => {
+    expect(guidelineGroupFor('typescript-rules')).toBe('TypeScript & JS ecosystem');
+    expect(guidelineGroupFor('pnpm-monorepo-patterns')).toBe('TypeScript & JS ecosystem');
+    expect(guidelineGroupFor('python-rules')).toBe('Python');
+    expect(guidelineGroupFor('rust-rules')).toBe('Rust');
+    expect(guidelineGroupFor('convex-rules')).toBe('Convex');
+  });
+
+  it('keeps language-specific testing rules out of General engineering', () => {
+    // A substring match on 'testing' or 'tdd' captures these, which would tell
+    // every session to read a single language's rules.
+    for (const name of ['rust-testing-rules', 'python-testing-rules', 'typescript-tdd-rules']) {
+      expect(guidelineGroupFor(name), name).not.toBe('General engineering');
+    }
+    expect(guidelineGroupFor('rust-testing-rules')).toBe('Rust');
+    expect(guidelineGroupFor('python-testing-rules')).toBe('Python');
+  });
+
+  it('files language-neutral topic guidelines under Cross-cutting engineering topics', () => {
+    for (const name of [
+      'ci-and-gates-rules',
+      'code-review-rules',
+      'filesystem-rules',
+      'release-engineering-rules',
+    ]) {
+      expect(guidelineGroupFor(name), name).toBe('Cross-cutting engineering topics');
+    }
+  });
+
+  it('falls through to the catch-all group', () => {
+    expect(guidelineGroupFor('common-doc-guidelines')).toBe('Docs, process & tooling');
+    expect(guidelineGroupFor('supply-chain-hardening')).toBe('Docs, process & tooling');
+  });
+});


### PR DESCRIPTION
## Summary

This change establishes the infrastructure for Rust guidelines in tbd by adding a Rust group to the guideline classification system and introducing a new "Cross-cutting engineering topics" group for language-neutral guidelines. It also adds test coverage to prevent future misrouting of language-specific guidelines.

## Key Changes

- **Added Rust guideline group** to `GUIDELINE_GROUPS` in `doc-cache.ts`, positioned before the catch-all group so Rust-specific documents are correctly categorized
- **Introduced Cross-cutting engineering topics group** for language-neutral guidelines (`ci-and-gates-rules`, `code-review-rules`, `filesystem-rules`, `release-engineering-rules`) that apply across all languages
- **Refactored General engineering group matching** to use explicit name sets (`GENERAL_ENGINEERING_NAMES`) instead of substring matching, preventing language-specific testing rules (e.g., `rust-testing-rules`) from being incorrectly filed under "General engineering"
- **Exported `guidelineGroupFor()` function** to make guideline group assignment directly testable
- **Added comprehensive test suite** (`guideline-groups.test.ts`) that validates:
  - General engineering guidelines are correctly identified
  - Language-specific guidelines land in their respective language groups
  - Language-specific testing rules are not captured by substring matching
  - Cross-cutting topic guidelines are properly routed
  - Fallback behavior for uncategorized guidelines

## Implementation Details

The key insight is that substring matching on `'testing'` or `'tdd'` was silently capturing language-prefixed guidelines like `rust-testing-rules` and filing them under "General engineering," which tells agents to read them for any engineering work regardless of language. The fix uses exact name matching for both general and cross-cutting guidelines, with language-specific matching only on the prefix.

The exported `guidelineGroupFor()` function enables direct testing of routing logic, which was previously only visible in the generated directory output and easy to miss during review.

https://claude.ai/code/session_01PbC8y9fMpRmvf2BLwUQ5m9