### PR TITLE
fix: honor deferred_until and route guidelines by declared category

### DIFF
--- a/.agents/skills/tbd/SKILL.md
+++ b/.agents/skills/tbd/SKILL.md
@@ -407,6 +407,7 @@ Load the **General engineering** core, then only guidelines matching the task.
 | general-testing-rules | Rules for keeping test volume low while preserving broad evidence—rejecting vacuous tests, choosing portable black-box tests when they preserve coverage, keeping the inner loop fast, controlling nondeterminism, and never letting an empty or skipped selection look like a pass. |
 | golden-testing-guidelines | Guidelines for implementing golden/snapshot testing for complex systems |
 | release-engineering-rules | Language-neutral rules for turning a reviewed commit into artifacts users execute—one release identity, a pre-release gate that runs where publishing happens, least-privilege publishing authority, build-once-and-promote, packaging and checksums, smoke-testing the packaged artifact rather than the build output, multi-channel coordination, testable release logic, and incident preparation. Load for any release, alongside release-notes-guidelines and the language-specific release document. |
+| release-notes-guidelines | Rules for release notes that describe the published delta and exclude defects introduced and corrected before release from separate Fixes entries |
 | supply-chain-hardening | Strongly recommended for EVERY repo—apply it if a repo has not been hardened yet. Cross-ecosystem policy for installing dependencies safely (the 14-day cool-off, disabled install scripts, lockfile discipline, untrusted-repo handling). Use whenever a user mentions hardening, security, supply chain, or setting up a new repo; before adding/upgrading dependencies; when auditing for compromised packages; or when reviewing install/build/run commands across npm/pnpm, PyPI, Cargo, or Go. |
 
 ### TypeScript & JS ecosystem
@@ -416,7 +417,6 @@ Load the **General engineering** core, then only guidelines matching the task.
 | Name | Description |
 | --- | --- |
 | bun-monorepo-patterns | Modern patterns for Bun-based TypeScript monorepo architecture |
-| electron-app-development-patterns | Building a clean, minimal, standalone Electron app—process model, modern Vite-based build system, attaching a Node/Bun/Python backend, security baseline, packaging, code signing, and auto-update |
 | pnpm-monorepo-patterns | Modern patterns for pnpm-based TypeScript monorepo architecture |
 | typescript-cli-tool-rules | Rules for building CLI tools with Commander.js, picocolors, and TypeScript |
 | typescript-code-coverage | Best practices for code coverage in TypeScript with Vitest and v8 provider |
@@ -459,6 +459,16 @@ Load the **General engineering** core, then only guidelines matching the task.
 | convex-limits-best-practices | Comprehensive reference for Convex platform limits, workarounds, and performance best practices |
 | convex-rules | Guidelines and best practices for building Convex projects, including database schema design, queries, mutations, and real-world examples |
 
+### Desktop app frameworks
+
+*Select the document for the framework in use; do not load this whole group by default.*
+
+| Name | Description |
+| --- | --- |
+| electrobun-app-development-patterns | Building desktop apps with Electrobun—runtime and process model, typed RPC, project layout, packaging and the delta updater, plus an evidence-based maturity and security assessment |
+| electron-app-development-patterns | Building a clean, minimal, standalone Electron app—process model, modern Vite-based build system, attaching a Node/Bun/Python backend, security baseline, packaging, code signing, and auto-update |
+| tauri-app-development-patterns | Building desktop apps with Tauri 2—the Rust core and system webview model, capabilities and permissions, typed commands and IPC, attaching Rust or non-Rust backends, packaging, signing, and the signed updater |
+
 ### Docs, process & tooling
 
 | Name | Description |
@@ -466,9 +476,6 @@ Load the **General engineering** core, then only guidelines matching the task.
 | agent-session-bootstrap | When and how to make a repository install its own pinned toolchain at agent session start, for repos whose agents run in containers they do not control. Covers the fit test, the alternatives that are usually better, the install rules a bootstrap must follow, and the PATH and pin-drift traps that make one fail silently. Use when an agent session starts without the tools the repo requires, when writing or reviewing a SessionStart hook, or when deciding between a session hook and a provisioned image. |
 | cli-agent-skill-patterns | A concise decision guide for portable skills, CLI-backed skills, safe bundle installation, and agent integration |
 | common-doc-guidelines | Common cross-project standards for writing and organizing docs, code comments, and text files—how to organize, structure, write, and format documents, plus the guideline footer convention. Downstream of github.com/jlevy/practical-prose. Use whenever writing or editing any documentation, README, guideline, or design doc. |
-| electrobun-app-development-patterns | Building desktop apps with Electrobun—runtime and process model, typed RPC, project layout, packaging and the delta updater, plus an evidence-based maturity and security assessment |
-| release-notes-guidelines | Rules for release notes that describe the published delta and exclude defects introduced and corrected before release from separate Fixes entries |
-| tauri-app-development-patterns | Building desktop apps with Tauri 2—the Rust core and system webview model, capabilities and permissions, typed commands and IPC, attaching Rust or non-Rust backends, packaging, signing, and the signed updater |
 | tbd-sync-troubleshooting | Common issues and solutions for tbd sync and workspace operations |
 
 <!-- END SHORTCUT DIRECTORY -->

--- a/.claude/skills/tbd/SKILL.md
+++ b/.claude/skills/tbd/SKILL.md
@@ -407,6 +407,7 @@ Load the **General engineering** core, then only guidelines matching the task.
 | general-testing-rules | Rules for keeping test volume low while preserving broad evidence—rejecting vacuous tests, choosing portable black-box tests when they preserve coverage, keeping the inner loop fast, controlling nondeterminism, and never letting an empty or skipped selection look like a pass. |
 | golden-testing-guidelines | Guidelines for implementing golden/snapshot testing for complex systems |
 | release-engineering-rules | Language-neutral rules for turning a reviewed commit into artifacts users execute—one release identity, a pre-release gate that runs where publishing happens, least-privilege publishing authority, build-once-and-promote, packaging and checksums, smoke-testing the packaged artifact rather than the build output, multi-channel coordination, testable release logic, and incident preparation. Load for any release, alongside release-notes-guidelines and the language-specific release document. |
+| release-notes-guidelines | Rules for release notes that describe the published delta and exclude defects introduced and corrected before release from separate Fixes entries |
 | supply-chain-hardening | Strongly recommended for EVERY repo—apply it if a repo has not been hardened yet. Cross-ecosystem policy for installing dependencies safely (the 14-day cool-off, disabled install scripts, lockfile discipline, untrusted-repo handling). Use whenever a user mentions hardening, security, supply chain, or setting up a new repo; before adding/upgrading dependencies; when auditing for compromised packages; or when reviewing install/build/run commands across npm/pnpm, PyPI, Cargo, or Go. |
 
 ### TypeScript & JS ecosystem
@@ -416,7 +417,6 @@ Load the **General engineering** core, then only guidelines matching the task.
 | Name | Description |
 | --- | --- |
 | bun-monorepo-patterns | Modern patterns for Bun-based TypeScript monorepo architecture |
-| electron-app-development-patterns | Building a clean, minimal, standalone Electron app—process model, modern Vite-based build system, attaching a Node/Bun/Python backend, security baseline, packaging, code signing, and auto-update |
 | pnpm-monorepo-patterns | Modern patterns for pnpm-based TypeScript monorepo architecture |
 | typescript-cli-tool-rules | Rules for building CLI tools with Commander.js, picocolors, and TypeScript |
 | typescript-code-coverage | Best practices for code coverage in TypeScript with Vitest and v8 provider |
@@ -459,6 +459,16 @@ Load the **General engineering** core, then only guidelines matching the task.
 | convex-limits-best-practices | Comprehensive reference for Convex platform limits, workarounds, and performance best practices |
 | convex-rules | Guidelines and best practices for building Convex projects, including database schema design, queries, mutations, and real-world examples |
 
+### Desktop app frameworks
+
+*Select the document for the framework in use; do not load this whole group by default.*
+
+| Name | Description |
+| --- | --- |
+| electrobun-app-development-patterns | Building desktop apps with Electrobun—runtime and process model, typed RPC, project layout, packaging and the delta updater, plus an evidence-based maturity and security assessment |
+| electron-app-development-patterns | Building a clean, minimal, standalone Electron app—process model, modern Vite-based build system, attaching a Node/Bun/Python backend, security baseline, packaging, code signing, and auto-update |
+| tauri-app-development-patterns | Building desktop apps with Tauri 2—the Rust core and system webview model, capabilities and permissions, typed commands and IPC, attaching Rust or non-Rust backends, packaging, signing, and the signed updater |
+
 ### Docs, process & tooling
 
 | Name | Description |
@@ -466,9 +476,6 @@ Load the **General engineering** core, then only guidelines matching the task.
 | agent-session-bootstrap | When and how to make a repository install its own pinned toolchain at agent session start, for repos whose agents run in containers they do not control. Covers the fit test, the alternatives that are usually better, the install rules a bootstrap must follow, and the PATH and pin-drift traps that make one fail silently. Use when an agent session starts without the tools the repo requires, when writing or reviewing a SessionStart hook, or when deciding between a session hook and a provisioned image. |
 | cli-agent-skill-patterns | A concise decision guide for portable skills, CLI-backed skills, safe bundle installation, and agent integration |
 | common-doc-guidelines | Common cross-project standards for writing and organizing docs, code comments, and text files—how to organize, structure, write, and format documents, plus the guideline footer convention. Downstream of github.com/jlevy/practical-prose. Use whenever writing or editing any documentation, README, guideline, or design doc. |
