### PR TITLE
Factual, clarity, and brevity review of the PR #258 guideline corpus

### DIFF
--- a/.agents/skills/tbd/SKILL.md
+++ b/.agents/skills/tbd/SKILL.md
@@ -391,7 +391,7 @@ Load the **General engineering** core, then only guidelines matching the task.
 
 ### Cross-cutting engineering topics
 
-*Select by the changed surface: general code details, comments, errors, tests or TDD, goldens, dependencies, published interfaces, commits, review, CI and gates, filesystem work, or releases.*
+*Select by the changed surface; do not load this whole group by default.*
 
 | Name | Description |
 | --- | --- |

--- a/.claude/skills/tbd/SKILL.md
+++ b/.claude/skills/tbd/SKILL.md
@@ -391,7 +391,7 @@ Load the **General engineering** core, then only guidelines matching the task.
 
 ### Cross-cutting engineering topics
 
-*Select by the changed surface: general code details, comments, errors, tests or TDD, goldens, dependencies, published interfaces, commits, review, CI and gates, filesystem work, or releases.*
+*Select by the changed surface; do not load this whole group by default.*
 
 | Name | Description |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ opinionated rules with concrete examples, built from months of heavy agentic cod
 | Guideline | What it covers |
 | --- | --- |
 | [general-eng-agent-principles](packages/tbd/docs/guidelines/general-eng-agent-principles.md) | Senior-engineer responsibility, verification, scope discipline, and when to act or clarify |
-| [general-coding-rules](packages/tbd/docs/guidelines/general-coding-rules.md) | Correctness checks, defensive coding boundaries, dependency discipline, and code structure |
+| [general-coding-rules](packages/tbd/docs/guidelines/general-coding-rules.md) | Named constants, magic-number avoidance, and when cryptographic hash checks add real assurance |
 | [general-comment-rules](packages/tbd/docs/guidelines/general-comment-rules.md) | Comments that preserve non-obvious rationale without restating code |
 | [backward-compatibility-rules](packages/tbd/docs/guidelines/backward-compatibility-rules.md) | Compatibility across code, APIs, file formats, and database schemas |
 | [error-handling-rules](packages/tbd/docs/guidelines/error-handling-rules.md) | Failure propagation, error context, cleanup, exit status, and partial success |
@@ -308,7 +308,7 @@ opinionated rules with concrete examples, built from months of heavy agentic cod
 | Guideline | What it covers |
 | --- | --- |
 | [typescript-rules](packages/tbd/docs/guidelines/typescript-rules.md) | Strict type safety, type guards, null safety, async patterns, and atomic file replacement |
-| [typescript-lint-format-rules](packages/tbd/docs/guidelines/typescript-lint-format-rules.md) | ESLint and formatting floors with effective-config checks |
+| [typescript-lint-format-rules](packages/tbd/docs/guidelines/typescript-lint-format-rules.md) | Lint and formatting floor across ESLint/Prettier and Biome toolchains |
 | [typescript-sorting-patterns](packages/tbd/docs/guidelines/typescript-sorting-patterns.md) | Deterministic sorting and comparison chains for multi-field sorts |
 | [typescript-cli-tool-rules](packages/tbd/docs/guidelines/typescript-cli-tool-rules.md) | Commander.js patterns, streams, exit status, and terminal formatting |
 | [typescript-yaml-handling-rules](packages/tbd/docs/guidelines/typescript-yaml-handling-rules.md) | YAML parsing and serialization, Zod validation, and stable formatting |
@@ -340,7 +340,7 @@ opinionated rules with concrete examples, built from months of heavy agentic cod
 
 | Guideline | What it covers |
 | --- | --- |
-| [cli-agent-skill-patterns](packages/tbd/docs/guidelines/cli-agent-skill-patterns.md) | CLIs designed to function as coding-agent skills |
+| [cli-agent-skill-patterns](packages/tbd/docs/guidelines/cli-agent-skill-patterns.md) | Portable skill, CLI-backed skill, and bundle installation decision guide |
 | [electron-app-development-patterns](packages/tbd/docs/guidelines/electron-app-development-patterns.md) | Electron process boundaries, backends, security, signing, and updates |
 | [electrobun-app-development-patterns](packages/tbd/docs/guidelines/electrobun-app-development-patterns.md) | Electrobun runtime, typed RPC, packaging, delta updates, and maturity risks |
 | [tauri-app-development-patterns](packages/tbd/docs/guidelines/tauri-app-development-patterns.md) | Tauri 2 capabilities, sidecars, non-Rust backends, signing, and updates |
@@ -352,7 +352,8 @@ opinionated rules with concrete examples, built from months of heavy agentic cod
 | Guideline | What it covers |
 | --- | --- |
 | [common-doc-guidelines](packages/tbd/docs/guidelines/common-doc-guidelines.md) | Concrete documentation structure, style, formatting, and required footer |