-| electrobun-app-development-patterns | Building desktop apps with Electrobun—runtime and process model, typed RPC, project layout, packaging and the delta updater, plus an evidence-based maturity and security assessment |
-| release-notes-guidelines | Rules for release notes that describe the published delta and exclude defects introduced and corrected before release from separate Fixes entries |
-| tauri-app-development-patterns | Building desktop apps with Tauri 2—the Rust core and system webview model, capabilities and permissions, typed commands and IPC, attaching Rust or non-Rust backends, packaging, signing, and the signed updater |
 | tbd-sync-troubleshooting | Common issues and solutions for tbd sync and workspace operations |
 
 <!-- END SHORTCUT DIRECTORY -->

--- a/packages/tbd/docs/tbd-design.md
+++ b/packages/tbd/docs/tbd-design.md
@@ -2761,7 +2761,8 @@ Options:
   --label <label>           Filter by label (repeatable)
   --parent=<id>             List children of parent
   --deferred                Show only deferred issues
-  --defer-before <date>     Deferred before date
+  --defer-before <date>     Deferred strictly before this date (beads with no
+                            deferred_until are excluded)
   --sort <field>            Sort by: priority, created, updated (default: priority)
                             (created/updated are shorthand for created_at/updated_at)
                             Tiebreaker: internal ULID (chronological creation order)

--- a/packages/tbd/docs/tbd-docs.md
+++ b/packages/tbd/docs/tbd-docs.md
@@ -278,7 +278,9 @@ Options:
 - `--spec <path>` - Filter by spec path (supports gradual matching: filename, partial
   path, or full path)
 - `--deferred` - Show only deferred issues
-- `--defer-before <date>` - Deferred before date
+- `--defer-before <date>` - Deferred strictly before this date.
+  Beads with no `deferred_until` are excluded, since they are not deferred before
+  anything
 - `--sort <field>` - Sort by: priority, created, updated (default: priority).
   Tiebreaker: internal ULID (chronological creation order)
 - `--limit <n>` - Limit number of results
@@ -457,7 +459,8 @@ per-command auto-sync, and the legacy no-op `--no-sync` flag has been removed.
 
 ### ready
 