-| [commit-conventions](packages/tbd/docs/guidelines/commit-conventions.md) | Conventional commit types and descriptions |
+| [commit-conventions](packages/tbd/docs/guidelines/commit-conventions.md) | Conventional Commits format with agentic-workflow extensions |
+| [tbd-sync-troubleshooting](packages/tbd/docs/guidelines/tbd-sync-troubleshooting.md) | Common issues and solutions for tbd sync and workspace operations |
 
 You can also add your own team’s guidelines from any URL:
 

--- a/docs/project/research/current/evidence-2026-08-23-rust-lint-cost.md
+++ b/docs/project/research/current/evidence-2026-08-23-rust-lint-cost.md
@@ -38,7 +38,7 @@ A `#[cfg(test)]` attribute applies to the *next item*. It is not a divider.
 test code.
 
 Reconstructing that method over the raw diagnostics and comparing it against the
-compile-unit classification below: **145 of 415 diagnostics — 34% — were placed in the
+compile-unit classification below: **145 of 415 diagnostics — 35% — were placed in the
 wrong bucket, in both directions.** Thirty-five `expect_used` hits in inline test
 modules were counted as production, and twenty-seven `indexing_slicing` hits in
 production code were counted as tests.

--- a/packages/tbd/docs/guidelines/ci-and-gates-rules.md
+++ b/packages/tbd/docs/guidelines/ci-and-gates-rules.md
@@ -198,11 +198,8 @@ node .tbd/docs/guidelines/scripts/check-rust-gate.mjs cross-targets \
 
 The expected targets come from the project’s support contract, not from what happens to
 be installed on the current runner.
-The command above uses tbd’s Node reference helper because tbd already pins Node; the
-file extension is not a language recommendation for Rust projects.
-If a project does not otherwise pin Node in its gate environment, implement the same
-contract in its existing toolchain and invoke that project-owned program from both local
-and CI entry points.
+The command above uses tbd’s Node reference helper because tbd already pins Node.
+If a project does not pin Node, implement the same contract in its existing toolchain.
 Do not add Node solely to run this check.
 The reference helper has negative tests for an empty workspace and a missing strict
 target. It also leaves `rustup target list` errors visible; silencing that command can

--- a/packages/tbd/docs/guidelines/code-review-rules.md
+++ b/packages/tbd/docs/guidelines/code-review-rules.md
@@ -20,8 +20,7 @@ Do not spend manual review time repeating work an effective passing gate already
 
 - `tbd shortcut review-code` (the review procedure and artifact format)
 - `rust-code-review-rules` (unsafe and FFI review)
-- `general-eng-agent-principles` (objectivity, and not reporting a preference as a
-  defect)
+- `general-eng-agent-principles` (objectivity)
 - `ci-and-gates-rules` (when the change is to a gate rather than to code)
 
 ## Assign Blocker, High, Medium, or Low Severity
@@ -148,7 +147,8 @@ finding. A pattern is not a severity: severity comes from reachability, impact,
 likelihood, and what already contains the failure, and none of those are visible in the
 grep hit. Carrying a preassigned severity through the scan produces exactly the review
 this document is trying to prevent—a list of matches reported at the level the table
-suggested.
+suggested. The third column states what happens when the question confirms the
+risk—severity follows from that consequence, not from the match.
 
 | Pattern | Question that decides it | If the answer is bad |
 | --- | --- | --- |
@@ -156,18 +156,18 @@ suggested.
 | required error or task result discarded | Does any caller depend on the work that error reports failed? | Blocker: silent partial state reported as success |
 | unsafe block or FFI call without a traceable safety argument | Which safe input can violate the invariant, and where is it checked? | Blocker: memory unsafety from safe code |
 | authorization decided from unvalidated or pre-resolution input | Can the value change between the check and the use? | Blocker: access granted on a value the caller controls |
-| success reported before all required work is verified | What does the exit status prove was completed? | High: a green run over unfinished work |
+| success reported before all required work is verified | What does the exit status prove was completed? | High: downstream steps proceed on results that do not yet exist |
 | partial failure reported as success (batch exits zero after failures) | Does the caller distinguish “all done” from “some done”? | High: undetected partial results |
 | non-atomic write to a file another process reads | Can a reader observe the file mid-write, or after a crash? | High: truncated file read as valid data |
-| blocking work on an async executor, or a lock held across I/O or await | How long, on which runtime, and what else shares that thread or lock? | Blocker on a shared runtime; Low in a one-shot CLI |
+| blocking work on an async executor, or a lock held across I/O or await | How long, on which runtime, and what else shares that thread or lock? | Blocker: executor starvation blocks unrelated tasks on a shared runtime; Low in a one-shot CLI |
 | unexplained production `unwrap`/`!`/bare `catch {}` swallowing an error | Is the invariant established locally, or assumed from a caller? | High: a crash or a swallowed failure on real input |
 | new always-on dependency added without a stated reason | What does it replace, and what does it execute at install or build time? | High: unreviewed code in the build |
 | mutable or unreviewed action, image, or build-tool pin | Can the referenced code change without a diff? | High: unreviewed code in a privileged context |
-| public item used only inside its own module or crate | Is it a deliberate API surface or leaked internals? | Medium: a compatibility obligation nobody chose |
+| public item used only inside its own module or package | Is it a deliberate API surface or leaked internals? | Medium: a compatibility obligation nobody chose |
 | test skipped, ignored, or narrowed without a tracking issue | What regression class is now unguarded, and who is reminded? | Medium: permanent silent gap |
 | suppression comment without a non-obvious reason or tracker ID | Is the rule wrong here, or is the code wrong? | Medium: a suppression that outlives its cause |
 | abstraction, trait, or interface with exactly one consumer | Is a second consumer real and near, or hypothetical? | Low: indirection with no payer |
-| TODO, FIXME, or HACK without tracking | Is this a note or an unshipped requirement? | Medium if it is a requirement, Low otherwise |
+| TODO, FIXME, or HACK without tracking | Is this a note or an unshipped requirement? | Medium: an unfinished requirement exits the plan; Low if only a note |
 | generated file edited by hand | Will the generator overwrite this, and does CI notice? | Medium: the change silently disappears |
 
 Reserve Blocker for a consequence you can describe as a sequence of events, not for a