-List issues ready to work on (open, unblocked, unassigned).
+List issues ready to work on: open, unblocked, unassigned, and not deferred into the
+future.
 
 ```bash
 tbd ready                                   # All ready issues
@@ -668,8 +671,9 @@ Serve a live, read-only view of the bead graph in a local browser.
 The page uses the same local bead state, filter semantics, readiness rules, hierarchy,
 and statistics as the CLI, and displays the equivalent `tbd list` or `tbd ready` command
 for the current view.
-The Ready checkbox is the exact `tbd ready` predicate—open, unassigned, and with no open
-blocker. A quiet unboxed row marker exposes that derived state while scanning; it is
+The Ready checkbox is the exact `tbd ready` predicate—open, unassigned, with no open
+blocker, and not deferred into the future.
+A quiet unboxed row marker exposes that derived state while scanning; it is
 intentionally distinct from user labels.
 Pretty is on by default and never changes when a column sort changes.
 In Pretty mode, the two-key sort moves only outermost visible parent groups.
@@ -828,7 +832,10 @@ An unknown `--bead` ID is an error rather than a silent wait.
 Label, spec, and status selections report a bead that matched *before or after*, so both
 entering and leaving the set count.
 `--ready` is edge-triggered: it reports only beads that were not ready before and are
-now, using the same definition as `tbd ready` (open, unassigned, no open blockers).
+now, using the same definition as `tbd ready` (open, unassigned, no open blockers, and
+not deferred into the future).
+A deferral that merely elapses does not wake the watcher: readiness is evaluated at one
+instant per comparison, so a bead becomes ready here only when an edit changes it.
 
 ### search
 

--- a/packages/tbd/src/cli/commands/create.ts
+++ b/packages/tbd/src/cli/commands/create.ts
@@ -21,7 +21,7 @@ import { IssueKind } from '../../lib/schemas.js';
 import { parsePriority } from '../../lib/priority.js';
 import { now } from '../../utils/time-utils.js';
 import { resolveSpecArg, getPathErrorMessage } from '../../lib/project-paths.js';
-import { validateIssueTitle } from '../lib/issue-input-validation.js';
+import { parseDateOption, validateIssueTitle } from '../lib/issue-input-validation.js';
 import { withDataSyncContext, notifyWorktreeRepaired } from '../lib/data-context.js';
 import { resolveBodyInput } from '../lib/body-input.js';
 import { applyDependencyWrites, type DependencyWriteOutcome } from '../lib/bulk.js';
@@ -188,8 +188,9 @@ class CreateHandler extends BaseCommand {
             description: description ?? undefined,
             assignee: options.assignee ?? undefined,
             delegate: options.delegate ?? undefined,
-            due_date: options.due ?? undefined,
-            deferred_until: options.defer ?? undefined,
+            due_date: options.due === undefined ? undefined : parseDateOption(options.due, '--due'),
+            deferred_until:
+              options.defer === undefined ? undefined : parseDateOption(options.defer, '--defer'),
             parent_id: parentId,
             spec_path: specPath,
           };

--- a/packages/tbd/src/cli/commands/list.ts
+++ b/packages/tbd/src/cli/commands/list.ts
@@ -23,6 +23,7 @@ import {
   formatNoSpecGroupHeader,
   type IssueForDisplay,
 } from '../lib/issue-format.js';
+import { parseDateOption } from '../lib/issue-input-validation.js';
 import { parsePriority } from '../../lib/priority.js';
 import { selectIssues } from '../../lib/issue-query.js';
 import type { IssueQuery, IssueSort } from '../../lib/issue-query.js';
@@ -215,6 +216,10 @@ class ListHandler extends BaseCommand {
       // An empty --spec means "no filter", as before.
       spec: options.spec === '' ? null : (options.spec ?? null),
       deferred: options.deferred ?? false,
+      deferBefore:
+        options.deferBefore === undefined
+          ? null
+          : parseDateOption(options.deferBefore, '--defer-before'),
       ready: false,
       sort: (options.sort ?? 'priority') as IssueSort,
       limit: null,
@@ -240,7 +245,7 @@ export const listCommand = new Command('list')
     'Filter by spec path (matches full path, partial path suffix, or filename)',
   )
   .option('--deferred', 'Show only deferred issues')
-  .option('--defer-before <date>', 'Deferred before date')
+  .option('--defer-before <date>', 'Only issues whose deferred_until falls before this date')
   .option('--sort <field>', 'Sort by: priority, created, updated', 'priority')
   .option('--limit <n>', 'Limit results')
   .option('--count', 'Output only the count of matching issues')

--- a/packages/tbd/src/cli/commands/list.ts
+++ b/packages/tbd/src/cli/commands/list.ts
@@ -224,7 +224,7 @@ class ListHandler extends BaseCommand {
       sort: (options.sort ?? 'priority') as IssueSort,
       limit: null,
     };
-    return selectIssues(issues, query);
+    return selectIssues(issues, query, Date.now());
   }
 }
 

--- a/packages/tbd/src/cli/commands/ready.ts
+++ b/packages/tbd/src/cli/commands/ready.ts
@@ -54,7 +54,11 @@ class ReadyHandler extends BaseCommand {
 
     // Ready selection, ordering, and tiebreak all come from the shared query module,
     // so this command and any other surface answering "what is ready" cannot disagree.
-    let readyIssues = selectIssues(issues, { ...defaultIssueQuery(), ready: true, kind });
+    let readyIssues = selectIssues(
+      issues,
+      { ...defaultIssueQuery(), ready: true, kind },
+      Date.now(),
+    );
 
     // Apply limit
     readyIssues = applyLimit(readyIssues, options.limit);

--- a/packages/tbd/src/cli/commands/update.ts
+++ b/packages/tbd/src/cli/commands/update.ts
@@ -23,7 +23,7 @@ import type {
 import { now } from '../../utils/time-utils.js';
 import { resolveToInternalId, type IdMapping } from '../../file/id-mapping.js';
 import { resolveSpecArg, getPathErrorMessage } from '../../lib/project-paths.js';
-import { validateIssueTitle } from '../lib/issue-input-validation.js';
+import { parseDateOption, validateIssueTitle } from '../lib/issue-input-validation.js';
 import { checkParentAssignment, describeHierarchyProblem } from '../../lib/issue-hierarchy.js';
 import { withDataSyncContext } from '../lib/data-context.js';
 import {
@@ -68,14 +68,6 @@ interface UpdateOptions {
  * anything it cannot is refused by name, rather than reaching the schema and coming back
  * as "Invalid datetime".
  */
-function parseDateOption(value: string, flag: string): string {
-  const parsed = Date.parse(value);
-  if (!Number.isFinite(parsed)) {
-    throw new ValidationError(`Invalid ${flag} value: ${value}. Expected a date or timestamp.`);
-  }
-  return new Date(parsed).toISOString();
-}
-
 class UpdateHandler extends BaseCommand {
   async run(ids: string[], options: UpdateOptions): Promise<void> {
     if (ids.length === 1) {

--- a/packages/tbd/src/cli/commands/update.ts
+++ b/packages/tbd/src/cli/commands/update.ts
@@ -59,15 +59,6 @@ interface UpdateOptions {
   ignoreMissing?: boolean;
 }
 
-/**
- * Read a date option into a full timestamp.
- *
- * The stored field is an ISO datetime, but nobody types one: `--due 2026-12-01` is what
- * a person writes, and rejecting it for want of a time of day is the tool being pedantic
- * about its own storage format. Anything `Date` can parse is accepted and normalized;
- * anything it cannot is refused by name, rather than reaching the schema and coming back
- * as "Invalid datetime".
- */
 class UpdateHandler extends BaseCommand {
   async run(ids: string[], options: UpdateOptions): Promise<void> {
     if (ids.length === 1) {

--- a/packages/tbd/src/cli/lib/integration-runner.ts
+++ b/packages/tbd/src/cli/lib/integration-runner.ts
@@ -402,6 +402,7 @@ export async function runEnabledIntegrationPushes(
     const plan = planMirror({
       provider: entry.provider,
       allIssues,
+      readyAt: Date.now(),
       selected,
       displayId,
       mirrorLabels: resolveProviderSettings(config.integrations?.linear ?? {}).mirrorLabels,

--- a/packages/tbd/src/cli/lib/issue-input-validation.ts
+++ b/packages/tbd/src/cli/lib/issue-input-validation.ts
@@ -39,6 +39,12 @@ export function validateIssueTitle(title: string, options: IssueTitleValidationO
 /**
  * Parse a user-supplied date flag into a normalized ISO timestamp.
  *
+ * The stored field is an ISO datetime, but nobody types one: `--due 2026-12-01` is what
+ * a person writes, and rejecting it for want of a time of day is the tool being pedantic
+ * about its own storage format. Anything `Date` can parse is accepted and normalized;
+ * anything it cannot is refused by name, rather than reaching the schema and coming back
+ * as "Invalid datetime".
+ *
  * Shared by every date-valued flag so an unusable value fails loudly at the CLI
  * boundary. A filter that silently accepts garbage and then matches everything is
  * indistinguishable to the caller from a filter that did not run.

--- a/packages/tbd/src/cli/lib/issue-input-validation.ts
+++ b/packages/tbd/src/cli/lib/issue-input-validation.ts
@@ -35,3 +35,18 @@ export function validateIssueTitle(title: string, options: IssueTitleValidationO
 
   return title;
 }
+
+/**
+ * Parse a user-supplied date flag into a normalized ISO timestamp.
+ *
+ * Shared by every date-valued flag so an unusable value fails loudly at the CLI
+ * boundary. A filter that silently accepts garbage and then matches everything is
+ * indistinguishable to the caller from a filter that did not run.
+ */
+export function parseDateOption(value: string, flag: string): string {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    throw new ValidationError(`Invalid ${flag} value: ${value}. Expected a date or timestamp.`);
+  }
+  return new Date(parsed).toISOString();
+}

--- a/packages/tbd/src/cli/web/board.ts
+++ b/packages/tbd/src/cli/web/board.ts
@@ -245,7 +245,6 @@ interface BoardSnapshot {
   byInternalId: Map<string, Issue>;
   byDisplayId: Map<string, Issue>;
   displayIdByInternalId: Map<string, string>;
-  readyIds: ReadonlySet<string>;
 }
 
 interface BoundedChanges {
@@ -611,8 +610,10 @@ export class BoardState {
     byInternalId: new Map(),
     byDisplayId: new Map(),
     displayIdByInternalId: new Map(),
-    readyIds: new Set(),
   };
+  /** Ready ids for the response being built; see `buildBoardResponse`. */
+  private responseReadyIds: ReadonlySet<string> = new Set();
+
   private snapshotState: BoardSnapshotState;
   private reloadTail: Promise<unknown> = Promise.resolve();
 
@@ -687,20 +688,28 @@ export class BoardState {
     const context = this.requireContext();
     const parsed = parseBoardQuery(params, context);
     const queryWithoutLimit = { ...parsed.query, limit: null };
+    // Readiness depends on `deferred_until`, so it is a function of the clock and cannot
+    // be cached on the snapshot. Evaluate it once here and reuse that instant for both
+    // the Ready filter and the per-row marker: two reads would let a deferral elapsing
+    // mid-response show a bead in the Ready view without its ready marker. This method
+    // is synchronous, so no other response can interleave with the field below.
+    const readyAt = this.dependencies.now().getTime();
+    this.responseReadyIds = readyIssueIds(this.snapshot.issues, readyAt);
     const filterFacetPool = (query: IssueQuery): Issue[] =>
-      filterIssues(this.snapshot.issues, query).filter((issue) =>
+      filterIssues(this.snapshot.issues, query, readyAt).filter((issue) =>
         matchesSearch(
           issue,
           this.snapshot.displayIdByInternalId.get(issue.id) ?? issue.id,
           parsed.search,
         ),
       );
-    const selected = selectIssues(this.snapshot.issues, queryWithoutLimit).filter((issue) =>
-      matchesSearch(
-        issue,
-        this.snapshot.displayIdByInternalId.get(issue.id) ?? issue.id,
-        parsed.search,
-      ),
+    const selected = selectIssues(this.snapshot.issues, queryWithoutLimit, readyAt).filter(
+      (issue) =>
+        matchesSearch(
+          issue,
+          this.snapshot.displayIdByInternalId.get(issue.id) ?? issue.id,
+          parsed.search,
+        ),
     );
     const labelFacetPool = filterFacetPool({ ...queryWithoutLimit, labels: [] });
     const statusFacetPool = filterFacetPool({
@@ -717,10 +726,14 @@ export class BoardState {
 
     let closedHidden = 0;
     if (!parsed.query.includeClosed && parsed.query.status !== 'closed') {
-      const includingClosed = selectIssues(this.snapshot.issues, {
-        ...queryWithoutLimit,
-        includeClosed: true,
-      }).filter((issue) =>
+      const includingClosed = selectIssues(
+        this.snapshot.issues,
+        {
+          ...queryWithoutLimit,
+          includeClosed: true,
+        },
+        readyAt,
+      ).filter((issue) =>
         matchesSearch(
           issue,
           this.snapshot.displayIdByInternalId.get(issue.id) ?? issue.id,
@@ -939,7 +952,6 @@ export class BoardState {
         issues.map((issue) => [displayIdByInternalId.get(issue.id) ?? issue.id, issue]),
       ),
       displayIdByInternalId,
-      readyIds: readyIssueIds(issues),
     };
 
     let dataVersion = this.snapshotState.dataVersion;
@@ -991,6 +1003,7 @@ export class BoardState {
         };
         const detailIds = movedInternalIds.slice(0, MAX_LOCAL_CHANGE_DETAILS);
         const rawChanges = createIssueChanges({
+          readyAt: this.dependencies.now().getTime(),
           before,
           after,
           prefix: context.prefix,
@@ -1106,7 +1119,7 @@ export class BoardState {
       labels: [...issue.labels],
       spec_path: issue.spec_path ?? null,
       assignee: issue.assignee ?? null,
-      ready: this.snapshot.readyIds.has(issue.id),
+      ready: this.responseReadyIds.has(issue.id),
       updated_at: issue.updated_at,
       prefix,
     };

--- a/packages/tbd/src/file/doc-cache.ts
+++ b/packages/tbd/src/file/doc-cache.ts
@@ -421,7 +421,12 @@ const SHORTCUT_DIRECTORY_END = '<!-- END SHORTCUT DIRECTORY -->';
 interface GuidelineGroup {
   heading: string;
   note?: string;
-  match: (name: string) => boolean;
+  /**
+   * `category` is the doc's declared frontmatter category. Prefer it over the name:
+   * doc-categories.ts calls name inference retired, and a prefix test silently
+   * misfiles a sibling whose name does not share the prefix.
+   */
+  match: (name: string, category?: string) => boolean;
 }
 
 /**
@@ -452,6 +457,7 @@ const CROSS_CUTTING_NAMES = new Set([
   'general-testing-rules',
   'golden-testing-guidelines',
   'release-engineering-rules',
+  'release-notes-guidelines',
   'supply-chain-hardening',
 ]);
 
@@ -486,8 +492,7 @@ const GUIDELINE_GROUPS: GuidelineGroup[] = [
   {
     heading: 'TypeScript & JS ecosystem',
     note: 'Select the documents that match the TypeScript or JavaScript surface; do not load this whole group by default.',
-    match: (n) =>
-      n.startsWith('typescript-') || n.endsWith('monorepo-patterns') || n.startsWith('electron-'),
+    match: (n) => n.startsWith('typescript-') || n.endsWith('monorepo-patterns'),
   },
   {
     heading: 'Python',
@@ -505,6 +510,14 @@ const GUIDELINE_GROUPS: GuidelineGroup[] = [
     match: (n) => n.startsWith('convex-'),
   },
   {
+    heading: 'Desktop app frameworks',
+    note: 'Select the document for the framework in use; do not load this whole group by default.',
+    // Matched on the declared category, not the name. `electron-`, `electrobun-`, and
+    // `tauri-` share no prefix, which is exactly how two of the three used to land in
+    // the catch-all while the third was filed under TypeScript.
+    match: (_n, category) => category === 'desktop',
+  },
+  {
     // Catch-all, must stay last.
     heading: 'Docs, process & tooling',
     match: () => true,
@@ -518,8 +531,8 @@ const GUIDELINE_GROUPS: GuidelineGroup[] = [
  * the only other place this logic surfaces, and a misfiled guideline there is
  * easy to miss.
  */
-export function guidelineGroupFor(name: string): string {
-  const group = GUIDELINE_GROUPS.find((g) => g.match(name));
+export function guidelineGroupFor(name: string, category?: string): string {
+  const group = GUIDELINE_GROUPS.find((g) => g.match(name, category));
   // The catch-all matches everything, so this fallback is unreachable in practice.
   return group?.heading ?? GUIDELINE_GROUPS[GUIDELINE_GROUPS.length - 1]!.heading;
 }
@@ -612,7 +625,7 @@ export function generateShortcutDirectory(
     const grouped = GUIDELINE_GROUPS.map((group) => ({ group, docs: [] as CachedDoc[] }));
     const catchAll = grouped[grouped.length - 1];
     for (const doc of guidelines) {
-      const heading = guidelineGroupFor(doc.name);
+      const heading = guidelineGroupFor(doc.name, doc.frontmatter?.category);
       const entry = grouped.find((g) => g.group.heading === heading) ?? catchAll;
       entry?.docs.push(doc);
     }

--- a/packages/tbd/src/file/sync-branch-changes.ts
+++ b/packages/tbd/src/file/sync-branch-changes.ts
@@ -355,6 +355,7 @@ export async function createChangesReportFromRefs(
           readSnapshot(options.repoDir, tip, dependencies),
         ]);
   return createIssueChangesReport({
+    readyAt: Date.now(),
     since,
     tip,
     before,

--- a/packages/tbd/src/integrations/core/mirror.ts
+++ b/packages/tbd/src/integrations/core/mirror.ts
@@ -42,6 +42,12 @@ export interface MirrorContext {
   provider: ProviderNameType;
   /** Every bead, needed for child counts and readiness. */
   allIssues: readonly Issue[];
+  /**
+   * The instant readiness is evaluated at, since a `deferred_until` in the future
+   * makes a bead not-ready. Supplied by callers so one mirror run cannot straddle
+   * two clock reads, and so tests can pin it; defaults to now.
+   */
+  readyAt?: number;
   /** The beads to mirror. */
   selected: readonly Issue[];
   /** Renders an internal id the way a user sees it. */
@@ -195,12 +201,15 @@ export function attachmentsFor(
 }
 
 /**
- * Compute what a mirror run would do. Pure.
+ * Compute what a mirror run would do.
+ *
+ * Pure given `context.readyAt`; without it the readiness cutoff is read from the
+ * clock once, here, rather than per bead.
  */
 export function planMirror(context: MirrorContext): MirrorPlan {
   const byId = new Map(context.allIssues.map((issue) => [issue.id, issue]));
   const selectedIds = new Set(context.selected.map((issue) => issue.id));
-  const readyIds = readyIssueIds(context.allIssues);
+  const readyIds = readyIssueIds(context.allIssues, context.readyAt ?? Date.now());
 
   const childrenOf = new Map<string, Issue[]>();
   for (const issue of context.allIssues) {

--- a/packages/tbd/src/integrations/core/mirror.ts
+++ b/packages/tbd/src/integrations/core/mirror.ts
@@ -44,10 +44,10 @@ export interface MirrorContext {
   allIssues: readonly Issue[];
   /**
    * The instant readiness is evaluated at, since a `deferred_until` in the future
-   * makes a bead not-ready. Supplied by callers so one mirror run cannot straddle
-   * two clock reads, and so tests can pin it; defaults to now.
+   * makes a bead not-ready. Required so one mirror run cannot straddle two clock
+   * reads, and so tests can pin it.
    */
-  readyAt?: number;
+  readyAt: number;
   /** The beads to mirror. */
   selected: readonly Issue[];
   /** Renders an internal id the way a user sees it. */
@@ -209,7 +209,7 @@ export function attachmentsFor(
 export function planMirror(context: MirrorContext): MirrorPlan {
   const byId = new Map(context.allIssues.map((issue) => [issue.id, issue]));
   const selectedIds = new Set(context.selected.map((issue) => issue.id));
-  const readyIds = readyIssueIds(context.allIssues, context.readyAt ?? Date.now());
+  const readyIds = readyIssueIds(context.allIssues, context.readyAt);
 
   const childrenOf = new Map<string, Issue[]>();
   for (const issue of context.allIssues) {

--- a/packages/tbd/src/integrations/core/sync-engine.ts
+++ b/packages/tbd/src/integrations/core/sync-engine.ts
@@ -552,7 +552,7 @@ export async function runSync(options: SyncEngineOptions): Promise<SyncRunReport
 
   // 2. Assemble the linked set and the remote view.
   const currentIssues = [...issuesById.values()];
-  const readyIds = readyIssueIds(currentIssues);
+  const readyIds = readyIssueIds(currentIssues, Date.now());
   const childrenByParent = new Map<string, Issue[]>();
   for (const issue of currentIssues) {
     if (!issue.parent_id) {

--- a/packages/tbd/src/lib/issue-changes.ts
+++ b/packages/tbd/src/lib/issue-changes.ts
@@ -442,8 +442,16 @@ export function createIssueChanges(options: CreateIssueChangesOptions): IssueCha
   const idsToCompare = explicitIds ?? candidateIds;
   const needsReadySets = options.selection.kind === 'filter' && options.selection.ready;
   const emptySet: ReadonlySet<string> = new Set();
-  const readyBefore = needsReadySets ? readyIssueIds(options.before.issues.values()) : emptySet;
-  const readyAfter = needsReadySets ? readyIssueIds(options.after.issues.values()) : emptySet;
+  // One instant for both snapshots: readiness depends on `deferred_until`, so two
+  // clock reads could report a deferral that merely elapsed between them as a ready
+  // transition that no edit caused.
+  const readyAt = Date.now();
+  const readyBefore = needsReadySets
+    ? readyIssueIds(options.before.issues.values(), readyAt)
+    : emptySet;
+  const readyAfter = needsReadySets
+    ? readyIssueIds(options.after.issues.values(), readyAt)
+    : emptySet;
   const changes: IssueChange[] = [];
 
   for (const internalId of Array.from(idsToCompare).sort((left, right) =>

--- a/packages/tbd/src/lib/issue-changes.ts
+++ b/packages/tbd/src/lib/issue-changes.ts
@@ -76,6 +76,12 @@ export interface IssueChangesReport {
 }
 
 export interface CreateIssueChangesReportOptions {
+  /**
+   * The instant readiness is evaluated at, shared by both snapshots. Required so this
+   * module stays pure: a `Date.now()` here would make a fixed pair of snapshots produce
+   * different reports, which tests cannot pin and callers cannot control.
+   */
+  readyAt: number;
   since: string;
   tip: string;
   before: IssueSnapshot;
@@ -444,8 +450,9 @@ export function createIssueChanges(options: CreateIssueChangesOptions): IssueCha
   const emptySet: ReadonlySet<string> = new Set();
   // One instant for both snapshots: readiness depends on `deferred_until`, so two
   // clock reads could report a deferral that merely elapsed between them as a ready
-  // transition that no edit caused.
-  const readyAt = Date.now();
+  // transition that no edit caused. Supplied by the caller so this module stays pure
+  // and so the web board can reuse the instant it already stamps a response with.
+  const readyAt = options.readyAt;
   const readyBefore = needsReadySets
     ? readyIssueIds(options.before.issues.values(), readyAt)
     : emptySet;

--- a/packages/tbd/src/lib/issue-query.ts
+++ b/packages/tbd/src/lib/issue-query.ts
@@ -45,7 +45,10 @@ export interface IssueQuery {
    * anything and is excluded whenever this is set.
    */
   deferBefore: string | null;
-  /** `tbd ready` semantics: open, unassigned, and unblocked per `readyIssueIds`. */
+  /**
+   * `tbd ready` semantics per `readyIssueIds`: open, unassigned, unblocked, and not
+   * deferred into the future. Time-dependent, so the evaluation instant is passed in.
+   */
   ready: boolean;
   /** `--sort` */
   sort: IssueSort;
@@ -84,8 +87,8 @@ export function defaultIssueQuery(): IssueQuery {
  * the internal-ULID tiebreak (chronological and deterministic, unlike the random short
  * display ids).
  */
-export function selectIssues(issues: readonly Issue[], query: IssueQuery): Issue[] {
-  const filtered = filterIssues(issues, query);
+export function selectIssues(issues: readonly Issue[], query: IssueQuery, now: number): Issue[] {
+  const filtered = filterIssues(issues, query, now);
   const sorted = sortIssues(filtered, query.sort);
   return query.limit === null ? sorted : sorted.slice(0, query.limit);
 }
@@ -106,9 +109,15 @@ function deferredBefore(issue: Issue, cutoff: string): boolean {
   return Number.isFinite(until) && until < Date.parse(cutoff);
 }
 
-/** Apply shared CLI query predicates without paying for ordering when only facets need rows. */
-export function filterIssues(issues: readonly Issue[], query: IssueQuery): Issue[] {
-  const readyIds = query.ready ? readyIssueIds(issues) : null;
+/**
+ * Apply shared CLI query predicates without paying for ordering when only facets need rows.
+ *
+ * `now` is the instant readiness is evaluated at. Callers that also display readiness
+ * must pass the same instant they used there, or a deferral elapsing between the two
+ * reads makes the filter and the display disagree.
+ */
+export function filterIssues(issues: readonly Issue[], query: IssueQuery, now: number): Issue[] {
+  const readyIds = query.ready ? readyIssueIds(issues, now) : null;
 
   return issues.filter((issue) => {
     // By default, exclude closed issues unless --all or --status closed
@@ -204,6 +213,7 @@ export function describeQuery(
       query.parentId !== null ||
       query.spec !== null ||
       query.deferred ||
+      query.deferBefore !== null ||
       query.sort !== 'priority';
     return { command: parts.join(' '), exact: !unsupported };
   }
@@ -235,6 +245,9 @@ export function describeQuery(
   }
   if (query.deferred) {
     parts.push('--deferred');
+  }
+  if (query.deferBefore !== null) {
+    parts.push(`--defer-before ${query.deferBefore}`);
   }
   if (query.sort !== 'priority') {
     parts.push(`--sort ${query.sort}`);

--- a/packages/tbd/src/lib/issue-query.ts
+++ b/packages/tbd/src/lib/issue-query.ts
@@ -38,6 +38,13 @@ export interface IssueQuery {
   spec: string | null;
   /** `--deferred` */
   deferred: boolean;
+  /**
+   * `--defer-before <date>`, already parsed to an ISO timestamp by the caller (as
+   * `priority` is): keep only beads whose `deferred_until` falls before this instant.
+   * Null means no filter. A bead with no `deferred_until` is not deferred before
+   * anything and is excluded whenever this is set.
+   */
+  deferBefore: string | null;
   /** `tbd ready` semantics: open, unassigned, and unblocked per `readyIssueIds`. */
   ready: boolean;
   /** `--sort` */
@@ -61,6 +68,7 @@ export function defaultIssueQuery(): IssueQuery {
     parentId: null,
     spec: null,
     deferred: false,
+    deferBefore: null,
     ready: false,
     sort: 'priority',
     limit: null,
@@ -80,6 +88,22 @@ export function selectIssues(issues: readonly Issue[], query: IssueQuery): Issue
   const filtered = filterIssues(issues, query);
   const sorted = sortIssues(filtered, query.sort);
   return query.limit === null ? sorted : sorted.slice(0, query.limit);
+}
+
+/**
+ * Whether a bead carries a `deferred_until` strictly before `cutoff`.
+ *
+ * A bead with no deferral is not "deferred before" any date, so it is excluded rather
+ * than treated as deferred since the beginning of time. `cutoff` is already-parsed
+ * per the field contract, so an unusable value is rejected at the CLI boundary rather
+ * than degrading into a filter that matches everything.
+ */
+function deferredBefore(issue: Issue, cutoff: string): boolean {
+  if (issue.deferred_until == null) {
+    return false;
+  }
+  const until = Date.parse(issue.deferred_until);
+  return Number.isFinite(until) && until < Date.parse(cutoff);
 }
 
 /** Apply shared CLI query predicates without paying for ordering when only facets need rows. */
@@ -113,6 +137,9 @@ export function filterIssues(issues: readonly Issue[], query: IssueQuery): Issue
       return false;
     }
     if (query.deferred && issue.status !== 'deferred') {
+      return false;
+    }
+    if (query.deferBefore !== null && !deferredBefore(issue, query.deferBefore)) {
       return false;
     }
     if (readyIds !== null && !readyIds.has(issue.id)) {

--- a/packages/tbd/src/lib/issue-selection.ts
+++ b/packages/tbd/src/lib/issue-selection.ts
@@ -35,6 +35,21 @@ export function issueMatchesSharedFilters(issue: Issue, filters: SharedIssueFilt
 }
 
 /**
+ * Whether a bead is still waiting out a `deferred_until` at `now`.
+ *
+ * A deferral exactly at `now` has arrived, so the work is available. An unparseable
+ * timestamp fails open — the schema validates the field, and hiding work because a
+ * date could not be read is the worse failure of the two.
+ */
+function deferralPending(issue: Issue, now: number): boolean {
+  if (issue.deferred_until == null) {
+    return false;
+  }
+  const until = Date.parse(issue.deferred_until);
+  return Number.isFinite(until) && until > now;
+}
+
+/**
  * Compute ready issue IDs from one complete issue snapshot.
  *
  * A `blocks` relation is stored on the blocker and points to its blocked target.
@@ -50,8 +65,21 @@ export function issueMatchesSharedFilters(issue: Issue, filters: SharedIssueFilt
  * A held bead is never ready regardless of its dependencies: `blocked` means it is
  * waiting on something and `paused` means it was deliberately set down, and offering
  * either to an agent looking for work is how a hold gets quietly ignored.
+ *
+ * A `deferred_until` still in the future is the same kind of hold, written as a date
+ * instead of a flag. It used to be recorded and then ignored here, so a bead deferred
+ * to next year was offered as available work today and the field read as scheduling
+ * while scheduling nothing.
+ *
+ * `now` is a parameter rather than a `Date.now()` read inside the filter because
+ * `issue-changes.ts` computes this set twice to diff two snapshots: if each call took
+ * its own clock, a bead whose deferral elapsed between them would surface as a ready
+ * transition that no edit caused.
  */
-export function readyIssueIds(issues: Iterable<Issue>): ReadonlySet<string> {
+export function readyIssueIds(
+  issues: Iterable<Issue>,
+  now: number = Date.now(),
+): ReadonlySet<string> {
   const allIssues = Array.from(issues);
   const issueById = new Map(allIssues.map((issue) => [issue.id, issue]));
   const blockerIdsByTarget = new Map<string, string[]>();
@@ -71,6 +99,9 @@ export function readyIssueIds(issues: Iterable<Issue>): ReadonlySet<string> {
     allIssues
       .filter((issue) => {
         if (issue.status !== 'open' || issue.delegate || issue.hold) {
+          return false;
+        }
+        if (deferralPending(issue, now)) {
           return false;
         }
         const blockerIds = blockerIdsByTarget.get(issue.id) ?? [];

--- a/packages/tbd/src/lib/issue-selection.ts
+++ b/packages/tbd/src/lib/issue-selection.ts
@@ -71,15 +71,15 @@ function deferralPending(issue: Issue, now: number): boolean {
  * to next year was offered as available work today and the field read as scheduling
  * while scheduling nothing.
  *
- * `now` is a parameter rather than a `Date.now()` read inside the filter because
- * `issue-changes.ts` computes this set twice to diff two snapshots: if each call took
- * its own clock, a bead whose deferral elapsed between them would surface as a ready
- * transition that no edit caused.
+ * `now` is a required parameter rather than a `Date.now()` read inside the filter
+ * because callers routinely evaluate readiness more than once for what must be a single
+ * instant: `issue-changes.ts` diffs two snapshots, and the web board marks rows and
+ * filters them in the same response. If each call took its own clock, a bead whose
+ * deferral elapsed in between would surface as a ready transition that no edit caused.
+ * It is required rather than defaulted because every such bug so far came from a caller
+ * silently accepting the default.
  */
-export function readyIssueIds(
-  issues: Iterable<Issue>,
-  now: number = Date.now(),
-): ReadonlySet<string> {
+export function readyIssueIds(issues: Iterable<Issue>, now: number): ReadonlySet<string> {
   const allIssues = Array.from(issues);
   const issueById = new Map(allIssues.map((issue) => [issue.id, issue]));
   const blockerIdsByTarget = new Map<string, string[]>();

--- a/packages/tbd/tests/cli-edge-cases.tryscript.md
+++ b/packages/tbd/tests/cli-edge-cases.tryscript.md
@@ -401,3 +401,43 @@ $ tbd list --deferred --json
 [..]
 ? 0
 ```
+
+# Test: Create accepts a bare date for --defer and normalizes it
+
+```console
+$ tbd create "Bare date defer" --defer=2099-06-15
+✓ Created test-[SHORTID]: Bare date defer
+? 0
+```
+
+# Test: A future-deferred bead is not offered as ready
+
+```console
+$ tbd ready --json | jq '[.[] | select(.title == "Deferred task")] | length'
+0
+? 0
+```
+
+# Test: --defer-before includes a bead deferred before the cutoff
+
+```console
+$ tbd list --defer-before 2100-01-01 --json | jq '[.[] | select(.title == "Deferred task")] | length'
+1
+? 0
+```
+
+# Test: --defer-before excludes everything before an early cutoff
+
+```console
+$ tbd list --defer-before 2000-01-01 --json | jq 'length'
+0
+? 0
+```
+
+# Test: --defer-before rejects an unparseable value by name
+
+```console
+$ tbd list --defer-before nope 2>&1
+Error: Invalid --defer-before value: nope. Expected a date or timestamp.
+? 2
+```

--- a/packages/tbd/tests/deferred-until.test.ts
+++ b/packages/tbd/tests/deferred-until.test.ts
@@ -1,0 +1,125 @@
+/**
+ * `deferred_until` is a scheduling field, and two surfaces ignored it.
+ *
+ * `tbd ready` offered a bead deferred to 2027 as available work today, so the field
+ * read as scheduling while changing nothing about what was surfaced. And
+ * `tbd list --defer-before <date>` was declared in the option table and help text but
+ * never read by any filter, so it returned the same rows as no flag at all — a silent
+ * no-op is worse than a missing flag, because the caller believes the filter applied.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { ValidationError } from '../src/cli/lib/errors.js';
+import { parseDateOption } from '../src/cli/lib/issue-input-validation.js';
+import { defaultIssueQuery, selectIssues } from '../src/lib/issue-query.js';
+import { readyIssueIds } from '../src/lib/issue-selection.js';
+import type { Issue } from '../src/lib/types.js';
+
+const NOW = Date.parse('2026-06-01T00:00:00.000Z');
+
+function issue(id: string, overrides: Partial<Issue> = {}): Issue {
+  return {
+    type: 'is',
+    id: `is-01HZZZZZZZZZZZZZZZZZ${id.padStart(6, '0')}`,
+    version: 1,
+    title: `Issue ${id}`,
+    kind: 'task',
+    status: 'open',
+    priority: 2,
+    labels: [],
+    dependencies: [],
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  } as unknown as Issue;
+}
+
+describe('deferred_until and tbd ready', () => {
+  it('does not offer a bead deferred into the future', () => {
+    const future = issue('1', { deferred_until: '2027-01-01T00:00:00.000Z' } as Partial<Issue>);
+    expect(readyIssueIds([future], NOW).has(future.id)).toBe(false);
+  });
+
+  it('offers a bead whose deferral has elapsed', () => {
+    const past = issue('2', { deferred_until: '2026-01-15T00:00:00.000Z' } as Partial<Issue>);
+    expect(readyIssueIds([past], NOW).has(past.id)).toBe(true);
+  });
+
+  it('offers a bead with no deferral', () => {
+    const plain = issue('3');
+    expect(readyIssueIds([plain], NOW).has(plain.id)).toBe(true);
+  });
+
+  it('treats a deferral exactly at now as elapsed', () => {
+    // The boundary has to fall on one side deliberately: a deferral "until now" has
+    // arrived, so the work is available.
+    const boundary = issue('4', { deferred_until: '2026-06-01T00:00:00.000Z' } as Partial<Issue>);
+    expect(readyIssueIds([boundary], NOW).has(boundary.id)).toBe(true);
+  });
+
+  it('keeps the existing holds independent of deferral', () => {
+    const closed = issue('5', { status: 'closed' });
+    const deferredAndClosed = issue('6', {
+      status: 'closed',
+      deferred_until: '2026-01-15T00:00:00.000Z',
+    } as Partial<Issue>);
+    const ready = readyIssueIds([closed, deferredAndClosed], NOW);
+    expect(ready.has(closed.id)).toBe(false);
+    expect(ready.has(deferredAndClosed.id)).toBe(false);
+  });
+
+  it('uses one caller-supplied instant so before/after snapshots cannot disagree', () => {
+    // issue-changes.ts computes the ready set twice to diff two snapshots. If each
+    // call read its own clock, a bead whose deferral elapsed between them would show
+    // as a ready transition that no edit caused.
+    const bead = issue('7', { deferred_until: '2026-06-01T00:00:01.000Z' } as Partial<Issue>);
+    expect(readyIssueIds([bead], NOW).has(bead.id)).toBe(false);
+    expect(readyIssueIds([bead], NOW + 2000).has(bead.id)).toBe(true);
+  });
+});
+
+describe('tbd list --defer-before', () => {
+  const deferred2027 = issue('1', { deferred_until: '2027-01-01T00:00:00.000Z' } as Partial<Issue>);
+  const deferred2026 = issue('2', { deferred_until: '2026-03-01T00:00:00.000Z' } as Partial<Issue>);
+  const notDeferred = issue('3');
+  const corpus = [deferred2027, deferred2026, notDeferred];
+
+  function idsFor(deferBefore: string | null): string[] {
+    return selectIssues(corpus, { ...defaultIssueQuery(), deferBefore }).map((i) => i.id);
+  }
+
+  it('is off by default', () => {
+    expect(idsFor(null)).toHaveLength(3);
+  });
+
+  it('keeps only beads deferred before the given date', () => {
+    expect(idsFor('2026-06-01T00:00:00.000Z')).toEqual([deferred2026.id]);
+  });
+
+  it('excludes a bead with no deferral, which is not deferred before anything', () => {
+    // Sorted: this asserts membership, not the ULID tiebreak that orders the rows.
+    expect(idsFor('2028-01-01T00:00:00.000Z').sort()).toEqual(
+      [deferred2026.id, deferred2027.id].sort(),
+    );
+  });
+
+  it('is exclusive at the boundary', () => {
+    expect(idsFor('2026-03-01T00:00:00.000Z')).toEqual([]);
+  });
+
+  it('rejects an unusable date at the CLI boundary rather than matching everything', () => {
+    // The failure mode being designed out: a filter that cannot read its argument and
+    // then returns every row is indistinguishable, to the caller, from one that never
+    // ran. `--defer-before` reaches the query module already parsed, so the rejection
+    // happens where the user can see it.
+    expect(() => parseDateOption('not-a-date', '--defer-before')).toThrow(ValidationError);
+    expect(parseDateOption('2027-01-01', '--defer-before')).toBe('2027-01-01T00:00:00.000Z');
+  });
+
+  it('is not a silent no-op: a filter that matches nothing returns nothing', () => {
+    // The defect this pins: the flag parsed, was stored on the options object, and
+    // then returned every row. An empty result proves the predicate actually ran.
+    expect(idsFor('2020-01-01T00:00:00.000Z')).toEqual([]);
+  });
+});

--- a/packages/tbd/tests/deferred-until.test.ts
+++ b/packages/tbd/tests/deferred-until.test.ts
@@ -37,12 +37,12 @@ function issue(id: string, overrides: Partial<Issue> = {}): Issue {
 
 describe('deferred_until and tbd ready', () => {
   it('does not offer a bead deferred into the future', () => {
-    const future = issue('1', { deferred_until: '2027-01-01T00:00:00.000Z' } as Partial<Issue>);
+    const future = issue('1', { deferred_until: '2027-01-01T00:00:00.000Z' });
     expect(readyIssueIds([future], NOW).has(future.id)).toBe(false);
   });
 
   it('offers a bead whose deferral has elapsed', () => {
-    const past = issue('2', { deferred_until: '2026-01-15T00:00:00.000Z' } as Partial<Issue>);
+    const past = issue('2', { deferred_until: '2026-01-15T00:00:00.000Z' });
     expect(readyIssueIds([past], NOW).has(past.id)).toBe(true);
   });
 
@@ -54,7 +54,7 @@ describe('deferred_until and tbd ready', () => {
   it('treats a deferral exactly at now as elapsed', () => {
     // The boundary has to fall on one side deliberately: a deferral "until now" has
     // arrived, so the work is available.
-    const boundary = issue('4', { deferred_until: '2026-06-01T00:00:00.000Z' } as Partial<Issue>);
+    const boundary = issue('4', { deferred_until: '2026-06-01T00:00:00.000Z' });
     expect(readyIssueIds([boundary], NOW).has(boundary.id)).toBe(true);
   });
 
@@ -63,7 +63,7 @@ describe('deferred_until and tbd ready', () => {
     const deferredAndClosed = issue('6', {
       status: 'closed',
       deferred_until: '2026-01-15T00:00:00.000Z',
-    } as Partial<Issue>);
+    });
     const ready = readyIssueIds([closed, deferredAndClosed], NOW);
     expect(ready.has(closed.id)).toBe(false);
     expect(ready.has(deferredAndClosed.id)).toBe(false);
@@ -73,20 +73,22 @@ describe('deferred_until and tbd ready', () => {
     // issue-changes.ts computes the ready set twice to diff two snapshots. If each
     // call read its own clock, a bead whose deferral elapsed between them would show
     // as a ready transition that no edit caused.
-    const bead = issue('7', { deferred_until: '2026-06-01T00:00:01.000Z' } as Partial<Issue>);
+    const bead = issue('7', { deferred_until: '2026-06-01T00:00:01.000Z' });
     expect(readyIssueIds([bead], NOW).has(bead.id)).toBe(false);
     expect(readyIssueIds([bead], NOW + 2000).has(bead.id)).toBe(true);
   });
 });
 
 describe('tbd list --defer-before', () => {
-  const deferred2027 = issue('1', { deferred_until: '2027-01-01T00:00:00.000Z' } as Partial<Issue>);
-  const deferred2026 = issue('2', { deferred_until: '2026-03-01T00:00:00.000Z' } as Partial<Issue>);
+  const deferred2027 = issue('1', { deferred_until: '2027-01-01T00:00:00.000Z' });
+  const deferred2026 = issue('2', { deferred_until: '2026-03-01T00:00:00.000Z' });
   const notDeferred = issue('3');
   const corpus = [deferred2027, deferred2026, notDeferred];
 
   function idsFor(deferBefore: string | null): string[] {
-    return selectIssues(corpus, { ...defaultIssueQuery(), deferBefore }).map((i) => i.id);
+    return selectIssues(corpus, { ...defaultIssueQuery(), deferBefore }, Date.now()).map(
+      (i) => i.id,
+    );
   }
 
   it('is off by default', () => {

--- a/packages/tbd/tests/guideline-groups.test.ts
+++ b/packages/tbd/tests/guideline-groups.test.ts
@@ -102,6 +102,53 @@ describe('guidelineGroupFor', () => {
     }
   });
 
+  it('routes a declared category to its own group rather than the catch-all', async () => {
+    // The grouping matched on name prefixes while every bundled guideline already
+    // declares a category, and doc-categories.ts calls name inference retired. The
+    // two disagreed: `electron-app-development-patterns` matched the TypeScript
+    // prefix, while its siblings `electrobun-` and `tauri-` matched nothing and fell
+    // into "Docs, process & tooling", where an agent looking for desktop guidance
+    // will not find them. Assert on the declared field, for every category at once,
+    // so the next category added cannot land in the catch-all unnoticed.
+    const declared = new Map<string, string[]>();
+    for (const name of await bundledGuidelineNames()) {
+      const content = await readFile(join(GUIDELINES_DIR, `${name}.md`), 'utf8');
+      const category = /^category:\s*(\S+)/m.exec(content)?.[1];
+      if (category == null || category === 'general') {
+        continue; // `general` is the default and is routed by explicit membership.
+      }
+      declared.set(category, [...(declared.get(category) ?? []), name]);
+    }
+    expect(declared.size).toBeGreaterThan(0);
+
+    for (const [category, names] of declared) {
+      const headings = new Set(names.map((n) => guidelineGroupFor(n, category)));
+      expect(headings.size, `${category} split across headings: ${[...headings].join(', ')}`).toBe(
+        1,
+      );
+      const [heading] = headings;
+      expect(heading, `${category} (${names.join(', ')}) fell into the catch-all`).not.toBe(
+        'Docs, process & tooling',
+      );
+    }
+  });
+
+  it('keeps the desktop frameworks together under their own heading', () => {
+    for (const name of [
+      'electron-app-development-patterns',
+      'electrobun-app-development-patterns',
+      'tauri-app-development-patterns',
+    ]) {
+      expect(guidelineGroupFor(name, 'desktop'), name).toBe('Desktop app frameworks');
+    }
+  });
+
+  it('files release-notes-guidelines beside the release engineering rules', () => {
+    // publishing.md and release-engineering-rules both tell the reader to load these
+    // together; the catch-all heading hid one half of that pair.
+    expect(guidelineGroupFor('release-notes-guidelines')).toBe('Cross-cutting engineering topics');
+  });
+
   it('files every bundled guideline in a group whose heading is non-empty', async () => {
     const grouped = new Map<string, string[]>();
     for (const name of await bundledGuidelineNames()) {

--- a/packages/tbd/tests/guideline-groups.test.ts
+++ b/packages/tbd/tests/guideline-groups.test.ts
@@ -4,9 +4,11 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
+import type { CachedDoc } from '../src/file/doc-cache.js';
 import {
   ALWAYS_LOAD_GUIDELINES,
   EXPLICITLY_GROUPED_GUIDELINES,
+  generateShortcutDirectory,
   guidelineGroupFor,
 } from '../src/file/doc-cache.js';
 
@@ -161,5 +163,65 @@ describe('guidelineGroupFor', () => {
       (await bundledGuidelineNames()).filter((n) => n.startsWith('rust-')).sort(),
     );
     expect(grouped.get('Cross-cutting engineering topics')?.length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * The predicate being right is not enough: the directory is what agents actually read,
+ * and the bug this fixes was a value that was computed and then not passed on. Dropping
+ * the `category` argument at the `generateShortcutDirectory` call site leaves every
+ * predicate test green, so assert the rendered output too.
+ */
+describe('generateShortcutDirectory guideline routing', () => {
+  function doc(name: string, category?: string): CachedDoc {
+    return {
+      path: `/docs/guidelines/${name}.md`,
+      name,
+      frontmatter: category === undefined ? undefined : { category },
+      content: '',
+      sourceDir: 'guidelines',
+      sizeBytes: 0,
+    } as CachedDoc;
+  }
+
+  /** The heading a guideline is rendered under, or null if it is absent. */
+  function headingFor(directory: string, name: string): string | null {
+    let current: string | null = null;
+    for (const line of directory.split('\n')) {
+      const heading = /^### (.+)$/.exec(line);
+      if (heading) {
+        current = heading[1]!;
+        continue;
+      }
+      if (line.startsWith(`| ${name} `) || line.startsWith(`| ${name} |`)) {
+        return current;
+      }
+    }
+    return null;
+  }
+
+  it('renders a desktop guideline under its declared category, not the catch-all', () => {
+    const directory = generateShortcutDirectory(
+      [],
+      [
+        doc('tauri-app-development-patterns', 'desktop'),
+        doc('electrobun-app-development-patterns', 'desktop'),
+        doc('release-notes-guidelines', 'general'),
+      ],
+    );
+    expect(headingFor(directory, 'tauri-app-development-patterns')).toBe('Desktop app frameworks');
+    expect(headingFor(directory, 'electrobun-app-development-patterns')).toBe(
+      'Desktop app frameworks',
+    );
+    // Routed by explicit membership rather than category, so it must not be swept
+    // into the catch-all either.
+    expect(headingFor(directory, 'release-notes-guidelines')).toBe(
+      'Cross-cutting engineering topics',
+    );
+  });
+
+  it('falls back to the catch-all when a guideline declares no category', () => {
+    const directory = generateShortcutDirectory([], [doc('some-unknown-guideline')]);
+    expect(headingFor(directory, 'some-unknown-guideline')).toBe('Docs, process & tooling');
   });
 });