--- a/packages/tbd/docs/guidelines/filesystem-rules.md
+++ b/packages/tbd/docs/guidelines/filesystem-rules.md
@@ -85,9 +85,9 @@ or staging files; those writes are not publication:
 }],
 ```
 
-Rust’s `clippy.toml` method restrictions are global and cannot tell a final output path
-from a private staging path, so do not ban `std::fs::write` or `std::fs::File::create`
-globally merely to enforce this boundary.
+Not every enforcement mechanism can scope to publication code—Rust’s method
+restrictions, for example, are global (see `rust-filesystem-rules`)—so do not ban
+standard write calls globally merely to enforce this boundary.
 Prefer an output module with named operations; disallow a project-specific helper only
 when its contract is unambiguously unsafe.
 Python can use a scoped lint rule or wrapper module.
@@ -145,8 +145,10 @@ The full same-filesystem replacement sequence:
 6. sync the parent directory where supported and required.
 
 Overwrite semantics of the final replacement differ by platform and by API. Read the
-exact call rather than assuming every rename replaces atomically—on Windows, several do
-not.
+exact call rather than assuming every rename replaces atomically: POSIX `rename`
+atomically replaces the destination, but on Windows, C `rename` and `MoveFile` fail when
+the destination exists, `MoveFileEx` with `MOVEFILE_REPLACE_EXISTING` is not documented
+as atomic, and only `ReplaceFile` is designed for atomic replacement.
 
 ## Make Metadata Policy Explicit
 

--- a/packages/tbd/docs/guidelines/general-testing-rules.md
+++ b/packages/tbd/docs/guidelines/general-testing-rules.md
@@ -34,11 +34,6 @@ evidence. Optimize these properties simultaneously:
    test another implementation language without being rewritten, when they preserve the
    same coverage and useful failure location.
 
-Reducing test volume is required maintenance.
-Merge or delete a test when another test already proves the same contract with equal
-clarity and diagnosis.
-Preserve tests that exercise different contracts through the same code.
-
 ## Don’t Just Test the Test
 
 A test is vacuous when it verifies only facts established by its own setup rather than

--- a/packages/tbd/docs/guidelines/python-rules.md
+++ b/packages/tbd/docs/guidelines/python-rules.md
@@ -91,11 +91,8 @@ These are general rules that *must* be followed on this project for Python code.
 - When one operation creates and completes an output file, strongly prefer Strif’s
   `atomic_output_file`, `atomic_write_text`, or `atomic_write_bytes` instead of writing
   directly to the final path.
-  This applies to new and replacement outputs regardless of how important or long-lived
-  they are. Append, live streams, and private staging files need their own primitives;
-  create-only output needs an atomic no-replace commit.
-  See `python-modern-guidelines` and `filesystem-rules` for the examples and decision
-  boundary.
+  See `python-modern-guidelines` for examples and `filesystem-rules` for the full
+  decision boundary.
 
 ## Types and Type Annotations
 

--- a/packages/tbd/docs/guidelines/release-engineering-rules.md
+++ b/packages/tbd/docs/guidelines/release-engineering-rules.md
@@ -133,8 +133,8 @@ Two refinements that catch what a naive smoke test misses:
   search path.
 - **Run the entry point the way a user gets it.** An isolated run from the built
   artifact (`uv tool run --isolated --no-index --from <wheel> tool --version`,
-  `npx --no-install`, extracting the archive to a scratch dir) exercises the console
-  script and its metadata, not just the library.
+  `npx --no`, extracting the archive to a scratch dir) exercises the console script and
+  its metadata, not just the library.
 
 Where a cross-compiled artifact cannot run on its builder, use a native validation job
 or explicitly record the evidence gap.
@@ -150,11 +150,10 @@ Two details make a rehearsal honest:
 
 - **Set the release identity explicitly**, even on a branch, so the rehearsal exercises
   exact-version behavior instead of a placeholder.
-- **Package interdependent components in one invocation.** A package that depends on an
-  unpublished sibling cannot resolve it from the registry; packaging the sibling first
-  in a separate run does not help, because that produces a build artifact rather than a
-  registry entry. Naming both in a single invocation is what lets the tooling verify each
+- **Package interdependent components in one invocation** so the tooling can verify each
   against the just-packaged sibling.
+  See the language-specific release document for the mechanism and command (e.g.
+  `rust-release-rules` §The Unpublished-Sibling Trap).
 
 ## Publish Only to Channels the Intended Audience Uses
 

--- a/packages/tbd/docs/guidelines/rust-cli-rules.md
+++ b/packages/tbd/docs/guidelines/rust-cli-rules.md
@@ -230,8 +230,7 @@ pipe surfaces during drop, where nothing can classify it.
 And writes to stderr in the failure path use `let _ =`: a closed stderr must not panic
 and must not change the status that was already decided.
 
-Test both a closed stdout and a closed stderr.
-The second is what separates the correct implementation from the plausible one.
+Test both a closed stdout and a closed stderr (`error-handling-rules`).
 
 ## Define One Configuration Precedence Order
 

--- a/packages/tbd/docs/guidelines/rust-code-review-rules.md
+++ b/packages/tbd/docs/guidelines/rust-code-review-rules.md
@@ -67,10 +67,10 @@ Review it first, and review it even when the diff is small.
 - [ ] **Blocker: unwinding across an FFI boundary is handled in the direction it
   actually travels.** The two directions have different consequences, and the common
   summary gets both wrong.
-  A Rust panic that would escape an `extern "C"` function aborts the process: defined
-  behavior, but a process death with no foreign cleanup and no way to report the
-  failure, so an exported function that must return an error wraps its body in
-  `catch_unwind` instead.
+  A Rust panic that would escape an `extern "C"` function aborts the process (defined
+  behavior since Rust 1.81), but a process death with no foreign cleanup and no way to
+  report the failure, so an exported function that must return an error wraps its body
+  in `catch_unwind` instead.
   A *foreign* exception entering Rust through a non-unwind ABI is the undefined-behavior
   case. `extern "C-unwind"` declares that unwinding is an intended and compatible part of
   the ABI on both sides; it is not a general fix for “this might panic”.
@@ -95,10 +95,7 @@ Each row here is a question to resolve, not a finding to report at a preset leve
 
 | Pattern | Question that decides it | If the answer is bad |
 | --- | --- | --- |
-| unsafe block without a safety argument | Which invariant makes this sound, and what code establishes it? | Blocker: unsound in the general case |
 | safe API through which unsafe code can be made to misbehave | Is there a safe input sequence that violates the invariant? | Blocker: safe code causes UB |
-| blocking call inside an async executor | Which runtime, how long, and how many worker threads? | Blocker on a shared multi-task runtime; Low in a one-shot CLI where the executor has nothing else to run |
-| recursive delete whose resolved scope is not verified | What does the path resolve to under a symlink or an empty argument? | Blocker: deletion outside the intended tree |
 | lock guard held across an `await` or slow I/O | Does another task need this lock to make progress? | Blocker if it can deadlock; High if it only serializes |
 | lock guard exposed through a public API | Can a caller hold it across arbitrary code? | High: the deadlock is now in someone else’s crate |
 | `unwrap()` in a production path, or `expect()` without a stated invariant | Is the invariant established locally, or assumed from a caller? | High: a panic on real input |

--- a/packages/tbd/docs/guidelines/rust-filesystem-rules.md
+++ b/packages/tbd/docs/guidelines/rust-filesystem-rules.md
@@ -37,8 +37,7 @@ This document owns what is specific to Rust: the types, the crates, and the enfo
   or an explicit base.
   Do not leave it to whatever the caller happened to have.
 - Canonicalize only when resolving links *and* requiring existence is the intended
-  behavior. Canonicalization changes semantics and can itself expose paths outside a
-  root.
+  behavior (`filesystem-rules` states the full rationale).
 
 ```rust
 use std::ffi::OsString;

--- a/packages/tbd/docs/guidelines/rust-lint-format-rules.md
+++ b/packages/tbd/docs/guidelines/rust-lint-format-rules.md
@@ -257,7 +257,7 @@ inferred *type* and is usually satisfied by a bounds check the code already has,
 **Measure by compile unit, not by reading the source.** The obvious method—split each
 file at its `#[cfg(test)]` and call the rest test code—is wrong, because a
 `#[cfg(test)]` attribute applies to the *next item* and not to the remainder of the
-file. Applied to this codebase it misfiled 34% of diagnostics, in both directions.
+file. Applied to this codebase it misfiled 35% of diagnostics, in both directions.
 Ask cargo instead:
 
 ```bash

--- a/packages/tbd/docs/guidelines/rust-testing-rules.md
+++ b/packages/tbd/docs/guidelines/rust-testing-rules.md
@@ -34,18 +34,16 @@ A workspace-root `tests/` directory is not automatically a test target.
 
 ## Assert Public Outcomes and Each Externally Distinct Failure
 
-- Assert public results, state transitions, emitted events, files, streams, and errors;
-  avoid private counters or call order unless those are the interface.
-- Cover each *externally distinct* failure behavior, not each fallible call.
-  Twenty `?` operators that all surface the same error, at the same exit status, with
+`general-testing-rules` owns the “cover externally distinct failures, not every fallible
+call” rule and the public-outcome focus.
+Rust specifics:
+
+- Twenty `?` operators that all surface the same error, at the same exit status, with
   the same cleanup, are one behavior and want one test.
   Two that differ in what the caller must do next are two, however similar the code
   looks.
-- Check structured error variants where callers depend on them and user-visible context
-  where users depend on it.
-- Test partial success, retries, interruption, cancellation, and cleanup for operations
-  that can stop mid-flight.
-- Never let a test ignore a fallible setup or assertion step.
+- Check structured error variants (`enum` arms callers match on) and user-visible
+  context fields callers display.
 - Use `panic!` or `assert!` with a useful impossible-branch message rather than an
   unconditional `assert!(false)`.
 
@@ -56,8 +54,8 @@ regeneration, reviewable diffs, and no machine-specific content.
 Rust adds one choice:
 
 - Use `include_str!` or `include_bytes!` when the fixture is fixed at compile time.
-  The bytes become part of the binary, so the test cannot drift from them and cannot
-  fail on a missing file.
+  The bytes become part of the binary, so the test cannot drift from them at runtime; a
+  missing file is caught at compile time.
 - Read at runtime when the test exercises path handling, permissions, or mutable state—
   embedding would bypass the very code under test.
 
@@ -73,48 +71,30 @@ fn renders_the_document() {
 
 ## Use Goldens for Stable Structured Output and CLI Sessions
 
-Golden or snapshot tests are useful for structured output, diagnostics, CLI sessions,
-serialized data, and large render trees.
-
-- Name the behavior each snapshot represents.
-- Normalize only fields outside the contract.
-- Review the rendered diff before accepting an update.
-- Keep snapshots small enough to diagnose.
-- Pair a broad snapshot with focused assertions for critical invariants that a reviewer
-  might miss in a large diff.
-- Never auto-accept snapshots in CI.
+`golden-testing-guidelines` owns the representation rules—naming, normalization, review,
+sizing, layered assertions, and CI acceptance policy.
 
 Use `insta` by default for Rust snapshots because it keeps reviewed snapshot files and
 update diffs in the test workflow.
 Use another representation only when the project documents a format, interoperability,
 or dependency-policy constraint that `insta` cannot satisfy.
-Apply `tbd guidelines golden-testing-guidelines` before choosing the representation.
 
 ## Use Property Tests for Invariants
 
 Property tests are appropriate when a broad input space can be described through
-invariants, such as:
+invariants—round trips, idempotency, ordering, boundary-safe string processing,
+state-machine rules, or no-panic over arbitrary valid input.
 
-- parse/serialize round trips;
-- output idempotency;
-- ordering and deduplication;
-- boundary-safe string processing;
-- state-machine transition rules;
-- no panic for arbitrary valid input.
-
-Use constrained generators that produce meaningful cases.
-Retain minimal failing cases as ordinary regression tests when they reveal a defect.
-Property tests complement, rather than replace, examples with exact expected output.
+Use `proptest` by default; it provides integrated shrinking, value trees, and composable
+strategies. Use `quickcheck` when the project already depends on it and migration is not
+justified.
 
 ## Test Filesystem Behavior in Isolated Roots
 
-Give every mutating test its own `tempfile::TempDir` by default, build all fixture paths
-under that root, and let its exact lifetime own cleanup.
-Inject filesystem behavior through a narrow adapter when a deterministic failure cannot
-be produced portably.
-
-`rust-filesystem-rules` owns the collision, symlink, metadata, commit-point, durability,
-and recovery cases that the test suite must cover.
+`rust-filesystem-rules` owns the `tempfile::TempDir` isolation pattern and the
+collision, symlink, metadata, commit-point, durability, and recovery cases that the test
+suite must cover. Inject filesystem behavior through a narrow adapter when a
+deterministic failure cannot be produced portably.
 
 ## Test CLI Contracts Through the Built Binary
 
@@ -155,20 +135,12 @@ platform adapters need real tests on the platform.
 
 ## Use Coverage to Find Untested Contracts, Not as the Goal
 
+`general-testing-rules` owns the principle: coverage is a discovery tool, not the
+definition of coverage.
+
 Use `cargo-llvm-cov` by default to identify unexecuted lines, regions, and branches.
 Use another coverage tool only when the compiler, target, or reporting environment
 cannot support it, and keep the replacement command reproducible.
-Use the report to ask which behavior lacks evidence.
-
-- Do not optimize for a universal percentage.
-- Require stronger evidence for parsers, state machines, security boundaries, and error
-  handling than for trivial glue.
-- Track coverage trends when a sudden drop indicates a missing test path.
-- Exclude generated or unreachable code only with a documented reason.
-- Keep the coverage command reproducible and subject to dependency pinning policy.
-
-Coverage is a discovery tool.
-It does not prove assertion quality or input-space completeness.
 
 ## Keep Ignored Tests Actionable
 

--- a/packages/tbd/docs/shortcuts/standard/new-guideline.md
+++ b/packages/tbd/docs/shortcuts/standard/new-guideline.md
@@ -77,7 +77,8 @@ Create a to-do list with the following items then perform all of them:
      render, so make it self-routing—say what the document covers and when to load it.
      Keep it to one sentence or two; it is re-rendered in every session that loads the
      skill. **Do not put a colon-space in it**: the frontmatter is YAML, and an unquoted
-     `foo: bar` parses as a nested mapping and fails the doc-categories test.
+     `foo: bar` causes a YAML parse error ("Nested mappings are not allowed in compact
+     mappings") and fails the doc-categories test.
      Quote the whole scalar—`description: 'Reads foo: bar and…'`—rather than avoiding
      the punctuation; the same applies to a leading `-`, `[`, `{`, `*`, `&`, or `%`.
    - A `**Related**:` block immediately under the H1, listing the guidelines this one
@@ -93,10 +94,12 @@ Create a to-do list with the following items then perform all of them:
    does not serve it and no user receives it):
    - Add `guidelines/<name>.md: internal:guidelines/<name>.md` to `docs_cache.files` in
      `.tbd/config.yml`.
-   - If the name does not start with an existing group prefix (`general-`,
-     `typescript-`, `python-`, `rust-`, `convex-`), add it to the right explicit name
-     set in `GUIDELINE_GROUPS` (`packages/tbd/src/file/doc-cache.ts`) or it lands in the
-     “Docs, process & tooling” catch-all.
+   - If the name does not start with a language-group prefix (`typescript-`, `python-`,
+     `rust-`, `convex-`, `electron-`) or end with `monorepo-patterns`, add it to the
+     right explicit name set in `GUIDELINE_GROUPS`
+     (`packages/tbd/src/file/doc-cache.ts`) or it lands in the “Docs, process & tooling”
+     catch-all. Note: `general-` is not a prefix match—`general-testing-rules` is routed
+     by explicit name, and a new `general-*` name falls through without it.
      Those sets are exported and asserted in `guideline-groups.test.ts`—a name added
      there without a bundled document fails that test rather than silently rendering an
      empty heading.
@@ -137,6 +140,7 @@ Create a to-do list with the following items then perform all of them:
 - [ ] Frontmatter has title, description, author, and a valid category
 - [ ] Description with a colon-space (or other YAML punctuation) is quoted
 - [ ] `**Related**:` block under the H1, and no trailing duplicate list
+- [ ] Language-specific docs have `globs`; no document-local `alwaysApply`
 - [ ] Registered in `.tbd/config.yml` `docs_cache.files`
 - [ ] Grouped correctly (prefix match, or added to an explicit name set)
 - [ ] Introduction explains when to use the guideline

--- a/packages/tbd/docs/shortcuts/standard/review-code-rust.md
+++ b/packages/tbd/docs/shortcuts/standard/review-code-rust.md
@@ -25,7 +25,8 @@ Create a to-do list with the following items then perform all of them:
    - Run `tbd guidelines code-review-rules rust-code-review-rules`
    - Run `tbd guidelines rust-rules rust-lint-format-rules`
 
-3. Add the topic guidelines that match the changed surface:
+3. Add the topic guidelines that match the changed surface (full table in
+   `rust-code-review-rules`):
    - Cargo layout, features, toolchains, workspace shape: `rust-project-setup`
    - Arguments, streams, terminal behavior, exits: `rust-cli-rules`
    - Paths, traversal, file mutation, metadata: `filesystem-rules rust-filesystem-rules`
@@ -33,6 +34,7 @@ Create a to-do list with the following items then perform all of them:
    - Artifacts, publishing, version identity:
      `release-engineering-rules rust-release-rules`
    - Lint config, `clippy.toml`, rustfmt, CI gates: `ci-and-gates-rules`
+   - Dependencies added or upgraded: `supply-chain-hardening`
 
 4. Inspect the repository’s documented automated gate before spending review time on
    what it owns. If the repository has no gate, the commands below are a baseline only
@@ -48,22 +50,14 @@ Create a to-do list with the following items then perform all of them:
    If the diff touches `cfg(target_os)` code, check whether it is linted for those
    targets at all—a single-platform CI run does not.
 
-5. Review the highest-risk boundaries first, per `rust-code-review-rules`:
-   - Unsafe code and FFI, using the checklist in that document
-   - Data loss and destructive operations
-   - Errors, partial failure, and recovery
-   - Public API and compatibility
-   - Concurrency, cancellation, and shutdown
-   - Ownership, lifetimes, and resource cleanup
+5. Review the highest-risk boundaries first, in the order `code-review-rules` defines.
+   Start with unsafe code and FFI, using the checklist in `rust-code-review-rules`.
 
 6. Run the quick scan for Rust-specific patterns (`rust-code-review-rules`), then read
    the changed control flow rather than stopping at the matches.
 
-7. Summarize findings:
-   - Severity (Blocker/High/Medium/Low), `file:line`, the violated contract, the
-     concrete failure path, and a bounded fix
-   - Group repeated instances under one root-cause finding
-   - Record confirmed false positives so the next reviewer does not repeat the work
+7. Summarize findings in the format `code-review-rules` specifies (severity,
+   `file:line`, violated contract, concrete failure path, bounded fix).
 
 <!-- This document follows common-doc-guidelines.md.
 See github.com/jlevy/practical-prose and review guidelines before editing.

--- a/packages/tbd/docs/shortcuts/standard/review-code.md
+++ b/packages/tbd/docs/shortcuts/standard/review-code.md
@@ -76,10 +76,12 @@ Create a to-do list with the following items then perform all of them:
    - For Rust files:
      `tbd guidelines rust-rules rust-lint-format-rules rust-code-review-rules`
    - Load each language present in the diff
-   - Add the topic guidelines the diff touches, in any language: `filesystem-rules`
-     (paths, traversal, file mutation), `ci-and-gates-rules` (build config, CI, hooks,
-     gate scripts), `release-engineering-rules` (artifacts, publishing, version
-     identity), `supply-chain-hardening` (dependencies added or upgraded)
+   - Add the topic guidelines the diff touches, in any language (full table in
+     `code-review-rules`): `filesystem-rules` (paths, traversal, file mutation),
+     `ci-and-gates-rules` (build config, CI, hooks, gate scripts),
+     `release-engineering-rules` (artifacts, publishing, version identity),
+     `supply-chain-hardening` (dependencies added or upgraded),
+     `backward-compatibility-rules` (public API or persisted data shape)
 
 6. **Perform comprehensive senior engineering review:**
 

--- a/packages/tbd/src/file/doc-cache.ts
+++ b/packages/tbd/src/file/doc-cache.ts
@@ -480,7 +480,7 @@ const GUIDELINE_GROUPS: GuidelineGroup[] = [
   },
   {
     heading: 'Cross-cutting engineering topics',
-    note: 'Select by the changed surface: general code details, comments, errors, tests or TDD, goldens, dependencies, published interfaces, commits, review, CI and gates, filesystem work, or releases.',
+    note: 'Select by the changed surface; do not load this whole group by default.',
     match: (n) => CROSS_CUTTING_NAMES.has(n),
   },
   {


### PR DESCRIPTION
Stacked on [#258](https://github.com/jlevy/tbd/pull/258); base is its head branch, so this diff shows only the review changes.

A full factual review plus a clarity and brevity review of every substantial document #258 adds or changes. Tracked as epic `tbd-81x8` with one sub-bead per major file (19 in total, all closed). Reviews ran as 14 parallel agents, each holding to one rule: change only for a factual error, an ambiguity, vagueness where a concrete fact is shorter, real duplication, or a sentence statable more simply with no information loss. No blanket rewrites; character and detail preserved.

**Net: 27 edits across 19 files, −42 lines.** Every factual claim was checked against a primary source, by compiling on rustc 1.94.1, or by running the tool — not from memory.

## The two that would have cost someone real time

Both in `new-guideline.md`, the document that tells authors how to add a guideline. Either one silently produces a guideline that is never served.

- **`general-` is not a group prefix.** The doc said a `general-*` name is grouped automatically. `guidelineGroupFor` matches the always-load and cross-cutting sets by *exact name*, so a new `general-*` document falls to the catch-all unless it is added to a set. Verified by running the exported function over all 43 bundled names.
- **The YAML colon-space claim was wrong.** An unquoted `foo: bar` in a `description` is a parse error (`Nested mappings are not allowed in compact mappings`), not a silent misparse into a nested mapping. Reproduced.

## Other corrections

| Finding | File |
| --- | --- |
| `general-coding-rules` advertised four topics; the document has two sections (Constants and Magic Numbers, Cryptographic Hash Checks) | `README.md` |
| `npx --no-install` is deprecated in favor of `npx --no` | `release-engineering-rules` |
| 145/415 is 35%, not 34% | `rust-lint-format-rules`, lint-cost evidence |
| "On Windows, several do not" replace atomically — now names which APIs do and don't | `filesystem-rules` |
| A Rust panic escaping `extern "C"` has aborted as *defined* behavior only since 1.81 | `rust-code-review-rules` |
| `include_str!` "cannot fail on a missing file" — it fails at compile time | `rust-testing-rules` |
| Routing drift: `review-code` omitted `backward-compatibility-rules`; `review-code-rust` omitted `supply-chain-hardening` | both shortcuts |
| The scan preamble said "a pattern is not a severity" while every row led with one | `code-review-rules` |
| Two more README cells misdescribed their document; `tbd-sync-troubleshooting` was in no table | `README.md` |
| Cross-cutting group note was 193 chars against an ~88-column constraint, listing topics the table below already shows | `doc-cache.ts` |

## Duplication removed

Fourteen ideas appeared in more than one document — the expected defect class, since four documents were split from a Rust playbook into a neutral core plus a language layer. Each was assigned a single owner and the other side reduced to a reference. The largest cut: `rust-testing-rules` 192 → 165 lines, dropping neutral bullets owned by `general-testing-rules` and `golden-testing-guidelines`. Its property-test section named no Rust crate at all, which was its only reason to sit in a Rust document; it names `proptest` and `quickcheck` now.

Three quick-scan rows were cut from `rust-code-review-rules` because they repeated the neutral table in Rust spelling, and the neutral document is loaded alongside it.

## What held up

The corpus is accurate. `rust-rules` and the whole TypeScript family needed **no edits**.

- The measured lint table **recounts exactly** from the 415-row TSV, by lint and by target class.
- Verified correct: the PyO3 0.29 `abi3t` / Python 3.15 claim, the FFI unwind matrix in both directions, `PanicException` deriving from `BaseException`, Strif's argument order and its `backup_suffix` visibility gap, `atomically`'s fsync behavior, `NamedTempFile::persist` semantics, all five Edition 2024 items, and `ErrorKind::CrossesDevices` — stable since 1.85.0, exactly the corpus MSRV.
- Lint precedence, `--all-targets`, `--cap-lints`, and `priority = -1` were confirmed by running clippy against probe crates. The bash pipeline-negation example was confirmed by running it.
- Reference integrity is clean: every `**Related**:` entry and inline document reference in every shipped doc resolves.

## Two things for the author

- **The #258 description contains a false claim.** It says the original `general-testing-rules` core was "restored verbatim." All six original bullets were reworded or split; none survives verbatim. The rewrites are more specific, so they were kept rather than reverted — but the PR body should be corrected.
- **`tbd-dado` filed** for a defect too wide for a doc review: `electrobun-app-development-patterns` and `tauri-app-development-patterns` land in the "Docs, process & tooling" catch-all, because the TypeScript matcher is `startsWith('electron-')` and `"electrobun-"` does not match it. Their sibling `electron-app-development-patterns` lands in the TypeScript group. An agent looking for Tauri guidance under that heading will not find it. Fixing it means changing `GUIDELINE_GROUPS`.

## Validation

`pnpm test` — 2446 passed, 163 files. The pre-push gate (`check`, `build`, `test`, `package-age`) passed. Agent surfaces regenerated after the `doc-cache.ts` note change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZwzVPkjr56FqMrvYg3saY

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZwzVPkjr56FqMrvYg3saY)_