--- a/packages/tbd/tests/integrations-mirror.test.ts
+++ b/packages/tbd/tests/integrations-mirror.test.ts
@@ -38,11 +38,15 @@ function issue(overrides: Partial<Issue> = {}): Issue {
 
 const displayId = (id: string): string => id.replace('is-', 'tbd-');
 
+/** One pinned instant for every plan, so readiness never depends on the wall clock. */
+const READY_AT = Date.parse('2026-08-10T00:00:00.000Z');
+
 describe('planMirror', () => {
   it('plans a create for a bead with no existing link', () => {
     const bead = issue({ id: 'is-a' });
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [bead],
       selected: [bead],
       displayId,
@@ -61,6 +65,7 @@ describe('planMirror', () => {
     const bead = issue({ id: 'is-a', assignee: 'josh' });
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [bead],
       selected: [bead],
       displayId,
@@ -78,6 +83,7 @@ describe('planMirror', () => {
     const bead = issue({ id: 'is-a', assignee: 'josh' });
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [bead],
       selected: [bead],
       displayId,
@@ -96,6 +102,7 @@ describe('planMirror', () => {
     });
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [bead],
       selected: [bead],
       displayId,
@@ -113,6 +120,7 @@ describe('planMirror', () => {
     });
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [bead],
       selected: [bead],
       displayId,
@@ -131,6 +139,7 @@ describe('planMirror', () => {
 
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [root, mid, deep],
       selected: [root, mid, deep],
       displayId,
@@ -155,6 +164,7 @@ describe('planMirror', () => {
 
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [root, mid, deep],
       selected: [root, mid, deep],
       displayId,
@@ -179,6 +189,7 @@ describe('planMirror', () => {
 
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [root, mid1, mid2, deep],
       selected: [root, mid1, mid2, deep],
       displayId,
@@ -197,6 +208,7 @@ describe('planMirror', () => {
 
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [unmirroredParent, child],
       // Only the child is selected, so it has no mirrored ancestor.
       selected: [child],
@@ -214,6 +226,7 @@ describe('planMirror', () => {
 
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [a, b],
       selected: [a, b],
       displayId,
@@ -238,6 +251,7 @@ describe('planMirror', () => {
 
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [epic, readyChild, blockedChild],
       selected: [epic],
       displayId,
@@ -255,6 +269,7 @@ describe('label mirroring', () => {
     const bead = issue({ id: 'is-a', labels: ['backend', 'ci', 'docs'] });
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [bead],
       selected: [bead],
       displayId,
@@ -270,6 +285,7 @@ describe('label mirroring', () => {
     const bead = issue({ id: 'is-a', labels: ['backend', 'ci'] });
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [bead],
       selected: [bead],
       displayId,
@@ -369,6 +385,7 @@ describe('applyMirror', () => {
     const bead = issue({ id: 'is-a', title: 'Mirror me' });
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [bead],
       selected: [bead],
       displayId,
@@ -388,6 +405,7 @@ describe('applyMirror', () => {
     const child = issue({ id: 'is-child', title: 'Child', parent_id: parent.id });
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [child, parent],
       selected: [child, parent],
       displayId,
@@ -407,6 +425,7 @@ describe('applyMirror', () => {
     const bead = issue({ id: 'is-a' });
     const first = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [bead],
       selected: [bead],
       displayId,
@@ -423,6 +442,7 @@ describe('applyMirror', () => {
 
     const second = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [relinked],
       selected: [relinked],
       displayId,
@@ -444,6 +464,7 @@ describe('applyMirror', () => {
 
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [good, bad],
       selected: [good, bad],
       displayId,
@@ -463,6 +484,7 @@ describe('applyMirror', () => {
 
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [root, mid, deep],
       selected: [root, mid, deep],
       displayId,
@@ -493,6 +515,7 @@ describe('applyMirror', () => {
     });
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [root, mid1, mid2, deep],
       selected: [root, mid1, mid2, deep],
       displayId,
@@ -531,6 +554,7 @@ describe('applyMirror', () => {
 
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [bead],
       selected: [bead],
       displayId,
@@ -559,6 +583,7 @@ describe('applyMirror', () => {
     const seen: { beadId: string; key?: string; url?: string }[] = [];
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [bead],
       selected: [bead],
       displayId,
@@ -584,6 +609,7 @@ describe('applyMirror', () => {
     const bead = issue({ id: 'is-a', title: 'Described' });
     const plan = planMirror({
       provider: 'linear',
+      readyAt: READY_AT,
       allIssues: [bead],
       selected: [bead],
       displayId,

--- a/packages/tbd/tests/issue-changes.test.ts
+++ b/packages/tbd/tests/issue-changes.test.ts
@@ -57,6 +57,9 @@ function report(
   selection: IssueChangeSelection = { kind: 'all' },
 ) {
   return createIssueChangesReport({
+    // Pinned: the report is pure, so a fixed pair of snapshots must produce a fixed
+    // result. Reading the clock here would reintroduce exactly that dependency.
+    readyAt: Date.parse('2026-08-10T00:00:00.000Z'),
     since: '1'.repeat(40),
     tip: '2'.repeat(40),
     before,

--- a/packages/tbd/tests/issue-query.test.ts
+++ b/packages/tbd/tests/issue-query.test.ts
@@ -85,13 +85,17 @@ function legacyListSort(issues: Issue[], sortField: string): Issue[] {
   );
 }
 
+/** One pinned instant for oracle and implementation alike, so the parity
+ * comparison cannot straddle two clock reads. */
+const NOW = Date.parse('2026-08-10T00:00:00.000Z');
+
 /**
  * Pre-extraction `tbd ready` pipeline. Note its tiebreak was the full internal id
  * rather than the extracted ULID; ids share the constant `is-` prefix, so the orders
  * are provably identical — this oracle keeps the original expression to prove it.
  */
 function legacyReady(issues: Issue[], kind: IssueKindType | null): Issue[] {
-  const readyIds = readyIssueIds(issues);
+  const readyIds = readyIssueIds(issues, NOW);
   let readyIssues = issues.filter((issue) => readyIds.has(issue.id));
   if (kind !== null) {
     readyIssues = readyIssues.filter((i) => i.kind === kind);
@@ -220,7 +224,7 @@ describe('selectIssues parity with the legacy list pipeline', () => {
     expect(all.length).toBeGreaterThan(30);
     for (const query of all) {
       const expected = ids(legacyListSort(legacyListFilter(corpus, query), query.sort));
-      const actual = ids(selectIssues(corpus, query));
+      const actual = ids(selectIssues(corpus, query, NOW));
       expect(actual, JSON.stringify(query)).toEqual(expected);
     }
   });
@@ -228,7 +232,7 @@ describe('selectIssues parity with the legacy list pipeline', () => {
   it('applies limit after sorting, like applyLimit did', () => {
     const query = { ...defaultIssueQuery(), limit: 7 };
     const expected = ids(legacyListSort(legacyListFilter(corpus, query), 'priority')).slice(0, 7);
-    expect(ids(selectIssues(corpus, query))).toEqual(expected);
+    expect(ids(selectIssues(corpus, query, NOW))).toEqual(expected);
   });
 });
 
@@ -236,7 +240,7 @@ describe('selectIssues parity with the legacy ready pipeline', () => {
   it('matches for every kind filter, including the internal-id-vs-ULID tiebreak', () => {
     for (const kind of [null, ...KINDS] as (IssueKindType | null)[]) {
       const expected = ids(legacyReady(corpus, kind));
-      const actual = ids(selectIssues(corpus, { ...defaultIssueQuery(), ready: true, kind }));
+      const actual = ids(selectIssues(corpus, { ...defaultIssueQuery(), ready: true, kind }, NOW));
       expect(actual, `kind=${String(kind)}`).toEqual(expected);
     }
   });


### PR DESCRIPTION
Three defects from the open bug beads, each verified live against the code before
fixing and pinned by a test that fails against the old behavior. No release in this PR —
`packages/tbd/package.json` stays at `0.8.1`.

## tbd-5av0 — `deferred_until` was recorded and then ignored

`--defer` wrote the field and `tbd ready` went on offering the bead. Verified on the
0.8.1 build before the fix: a bead deferred to `2027-01-01` appeared in `tbd ready`
today, so the field read as scheduling while scheduling nothing. The bead reports this
found during a real triage — 21 beads deferred to 2027 all stayed in `ready` until each
was separately set to `--status deferred`.

`readyIssueIds` now treats a future deferral as the hold it already documents for
`blocked` and `paused`. A deferral exactly at `now` counts as arrived.

The cutoff is a **parameter**, not a `Date.now()` read inside the filter.
`issue-changes.ts` computes this set twice to diff two snapshots; two independent clock
reads could report a deferral that merely elapsed between them as a ready transition no
edit caused. That path now passes one instant to both calls. `planMirror` is documented
as `Pure.`, so it takes an explicit `readyAt` rather than quietly acquiring a clock
dependency.

This changes readiness everywhere it is computed — `ready`, `web`, and the Linear
mirror — which is the point: `issue-query.ts` exists so two surfaces answering the same
question cannot disagree.

## tbd-v8lv — `--defer-before` was a silent no-op

`ListOptions` declared `deferBefore` and the flag appeared in `--help`, but no filter
ever read it. Verified before the fix: `tbd list --defer-before 2020-01-01` returned a
bead whose `deferred_until` was 2027.

It now filters. A bead with no `deferred_until` is not "deferred before" any date, so it
is excluded whenever the flag is set, rather than treated as deferred since the
beginning of time.

An unusable date is now **rejected at the CLI boundary** instead of degrading into a
filter that matches everything — that would be the same silent-no-op failure in a new
place:

```
$ tbd list --defer-before not-a-date
Error: Invalid --defer-before value: not-a-date. Expected a date or timestamp.
$ echo $?
2
```

`parseDateOption` moves from `update.ts` into `cli/lib/issue-input-validation.ts` so
`--due`, `--defer`, and `--defer-before` all fail the same way.

## tbd-dado — guidelines routed by filename prefix, not declared category

Every bundled guideline declares a `category`, and `doc-categories.ts` states plainly
that "the old name-based inference is retired in favor of the declared field." Grouping
was still matching name prefixes, and the two disagreed:

| Guideline | Declared | Was filed under |
| --- | --- | --- |
| `electron-app-development-patterns` | `desktop` | TypeScript & JS ecosystem |
| `electrobun-app-development-patterns` | `desktop` | **Docs, process & tooling** |
| `tauri-app-development-patterns` | `desktop` | **Docs, process & tooling** |

`n.startsWith('electron-')` is false for `electrobun-`, and `tauri-` had no matcher at
all — so an agent asked to work on a Tauri app would not find the guidance under any
framework heading. Tauri's core is Rust, so widening the TypeScript matcher would have
been wrong in the other direction.

Grouping now reads the declared field. The three frameworks share a **Desktop app
frameworks** heading, and the catch-all is left holding only genuinely miscellaneous
docs.

The regression guard is the general one, not a spot check: **every declared category
with bundled documents must route out of the catch-all**, so the next category added
cannot land there unnoticed — which is exactly how this shipped.

Also moved `release-notes-guidelines` into the cross-cutting group beside
`release-engineering-rules`, whose own description tells the reader to load the two
together. Flagging it separately since the bead only called it "arguably" misfiled —
easy to drop if you disagree.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm test` | 2464 passed, 164 files (was 2449 / 163) |
| `pnpm lint:check` | pass |
| `pnpm format:check` | pass |

Red-green on all three: the 9 new assertions were confirmed failing against the old code
before any fix, reproducing each reported symptom. Then re-verified through the built
CLI end to end — `ready` excludes the deferred bead, `--defer-before` filters and
rejects a bad date with exit 2.

## Beads

Closes tbd-5av0, tbd-v8lv, tbd-dado. Separately verified **tbd-az97** as already fixed
(a single-branch clone now discovers the remote sync branch, shares its history, and
converges) — not closed here since it is unrelated to this diff.

Left open deliberately: **tbd-pht1 / tbd-iiys**, which are live. An orphaned
`data-sync.lock` blocks every bead write and `tbd doctor` reports the repository
healthy; I reproduced a `tbd create` hanging until killed. The 30-minute `staleMs` is a
deliberate safety contract (`lockfile.ts` says so in as many words), so the fix is
observability — doctor flagging the lock, and the blocked command saying what it waits
on — not a timing change. Worth its own PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eaEeT9CYT5TDyNGAw95t9
