### PR TITLE
fix: enforce a gh version floor, bump the pin to 2.97.0, and add stacked-PR support

### DIFF
--- a/.agents/skills/tbd/SKILL.md
+++ b/.agents/skills/tbd/SKILL.md
@@ -370,6 +370,7 @@ Run `tbd shortcut <name>` to use any of these shortcuts:
 | revise-architecture-doc | Update an architecture document to reflect current codebase state |
 | setup-github-cli | Ensure GitHub CLI (gh) is installed and working |
 | setup-linear | Set up the Linear integration end to end—first-time configuration for a repository, or adding your own API key to a repository your team already configured |
+| stacked-prs | When to split work into a stack of dependent PRs, how stacks line up with beads, and how the PR shortcuts change when a branch is part of a stack |
 | suggest-upstream-improvements | Review local doc-fork customizations and contribute the generally useful changes back upstream |
 | sync-failure-recovery | Handle tbd sync failures by saving to workspace and recovering later |
 | update-specs-status | Reconcile active specs, the top-level work index (e.g. TODO.md), and tbd beads into one current status map |

--- a/.claude/scripts/ensure-gh-cli.sh
+++ b/.claude/scripts/ensure-gh-cli.sh
@@ -8,6 +8,10 @@
 # that bypasses the cool-off window. To bump the pin, pick a release that is >=14
 # days old and copy its checksums from:
 #   https://github.com/cli/cli/releases/download/v<VERSION>/gh_<VERSION>_checksums.txt
+#
+# Presence is NOT sufficient: an already-installed gh is accepted only if it meets
+# GH_MIN_VERSION. A distro-packaged gh is routinely several minor versions behind,
+# which is exactly the case the pin exists to fix.
 
 set -euo pipefail
 
@@ -26,8 +30,31 @@ cleanup() {
 # Add common binary locations to PATH
 export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
 
+# Stacked-PR tooling is opt-in. SessionStart runs this script with no arguments, so the
+# default path stays exactly as fast and quiet as before for users who never stack.
+WITH_STACK=0
+for arg in "$@"; do
+    case "$arg" in
+        --with-stack) WITH_STACK=1 ;;
+        -h|--help)
+            echo "Usage: ensure-gh-cli.sh [--with-stack]"
+            echo "  --with-stack  Also install the pinned gh-stack extension and its agent skill"
+            exit 0
+            ;;
+        *) echo "[gh] WARNING: ignoring unknown argument: $arg" ;;
+    esac
+done
+
 # Pinned gh release (>=14 days old per supply-chain cool-off) and its checksums.
-GH_VERSION="2.92.0"
+GH_VERSION="2.97.0"
+
+# Minimum acceptable gh version; an older gh is replaced with the pinned build.
+# The floor tracks the pin because v2.97.0 fixed four advisories, two on paths agents
+# use constantly: `gh auth status` printed part of the token in plaintext for ghs_*,
+# github_pat_* and ghu_* formats (GHSA-cg6r-mpgc-h9mm), and `gh api` / `gh pr diff`
+# emitted externally controlled content without neutralizing terminal escape
+# sequences (GHSA-3m3g-3wcr-px46). It also carries the mature `gh skill` commands.
+GH_MIN_VERSION="2.97.0"
 
 # GitHub hosts to exempt from a session HTTPS proxy when that proxy intercepts
 # GitHub (proxied remote sessions, e.g. Claude Code cloud). Scoped and additive:
@@ -50,22 +77,65 @@ run_bounded() {
     fi
 }
 
-# SHA-256 checksums from gh_2.92.0_checksums.txt, keyed by asset suffix.
+# SHA-256 checksums from gh_2.97.0_checksums.txt, keyed by asset suffix.
 checksum_for() {
     case "$1" in
-        linux_amd64.tar.gz) echo "b57848131bdf0c229cd35e1f2a51aa718199858b2e728410b37e89a428943ec4" ;;
-        linux_arm64.tar.gz) echo "c2248526dd0160c08d3fccca2332c3c1a07c15a78b23978e77735f1b5a18cfee" ;;
-        macOS_amd64.zip)    echo "ae9bb327ab0d91071bdada79f8f14034a2a0f19b0e001835a782eafa519d2af0" ;;
-        macOS_arm64.zip)    echo "b11c54f6bd7d15ed6590475079e5b2fcf36f45d3991a80041b29c9d0cc1f1d07" ;;
+        linux_amd64.tar.gz) echo "a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112" ;;
+        linux_arm64.tar.gz) echo "73ea440ecad9c9e284429997ee6f93577bc6f7bc6fba357ef62c53ad8fb641a5" ;;
+        macOS_amd64.zip)    echo "63298c998cc2a924c9e254c6af6a1caad6ece281122687a91f079bc0a462700e" ;;
+        macOS_arm64.zip)    echo "a58b8fd77b417a38f47a0b54d1370c59b0fcdb324ccc9ca002b0998f7c4c999e" ;;
         *) echo "" ;;
     esac
 }
 
-# Check if gh is already installed
+# Compare dotted versions without sort -V (absent on stock macOS) or python.
+# Returns 0 when $1 >= $2. Any prerelease suffix is stripped before comparing, so
+# 2.97.0-rc1 compares equal to 2.97.0; gh ships no prereleases through this path.
+version_ge() {
+    local have="$1" want="$2" i have_part want_part
+    local -a have_parts want_parts
+    IFS='.' read -r -a have_parts <<< "${have%%-*}"
+    IFS='.' read -r -a want_parts <<< "${want%%-*}"
+    for i in 0 1 2; do
+        have_part=$(printf '%s' "${have_parts[i]:-0}" | tr -cd '0-9')
+        want_part=$(printf '%s' "${want_parts[i]:-0}" | tr -cd '0-9')
+        have_part=${have_part:-0}
+        want_part=${want_part:-0}
+        if [ "$((10#$have_part))" -gt "$((10#$want_part))" ]; then return 0; fi
+        if [ "$((10#$have_part))" -lt "$((10#$want_part))" ]; then return 1; fi
+    done
+    return 0
+}
+
+# `gh --version` prints "gh version 2.97.0 (2026-07-31)" on its first line.
+installed_gh_version() {
+    "$1" --version 2>/dev/null | awk 'NR==1 {print $3}'
+}
+
+# Decide whether to install. Presence alone is not enough: a distro-packaged gh is
+# routinely several minor versions behind, and accepting it silently is how the pin
+# fails to apply on exactly the machines that need it.
+NEED_INSTALL=0
 if command -v gh &> /dev/null; then
-    echo "[gh] CLI found at $(which gh)"
+    GH_PATH="$(command -v gh)"
+    GH_CURRENT="$(installed_gh_version "$GH_PATH")"
+    if [ -z "$GH_CURRENT" ]; then
+        echo "[gh] CLI at ${GH_PATH} does not report a usable version; installing pinned v${GH_VERSION}"
+        NEED_INSTALL=1
+    elif version_ge "$GH_CURRENT" "$GH_MIN_VERSION"; then
+        # Newer than the pin is fine and is left alone; this must never downgrade.
+        echo "[gh] CLI found at ${GH_PATH} (v${GH_CURRENT})"
+    else
+        echo "[gh] CLI at ${GH_PATH} is v${GH_CURRENT}, below the required v${GH_MIN_VERSION}"
+        echo "[gh] Installing pinned v${GH_VERSION} to ~/.local/bin (existing gh left in place)"
+        NEED_INSTALL=1
+    fi
 else
     echo "[gh] CLI not found, installing pinned v${GH_VERSION}..."
+    NEED_INSTALL=1
+fi
+
+if [ "$NEED_INSTALL" = "1" ]; then
 
     INSTALL_TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/tbd-gh.XXXXXX")
     trap cleanup EXIT
@@ -142,11 +212,25 @@ else
     echo "[gh] Installed to $HOME/.local/bin/gh"
 fi
 
-# Verify gh is now in PATH
+# Verify gh is now in PATH. Clear bash's command lookup cache first, otherwise a
+# freshly installed binary can be masked by the path resolved earlier in this shell.
+hash -r 2>/dev/null || true
 if ! command -v gh &> /dev/null; then
     echo "[gh] ERROR: gh CLI still not found in PATH after installation"
     echo "[gh] Ensure ~/.local/bin is in your PATH"
     exit 1
+fi
+
+# Confirm the gh that PATH actually resolves meets the floor. An older gh earlier in
+# PATH would otherwise shadow the pinned build we just installed.
+GH_RESOLVED="$(command -v gh)"
+GH_RESOLVED_VERSION="$(installed_gh_version "$GH_RESOLVED")"
+if [ -n "$GH_RESOLVED_VERSION" ] && ! version_ge "$GH_RESOLVED_VERSION" "$GH_MIN_VERSION"; then
+    echo "[gh] WARNING: PATH resolves gh to ${GH_RESOLVED} (v${GH_RESOLVED_VERSION}),"
+    echo "[gh] which is below the required v${GH_MIN_VERSION}. The pinned build is at"
+    echo "[gh] $HOME/.local/bin/gh — put ~/.local/bin ahead of ${GH_RESOLVED%/gh} in PATH."
+    echo "[gh] Older gh versions leak part of the auth token via 'gh auth status' and do"
+    echo "[gh] not neutralize terminal escape sequences in 'gh api'/'gh pr diff' output."
 fi
 
 # Check authentication status
@@ -193,9 +277,56 @@ if [ -n "${GH_TOKEN:-}" ]; then
             echo "[gh] Diagnosis: tbd shortcut setup-github-cli (Proxied Remote Sessions)"
         fi
     fi
+elif gh auth status &> /dev/null; then
+    # No GH_TOKEN, but gh is authenticated another way (keyring after `gh auth login`,
+    # or a host config). That is a fully working setup; saying "not set" here reads as a
+    # problem on a healthy machine, so report what is actually true.
+    echo "[gh] Authenticated (no GH_TOKEN; using stored gh credentials)"
 else
-    echo "[gh] NOTE: GH_TOKEN not set - some operations may require authentication"
+    echo "[gh] NOTE: GH_TOKEN not set and no stored gh credentials found"
+    echo "[gh] Run 'gh auth login', or set GH_TOKEN before starting the session."
     echo "[gh] See: tbd shortcut setup-github-cli"
+fi
+
+# Optional stacked-PR tooling (opt-in via --with-stack).
+#
+# Pinned per SUPPLY-CHAIN-SECURITY.md: gh-stack v0.1.0 was published 2026-07-29 and
+# clears the 14-day cool-off. Both `gh extension install` and `gh skill install` accept
+# --pin, so neither resolves "latest" at run time.
+#
+# Nothing here is fatal. Stacked PRs are one workflow among several, and a network
+# failure while fetching an optional extension must never block a session.
+GH_STACK_REPO="github/gh-stack"
+GH_STACK_VERSION="v0.1.0"
+GH_SKILL_AGENT="${GH_SKILL_AGENT:-claude-code}"
+
+if [ "$WITH_STACK" = "1" ]; then
+    if gh extension list 2>/dev/null | grep -q "gh stack"; then
+        echo "[gh] gh-stack extension already installed"
+    elif gh extension install "$GH_STACK_REPO" --pin "$GH_STACK_VERSION" 2>&1 | sed 's/^/[gh]   /'; then
+        echo "[gh] Installed ${GH_STACK_REPO} extension (pinned ${GH_STACK_VERSION})"
+    else
+        echo "[gh] WARNING: could not install the ${GH_STACK_REPO} extension"
+        echo "[gh] Stacked-PR commands will be unavailable; everything else still works."
+    fi
+
+    # The official agent skill teaches an agent to drive `gh stack` non-interactively,
+    # which matters because several subcommands open a blocking TUI under a PTY.
+    #
+    # User scope on purpose, for consistency: `gh extension install` above is already
+    # machine-global, so a per-repo skill would be incoherent with it, and project scope
+    # would write skill files into the user's repo. The opt-in gate is --with-stack, not
+    # the scope. Note `gh skill` has no uninstall command: removal means deleting the
+    # installed directory (see `gh skill list` for its location).
+    if gh skill list 2>/dev/null | grep -q "gh-stack"; then
+        echo "[gh] gh-stack agent skill already installed"
+    elif gh skill install "$GH_STACK_REPO" --pin "$GH_STACK_VERSION" \
+            --agent "$GH_SKILL_AGENT" --scope user --force 2>&1 | sed 's/^/[gh]   /'; then
+        echo "[gh] Installed the gh-stack agent skill (${GH_SKILL_AGENT}, user scope)"
+    else
+        echo "[gh] WARNING: could not install the gh-stack agent skill"
+        echo "[gh] The extension may still work; see: tbd shortcut stacked-prs"
+    fi
 fi
 
 exit 0

--- a/.claude/scripts/ensure-gh-cli.sh
+++ b/.claude/scripts/ensure-gh-cli.sh
@@ -298,7 +298,21 @@ fi
 # failure while fetching an optional extension must never block a session.
 GH_STACK_REPO="github/gh-stack"
 GH_STACK_VERSION="v0.1.0"
+
+# The skill is pinned by commit SHA rather than the tag. A tag can be moved, and a skill
+# is not inert data: it is instructions loaded into every later agent session on this
+# machine, so it deserves the stricter pin. This is the commit v0.1.0 points at, which
+# `gh skill install` also prints when it resolves the tag.
+GH_STACK_SKILL_SHA="a1b4a3d4d0bcde9ec3a78ab99b2d63af121857a9"
 GH_SKILL_AGENT="${GH_SKILL_AGENT:-claude-code}"
+
+# Is the gh-stack skill present for this agent? Used both as the pre-check and as the
+# post-install verification, because `gh skill install` exit status cannot be trusted
+# (see below).
+gh_stack_skill_present() {
+    gh skill list --agent "$GH_SKILL_AGENT" --json skillName -q '.[].skillName' 2>/dev/null \
+        | grep -qx 'gh-stack'
+}
 
 if [ "$WITH_STACK" = "1" ]; then
     if gh extension list 2>/dev/null | grep -q "gh stack"; then
@@ -318,14 +332,25 @@ if [ "$WITH_STACK" = "1" ]; then
     # would write skill files into the user's repo. The opt-in gate is --with-stack, not
     # the scope. Note `gh skill` has no uninstall command: removal means deleting the
     # installed directory (see `gh skill list` for its location).
-    if gh skill list 2>/dev/null | grep -q "gh-stack"; then
+    #
+    # The skill NAME is required. Given only a repository, `gh skill install` prints the
+    # skills it found, installs nothing, and still exits 0, so a bare repo argument
+    # silently does nothing while looking like success. Verify the result rather than
+    # trusting the exit status.
+    if gh_stack_skill_present; then
         echo "[gh] gh-stack agent skill already installed"
-    elif gh skill install "$GH_STACK_REPO" --pin "$GH_STACK_VERSION" \
-            --agent "$GH_SKILL_AGENT" --scope user --force 2>&1 | sed 's/^/[gh]   /'; then
-        echo "[gh] Installed the gh-stack agent skill (${GH_SKILL_AGENT}, user scope)"
     else
-        echo "[gh] WARNING: could not install the gh-stack agent skill"
-        echo "[gh] The extension may still work; see: tbd shortcut stacked-prs"
+        gh skill install "$GH_STACK_REPO" gh-stack --pin "$GH_STACK_SKILL_SHA" \
+            --agent "$GH_SKILL_AGENT" --scope user --force 2>&1 | sed 's/^/[gh]   /' || true
+        if gh_stack_skill_present; then
+            echo "[gh] Installed the gh-stack agent skill (${GH_SKILL_AGENT}, user scope)"
+            echo "[gh] GitHub does not verify skills, and a skill is instructions that load"
+            echo "[gh] into later sessions. Review it before relying on it:"
+            echo "[gh]   gh skill preview ${GH_STACK_REPO} gh-stack@${GH_STACK_SKILL_SHA}"
+        else
+            echo "[gh] WARNING: the gh-stack agent skill did not install"
+            echo "[gh] The extension may still work; see: tbd shortcut stacked-prs"
+        fi
     fi
 fi
 

--- a/.claude/skills/tbd/SKILL.md
+++ b/.claude/skills/tbd/SKILL.md
@@ -370,6 +370,7 @@ Run `tbd shortcut <name>` to use any of these shortcuts:
 | revise-architecture-doc | Update an architecture document to reflect current codebase state |
 | setup-github-cli | Ensure GitHub CLI (gh) is installed and working |
 | setup-linear | Set up the Linear integration end to end—first-time configuration for a repository, or adding your own API key to a repository your team already configured |
+| stacked-prs | When to split work into a stack of dependent PRs, how stacks line up with beads, and how the PR shortcuts change when a branch is part of a stack |
 | suggest-upstream-improvements | Review local doc-fork customizations and contribute the generally useful changes back upstream |
 | sync-failure-recovery | Handle tbd sync failures by saving to workspace and recovering later |
 | update-specs-status | Reconcile active specs, the top-level work index (e.g. TODO.md), and tbd beads into one current status map |

--- a/.codex/ensure-gh-cli.sh
+++ b/.codex/ensure-gh-cli.sh
@@ -8,6 +8,10 @@
 # that bypasses the cool-off window. To bump the pin, pick a release that is >=14
 # days old and copy its checksums from:
 #   https://github.com/cli/cli/releases/download/v<VERSION>/gh_<VERSION>_checksums.txt
+#
+# Presence is NOT sufficient: an already-installed gh is accepted only if it meets
+# GH_MIN_VERSION. A distro-packaged gh is routinely several minor versions behind,
+# which is exactly the case the pin exists to fix.
 
 set -euo pipefail
 
@@ -26,8 +30,31 @@ cleanup() {
 # Add common binary locations to PATH
 export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
 
+# Stacked-PR tooling is opt-in. SessionStart runs this script with no arguments, so the
+# default path stays exactly as fast and quiet as before for users who never stack.
+WITH_STACK=0
+for arg in "$@"; do
+    case "$arg" in
+        --with-stack) WITH_STACK=1 ;;
+        -h|--help)
+            echo "Usage: ensure-gh-cli.sh [--with-stack]"
+            echo "  --with-stack  Also install the pinned gh-stack extension and its agent skill"
+            exit 0
+            ;;
+        *) echo "[gh] WARNING: ignoring unknown argument: $arg" ;;
+    esac
+done
+
 # Pinned gh release (>=14 days old per supply-chain cool-off) and its checksums.
-GH_VERSION="2.92.0"
+GH_VERSION="2.97.0"
+
+# Minimum acceptable gh version; an older gh is replaced with the pinned build.
+# The floor tracks the pin because v2.97.0 fixed four advisories, two on paths agents
+# use constantly: `gh auth status` printed part of the token in plaintext for ghs_*,
+# github_pat_* and ghu_* formats (GHSA-cg6r-mpgc-h9mm), and `gh api` / `gh pr diff`
+# emitted externally controlled content without neutralizing terminal escape
+# sequences (GHSA-3m3g-3wcr-px46). It also carries the mature `gh skill` commands.
+GH_MIN_VERSION="2.97.0"
 
 # GitHub hosts to exempt from a session HTTPS proxy when that proxy intercepts
 # GitHub (proxied remote sessions, e.g. Claude Code cloud). Scoped and additive:
@@ -50,22 +77,65 @@ run_bounded() {
     fi
 }
 
-# SHA-256 checksums from gh_2.92.0_checksums.txt, keyed by asset suffix.
+# SHA-256 checksums from gh_2.97.0_checksums.txt, keyed by asset suffix.
 checksum_for() {
     case "$1" in
-        linux_amd64.tar.gz) echo "b57848131bdf0c229cd35e1f2a51aa718199858b2e728410b37e89a428943ec4" ;;
-        linux_arm64.tar.gz) echo "c2248526dd0160c08d3fccca2332c3c1a07c15a78b23978e77735f1b5a18cfee" ;;
-        macOS_amd64.zip)    echo "ae9bb327ab0d91071bdada79f8f14034a2a0f19b0e001835a782eafa519d2af0" ;;
-        macOS_arm64.zip)    echo "b11c54f6bd7d15ed6590475079e5b2fcf36f45d3991a80041b29c9d0cc1f1d07" ;;
+        linux_amd64.tar.gz) echo "a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112" ;;
+        linux_arm64.tar.gz) echo "73ea440ecad9c9e284429997ee6f93577bc6f7bc6fba357ef62c53ad8fb641a5" ;;
+        macOS_amd64.zip)    echo "63298c998cc2a924c9e254c6af6a1caad6ece281122687a91f079bc0a462700e" ;;
+        macOS_arm64.zip)    echo "a58b8fd77b417a38f47a0b54d1370c59b0fcdb324ccc9ca002b0998f7c4c999e" ;;
         *) echo "" ;;
     esac
 }
 
-# Check if gh is already installed
+# Compare dotted versions without sort -V (absent on stock macOS) or python.
+# Returns 0 when $1 >= $2. Any prerelease suffix is stripped before comparing, so
+# 2.97.0-rc1 compares equal to 2.97.0; gh ships no prereleases through this path.
+version_ge() {
+    local have="$1" want="$2" i have_part want_part
+    local -a have_parts want_parts
+    IFS='.' read -r -a have_parts <<< "${have%%-*}"
+    IFS='.' read -r -a want_parts <<< "${want%%-*}"
+    for i in 0 1 2; do
+        have_part=$(printf '%s' "${have_parts[i]:-0}" | tr -cd '0-9')
+        want_part=$(printf '%s' "${want_parts[i]:-0}" | tr -cd '0-9')
+        have_part=${have_part:-0}
+        want_part=${want_part:-0}
+        if [ "$((10#$have_part))" -gt "$((10#$want_part))" ]; then return 0; fi
+        if [ "$((10#$have_part))" -lt "$((10#$want_part))" ]; then return 1; fi
+    done
+    return 0
+}
+
+# `gh --version` prints "gh version 2.97.0 (2026-07-31)" on its first line.
+installed_gh_version() {
+    "$1" --version 2>/dev/null | awk 'NR==1 {print $3}'
+}
+
+# Decide whether to install. Presence alone is not enough: a distro-packaged gh is
+# routinely several minor versions behind, and accepting it silently is how the pin
+# fails to apply on exactly the machines that need it.
+NEED_INSTALL=0
 if command -v gh &> /dev/null; then
-    echo "[gh] CLI found at $(which gh)"
+    GH_PATH="$(command -v gh)"
+    GH_CURRENT="$(installed_gh_version "$GH_PATH")"
+    if [ -z "$GH_CURRENT" ]; then
+        echo "[gh] CLI at ${GH_PATH} does not report a usable version; installing pinned v${GH_VERSION}"
+        NEED_INSTALL=1
+    elif version_ge "$GH_CURRENT" "$GH_MIN_VERSION"; then
+        # Newer than the pin is fine and is left alone; this must never downgrade.
+        echo "[gh] CLI found at ${GH_PATH} (v${GH_CURRENT})"
+    else
+        echo "[gh] CLI at ${GH_PATH} is v${GH_CURRENT}, below the required v${GH_MIN_VERSION}"
+        echo "[gh] Installing pinned v${GH_VERSION} to ~/.local/bin (existing gh left in place)"
+        NEED_INSTALL=1
+    fi
 else
     echo "[gh] CLI not found, installing pinned v${GH_VERSION}..."
+    NEED_INSTALL=1
+fi
+
+if [ "$NEED_INSTALL" = "1" ]; then
 
     INSTALL_TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/tbd-gh.XXXXXX")
     trap cleanup EXIT
@@ -142,11 +212,25 @@ else
     echo "[gh] Installed to $HOME/.local/bin/gh"
 fi
 
-# Verify gh is now in PATH
+# Verify gh is now in PATH. Clear bash's command lookup cache first, otherwise a
+# freshly installed binary can be masked by the path resolved earlier in this shell.
+hash -r 2>/dev/null || true
 if ! command -v gh &> /dev/null; then
     echo "[gh] ERROR: gh CLI still not found in PATH after installation"
     echo "[gh] Ensure ~/.local/bin is in your PATH"
     exit 1
+fi
+
+# Confirm the gh that PATH actually resolves meets the floor. An older gh earlier in
+# PATH would otherwise shadow the pinned build we just installed.
+GH_RESOLVED="$(command -v gh)"
+GH_RESOLVED_VERSION="$(installed_gh_version "$GH_RESOLVED")"
+if [ -n "$GH_RESOLVED_VERSION" ] && ! version_ge "$GH_RESOLVED_VERSION" "$GH_MIN_VERSION"; then
+    echo "[gh] WARNING: PATH resolves gh to ${GH_RESOLVED} (v${GH_RESOLVED_VERSION}),"
+    echo "[gh] which is below the required v${GH_MIN_VERSION}. The pinned build is at"
+    echo "[gh] $HOME/.local/bin/gh — put ~/.local/bin ahead of ${GH_RESOLVED%/gh} in PATH."
+    echo "[gh] Older gh versions leak part of the auth token via 'gh auth status' and do"
+    echo "[gh] not neutralize terminal escape sequences in 'gh api'/'gh pr diff' output."
 fi
 
 # Check authentication status
@@ -193,9 +277,56 @@ if [ -n "${GH_TOKEN:-}" ]; then
             echo "[gh] Diagnosis: tbd shortcut setup-github-cli (Proxied Remote Sessions)"
         fi
     fi
+elif gh auth status &> /dev/null; then
+    # No GH_TOKEN, but gh is authenticated another way (keyring after `gh auth login`,
+    # or a host config). That is a fully working setup; saying "not set" here reads as a
+    # problem on a healthy machine, so report what is actually true.
+    echo "[gh] Authenticated (no GH_TOKEN; using stored gh credentials)"
 else
-    echo "[gh] NOTE: GH_TOKEN not set - some operations may require authentication"
+    echo "[gh] NOTE: GH_TOKEN not set and no stored gh credentials found"
+    echo "[gh] Run 'gh auth login', or set GH_TOKEN before starting the session."
     echo "[gh] See: tbd shortcut setup-github-cli"
+fi
+
+# Optional stacked-PR tooling (opt-in via --with-stack).
+#
+# Pinned per SUPPLY-CHAIN-SECURITY.md: gh-stack v0.1.0 was published 2026-07-29 and
+# clears the 14-day cool-off. Both `gh extension install` and `gh skill install` accept
+# --pin, so neither resolves "latest" at run time.
+#
+# Nothing here is fatal. Stacked PRs are one workflow among several, and a network
+# failure while fetching an optional extension must never block a session.
+GH_STACK_REPO="github/gh-stack"
+GH_STACK_VERSION="v0.1.0"
+GH_SKILL_AGENT="${GH_SKILL_AGENT:-claude-code}"
+
+if [ "$WITH_STACK" = "1" ]; then
+    if gh extension list 2>/dev/null | grep -q "gh stack"; then
+        echo "[gh] gh-stack extension already installed"
+    elif gh extension install "$GH_STACK_REPO" --pin "$GH_STACK_VERSION" 2>&1 | sed 's/^/[gh]   /'; then
+        echo "[gh] Installed ${GH_STACK_REPO} extension (pinned ${GH_STACK_VERSION})"
+    else
+        echo "[gh] WARNING: could not install the ${GH_STACK_REPO} extension"
+        echo "[gh] Stacked-PR commands will be unavailable; everything else still works."
+    fi
+
+    # The official agent skill teaches an agent to drive `gh stack` non-interactively,
+    # which matters because several subcommands open a blocking TUI under a PTY.
+    #
+    # User scope on purpose, for consistency: `gh extension install` above is already
+    # machine-global, so a per-repo skill would be incoherent with it, and project scope
+    # would write skill files into the user's repo. The opt-in gate is --with-stack, not
+    # the scope. Note `gh skill` has no uninstall command: removal means deleting the
+    # installed directory (see `gh skill list` for its location).
+    if gh skill list 2>/dev/null | grep -q "gh-stack"; then
+        echo "[gh] gh-stack agent skill already installed"
+    elif gh skill install "$GH_STACK_REPO" --pin "$GH_STACK_VERSION" \
+            --agent "$GH_SKILL_AGENT" --scope user --force 2>&1 | sed 's/^/[gh]   /'; then
+        echo "[gh] Installed the gh-stack agent skill (${GH_SKILL_AGENT}, user scope)"
+    else
+        echo "[gh] WARNING: could not install the gh-stack agent skill"
+        echo "[gh] The extension may still work; see: tbd shortcut stacked-prs"
+    fi
 fi
 
 exit 0

--- a/.codex/ensure-gh-cli.sh
+++ b/.codex/ensure-gh-cli.sh
@@ -298,7 +298,21 @@ fi
 # failure while fetching an optional extension must never block a session.
 GH_STACK_REPO="github/gh-stack"
 GH_STACK_VERSION="v0.1.0"
+
+# The skill is pinned by commit SHA rather than the tag. A tag can be moved, and a skill
+# is not inert data: it is instructions loaded into every later agent session on this
+# machine, so it deserves the stricter pin. This is the commit v0.1.0 points at, which
+# `gh skill install` also prints when it resolves the tag.
+GH_STACK_SKILL_SHA="a1b4a3d4d0bcde9ec3a78ab99b2d63af121857a9"
 GH_SKILL_AGENT="${GH_SKILL_AGENT:-claude-code}"
+
+# Is the gh-stack skill present for this agent? Used both as the pre-check and as the
+# post-install verification, because `gh skill install` exit status cannot be trusted
+# (see below).
+gh_stack_skill_present() {
+    gh skill list --agent "$GH_SKILL_AGENT" --json skillName -q '.[].skillName' 2>/dev/null \
+        | grep -qx 'gh-stack'
+}
 
 if [ "$WITH_STACK" = "1" ]; then
     if gh extension list 2>/dev/null | grep -q "gh stack"; then
@@ -318,14 +332,25 @@ if [ "$WITH_STACK" = "1" ]; then
     # would write skill files into the user's repo. The opt-in gate is --with-stack, not
     # the scope. Note `gh skill` has no uninstall command: removal means deleting the
     # installed directory (see `gh skill list` for its location).
-    if gh skill list 2>/dev/null | grep -q "gh-stack"; then
+    #
+    # The skill NAME is required. Given only a repository, `gh skill install` prints the
+    # skills it found, installs nothing, and still exits 0, so a bare repo argument
+    # silently does nothing while looking like success. Verify the result rather than
+    # trusting the exit status.
+    if gh_stack_skill_present; then
         echo "[gh] gh-stack agent skill already installed"
-    elif gh skill install "$GH_STACK_REPO" --pin "$GH_STACK_VERSION" \
-            --agent "$GH_SKILL_AGENT" --scope user --force 2>&1 | sed 's/^/[gh]   /'; then
-        echo "[gh] Installed the gh-stack agent skill (${GH_SKILL_AGENT}, user scope)"
     else
-        echo "[gh] WARNING: could not install the gh-stack agent skill"
-        echo "[gh] The extension may still work; see: tbd shortcut stacked-prs"
+        gh skill install "$GH_STACK_REPO" gh-stack --pin "$GH_STACK_SKILL_SHA" \
+            --agent "$GH_SKILL_AGENT" --scope user --force 2>&1 | sed 's/^/[gh]   /' || true
+        if gh_stack_skill_present; then
+            echo "[gh] Installed the gh-stack agent skill (${GH_SKILL_AGENT}, user scope)"
+            echo "[gh] GitHub does not verify skills, and a skill is instructions that load"
+            echo "[gh] into later sessions. Review it before relying on it:"
+            echo "[gh]   gh skill preview ${GH_STACK_REPO} gh-stack@${GH_STACK_SKILL_SHA}"
+        else
+            echo "[gh] WARNING: the gh-stack agent skill did not install"
+            echo "[gh] The extension may still work; see: tbd shortcut stacked-prs"
+        fi
     fi
 fi
 

--- a/.tbd/config.yml
+++ b/.tbd/config.yml
@@ -99,6 +99,7 @@ docs_cache:
     shortcuts/standard/revise-architecture-doc.md: internal:shortcuts/standard/revise-architecture-doc.md
     shortcuts/standard/setup-github-cli.md: internal:shortcuts/standard/setup-github-cli.md
     shortcuts/standard/setup-linear.md: internal:shortcuts/standard/setup-linear.md
+    shortcuts/standard/stacked-prs.md: internal:shortcuts/standard/stacked-prs.md
     shortcuts/standard/suggest-upstream-improvements.md: internal:shortcuts/standard/suggest-upstream-improvements.md
     shortcuts/standard/sync-failure-recovery.md: internal:shortcuts/standard/sync-failure-recovery.md
     shortcuts/standard/update-specs-status.md: internal:shortcuts/standard/update-specs-status.md

--- a/README.md
+++ b/README.md
@@ -626,6 +626,7 @@ tbd docs fork --all              # Or fork by name: tbd docs fork <name> [<name>
 |  | `create-or-update-pr-simple` | Basic PR creation |
 |  | `create-or-update-pr-with-validation-plan` | PR with a validation plan |
 |  | `merge-upstream` | Merge origin/main with conflict resolution |
+|  | `stacked-prs` | When to split work into a stack of dependent PRs, and how stacks change the PR shortcuts |
 | **Cleanup** | `code-cleanup-all` | Full code cleanup (duplicates, dead code, quality) |
 |  | `code-cleanup-tests` | Remove trivial/low-value tests |
 |  | `code-cleanup-docstrings` | Add docstrings to major functions |

--- a/packages/tbd/docs/install/ensure-gh-cli.sh
+++ b/packages/tbd/docs/install/ensure-gh-cli.sh
@@ -8,6 +8,10 @@
 # that bypasses the cool-off window. To bump the pin, pick a release that is >=14
 # days old and copy its checksums from:
 #   https://github.com/cli/cli/releases/download/v<VERSION>/gh_<VERSION>_checksums.txt
+#
+# Presence is NOT sufficient: an already-installed gh is accepted only if it meets
+# GH_MIN_VERSION. A distro-packaged gh is routinely several minor versions behind,
+# which is exactly the case the pin exists to fix.
 
 set -euo pipefail
 
@@ -26,8 +30,31 @@ cleanup() {
 # Add common binary locations to PATH
 export PATH="$HOME/.local/bin:$HOME/bin:/usr/local/bin:$PATH"
 
+# Stacked-PR tooling is opt-in. SessionStart runs this script with no arguments, so the
+# default path stays exactly as fast and quiet as before for users who never stack.
+WITH_STACK=0
+for arg in "$@"; do
+    case "$arg" in
+        --with-stack) WITH_STACK=1 ;;
+        -h|--help)
+            echo "Usage: ensure-gh-cli.sh [--with-stack]"
+            echo "  --with-stack  Also install the pinned gh-stack extension and its agent skill"
+            exit 0
+            ;;
+        *) echo "[gh] WARNING: ignoring unknown argument: $arg" ;;
+    esac
+done
+
 # Pinned gh release (>=14 days old per supply-chain cool-off) and its checksums.
-GH_VERSION="2.92.0"
+GH_VERSION="2.97.0"
+
+# Minimum acceptable gh version; an older gh is replaced with the pinned build.
+# The floor tracks the pin because v2.97.0 fixed four advisories, two on paths agents
+# use constantly: `gh auth status` printed part of the token in plaintext for ghs_*,
+# github_pat_* and ghu_* formats (GHSA-cg6r-mpgc-h9mm), and `gh api` / `gh pr diff`
+# emitted externally controlled content without neutralizing terminal escape
+# sequences (GHSA-3m3g-3wcr-px46). It also carries the mature `gh skill` commands.
+GH_MIN_VERSION="2.97.0"
 
 # GitHub hosts to exempt from a session HTTPS proxy when that proxy intercepts
 # GitHub (proxied remote sessions, e.g. Claude Code cloud). Scoped and additive:
@@ -50,22 +77,65 @@ run_bounded() {
     fi
 }
 
-# SHA-256 checksums from gh_2.92.0_checksums.txt, keyed by asset suffix.
+# SHA-256 checksums from gh_2.97.0_checksums.txt, keyed by asset suffix.
 checksum_for() {
     case "$1" in
-        linux_amd64.tar.gz) echo "b57848131bdf0c229cd35e1f2a51aa718199858b2e728410b37e89a428943ec4" ;;
-        linux_arm64.tar.gz) echo "c2248526dd0160c08d3fccca2332c3c1a07c15a78b23978e77735f1b5a18cfee" ;;
-        macOS_amd64.zip)    echo "ae9bb327ab0d91071bdada79f8f14034a2a0f19b0e001835a782eafa519d2af0" ;;
-        macOS_arm64.zip)    echo "b11c54f6bd7d15ed6590475079e5b2fcf36f45d3991a80041b29c9d0cc1f1d07" ;;
+        linux_amd64.tar.gz) echo "a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112" ;;
+        linux_arm64.tar.gz) echo "73ea440ecad9c9e284429997ee6f93577bc6f7bc6fba357ef62c53ad8fb641a5" ;;
+        macOS_amd64.zip)    echo "63298c998cc2a924c9e254c6af6a1caad6ece281122687a91f079bc0a462700e" ;;
+        macOS_arm64.zip)    echo "a58b8fd77b417a38f47a0b54d1370c59b0fcdb324ccc9ca002b0998f7c4c999e" ;;
         *) echo "" ;;
     esac
 }
 
-# Check if gh is already installed
+# Compare dotted versions without sort -V (absent on stock macOS) or python.
+# Returns 0 when $1 >= $2. Any prerelease suffix is stripped before comparing, so
+# 2.97.0-rc1 compares equal to 2.97.0; gh ships no prereleases through this path.
+version_ge() {
+    local have="$1" want="$2" i have_part want_part
+    local -a have_parts want_parts
+    IFS='.' read -r -a have_parts <<< "${have%%-*}"
+    IFS='.' read -r -a want_parts <<< "${want%%-*}"
+    for i in 0 1 2; do
+        have_part=$(printf '%s' "${have_parts[i]:-0}" | tr -cd '0-9')
+        want_part=$(printf '%s' "${want_parts[i]:-0}" | tr -cd '0-9')
+        have_part=${have_part:-0}
+        want_part=${want_part:-0}
+        if [ "$((10#$have_part))" -gt "$((10#$want_part))" ]; then return 0; fi
+        if [ "$((10#$have_part))" -lt "$((10#$want_part))" ]; then return 1; fi
+    done
+    return 0
+}
+
+# `gh --version` prints "gh version 2.97.0 (2026-07-31)" on its first line.
+installed_gh_version() {
+    "$1" --version 2>/dev/null | awk 'NR==1 {print $3}'
+}
+
+# Decide whether to install. Presence alone is not enough: a distro-packaged gh is
+# routinely several minor versions behind, and accepting it silently is how the pin
+# fails to apply on exactly the machines that need it.
+NEED_INSTALL=0
 if command -v gh &> /dev/null; then
-    echo "[gh] CLI found at $(which gh)"
+    GH_PATH="$(command -v gh)"
+    GH_CURRENT="$(installed_gh_version "$GH_PATH")"
+    if [ -z "$GH_CURRENT" ]; then
+        echo "[gh] CLI at ${GH_PATH} does not report a usable version; installing pinned v${GH_VERSION}"
+        NEED_INSTALL=1
+    elif version_ge "$GH_CURRENT" "$GH_MIN_VERSION"; then
+        # Newer than the pin is fine and is left alone; this must never downgrade.
+        echo "[gh] CLI found at ${GH_PATH} (v${GH_CURRENT})"
+    else
+        echo "[gh] CLI at ${GH_PATH} is v${GH_CURRENT}, below the required v${GH_MIN_VERSION}"
+        echo "[gh] Installing pinned v${GH_VERSION} to ~/.local/bin (existing gh left in place)"
+        NEED_INSTALL=1
+    fi
 else
     echo "[gh] CLI not found, installing pinned v${GH_VERSION}..."
+    NEED_INSTALL=1
+fi
+
+if [ "$NEED_INSTALL" = "1" ]; then
 
     INSTALL_TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/tbd-gh.XXXXXX")
     trap cleanup EXIT
@@ -142,11 +212,25 @@ else
     echo "[gh] Installed to $HOME/.local/bin/gh"
 fi
 
-# Verify gh is now in PATH
+# Verify gh is now in PATH. Clear bash's command lookup cache first, otherwise a
+# freshly installed binary can be masked by the path resolved earlier in this shell.
+hash -r 2>/dev/null || true
 if ! command -v gh &> /dev/null; then
     echo "[gh] ERROR: gh CLI still not found in PATH after installation"
     echo "[gh] Ensure ~/.local/bin is in your PATH"
     exit 1
+fi
+
+# Confirm the gh that PATH actually resolves meets the floor. An older gh earlier in
+# PATH would otherwise shadow the pinned build we just installed.
+GH_RESOLVED="$(command -v gh)"
+GH_RESOLVED_VERSION="$(installed_gh_version "$GH_RESOLVED")"
+if [ -n "$GH_RESOLVED_VERSION" ] && ! version_ge "$GH_RESOLVED_VERSION" "$GH_MIN_VERSION"; then
+    echo "[gh] WARNING: PATH resolves gh to ${GH_RESOLVED} (v${GH_RESOLVED_VERSION}),"
+    echo "[gh] which is below the required v${GH_MIN_VERSION}. The pinned build is at"
+    echo "[gh] $HOME/.local/bin/gh — put ~/.local/bin ahead of ${GH_RESOLVED%/gh} in PATH."
+    echo "[gh] Older gh versions leak part of the auth token via 'gh auth status' and do"
+    echo "[gh] not neutralize terminal escape sequences in 'gh api'/'gh pr diff' output."
 fi
 
 # Check authentication status
@@ -193,9 +277,56 @@ if [ -n "${GH_TOKEN:-}" ]; then
             echo "[gh] Diagnosis: tbd shortcut setup-github-cli (Proxied Remote Sessions)"
         fi
     fi
+elif gh auth status &> /dev/null; then
+    # No GH_TOKEN, but gh is authenticated another way (keyring after `gh auth login`,
+    # or a host config). That is a fully working setup; saying "not set" here reads as a
+    # problem on a healthy machine, so report what is actually true.
+    echo "[gh] Authenticated (no GH_TOKEN; using stored gh credentials)"
 else
-    echo "[gh] NOTE: GH_TOKEN not set - some operations may require authentication"
+    echo "[gh] NOTE: GH_TOKEN not set and no stored gh credentials found"
+    echo "[gh] Run 'gh auth login', or set GH_TOKEN before starting the session."
     echo "[gh] See: tbd shortcut setup-github-cli"
+fi
+
+# Optional stacked-PR tooling (opt-in via --with-stack).
+#
+# Pinned per SUPPLY-CHAIN-SECURITY.md: gh-stack v0.1.0 was published 2026-07-29 and
+# clears the 14-day cool-off. Both `gh extension install` and `gh skill install` accept
+# --pin, so neither resolves "latest" at run time.
+#
+# Nothing here is fatal. Stacked PRs are one workflow among several, and a network
+# failure while fetching an optional extension must never block a session.
+GH_STACK_REPO="github/gh-stack"
+GH_STACK_VERSION="v0.1.0"
+GH_SKILL_AGENT="${GH_SKILL_AGENT:-claude-code}"
+
+if [ "$WITH_STACK" = "1" ]; then
+    if gh extension list 2>/dev/null | grep -q "gh stack"; then
+        echo "[gh] gh-stack extension already installed"
+    elif gh extension install "$GH_STACK_REPO" --pin "$GH_STACK_VERSION" 2>&1 | sed 's/^/[gh]   /'; then
+        echo "[gh] Installed ${GH_STACK_REPO} extension (pinned ${GH_STACK_VERSION})"
+    else
+        echo "[gh] WARNING: could not install the ${GH_STACK_REPO} extension"
+        echo "[gh] Stacked-PR commands will be unavailable; everything else still works."
+    fi
+
+    # The official agent skill teaches an agent to drive `gh stack` non-interactively,
+    # which matters because several subcommands open a blocking TUI under a PTY.
+    #
+    # User scope on purpose, for consistency: `gh extension install` above is already
+    # machine-global, so a per-repo skill would be incoherent with it, and project scope
+    # would write skill files into the user's repo. The opt-in gate is --with-stack, not
+    # the scope. Note `gh skill` has no uninstall command: removal means deleting the
+    # installed directory (see `gh skill list` for its location).
+    if gh skill list 2>/dev/null | grep -q "gh-stack"; then
+        echo "[gh] gh-stack agent skill already installed"
+    elif gh skill install "$GH_STACK_REPO" --pin "$GH_STACK_VERSION" \
+            --agent "$GH_SKILL_AGENT" --scope user --force 2>&1 | sed 's/^/[gh]   /'; then
+        echo "[gh] Installed the gh-stack agent skill (${GH_SKILL_AGENT}, user scope)"
+    else
+        echo "[gh] WARNING: could not install the gh-stack agent skill"
+        echo "[gh] The extension may still work; see: tbd shortcut stacked-prs"
+    fi
 fi
 
 exit 0

--- a/packages/tbd/docs/install/ensure-gh-cli.sh
+++ b/packages/tbd/docs/install/ensure-gh-cli.sh
@@ -298,7 +298,21 @@ fi
 # failure while fetching an optional extension must never block a session.
 GH_STACK_REPO="github/gh-stack"
 GH_STACK_VERSION="v0.1.0"
+
+# The skill is pinned by commit SHA rather than the tag. A tag can be moved, and a skill
+# is not inert data: it is instructions loaded into every later agent session on this
+# machine, so it deserves the stricter pin. This is the commit v0.1.0 points at, which
+# `gh skill install` also prints when it resolves the tag.
+GH_STACK_SKILL_SHA="a1b4a3d4d0bcde9ec3a78ab99b2d63af121857a9"
 GH_SKILL_AGENT="${GH_SKILL_AGENT:-claude-code}"
+
+# Is the gh-stack skill present for this agent? Used both as the pre-check and as the
+# post-install verification, because `gh skill install` exit status cannot be trusted
+# (see below).
+gh_stack_skill_present() {
+    gh skill list --agent "$GH_SKILL_AGENT" --json skillName -q '.[].skillName' 2>/dev/null \
+        | grep -qx 'gh-stack'
+}
 
 if [ "$WITH_STACK" = "1" ]; then
     if gh extension list 2>/dev/null | grep -q "gh stack"; then
@@ -318,14 +332,25 @@ if [ "$WITH_STACK" = "1" ]; then
     # would write skill files into the user's repo. The opt-in gate is --with-stack, not
     # the scope. Note `gh skill` has no uninstall command: removal means deleting the
     # installed directory (see `gh skill list` for its location).
-    if gh skill list 2>/dev/null | grep -q "gh-stack"; then
+    #
+    # The skill NAME is required. Given only a repository, `gh skill install` prints the
+    # skills it found, installs nothing, and still exits 0, so a bare repo argument
+    # silently does nothing while looking like success. Verify the result rather than
+    # trusting the exit status.
+    if gh_stack_skill_present; then
         echo "[gh] gh-stack agent skill already installed"
-    elif gh skill install "$GH_STACK_REPO" --pin "$GH_STACK_VERSION" \
-            --agent "$GH_SKILL_AGENT" --scope user --force 2>&1 | sed 's/^/[gh]   /'; then
-        echo "[gh] Installed the gh-stack agent skill (${GH_SKILL_AGENT}, user scope)"
     else
-        echo "[gh] WARNING: could not install the gh-stack agent skill"
-        echo "[gh] The extension may still work; see: tbd shortcut stacked-prs"
+        gh skill install "$GH_STACK_REPO" gh-stack --pin "$GH_STACK_SKILL_SHA" \
+            --agent "$GH_SKILL_AGENT" --scope user --force 2>&1 | sed 's/^/[gh]   /' || true
+        if gh_stack_skill_present; then
+            echo "[gh] Installed the gh-stack agent skill (${GH_SKILL_AGENT}, user scope)"
+            echo "[gh] GitHub does not verify skills, and a skill is instructions that load"
+            echo "[gh] into later sessions. Review it before relying on it:"
+            echo "[gh]   gh skill preview ${GH_STACK_REPO} gh-stack@${GH_STACK_SKILL_SHA}"
+        else
+            echo "[gh] WARNING: the gh-stack agent skill did not install"
+            echo "[gh] The extension may still work; see: tbd shortcut stacked-prs"
+        fi
     fi
 fi
 

--- a/packages/tbd/docs/shortcuts/standard/address-pr-review.md
+++ b/packages/tbd/docs/shortcuts/standard/address-pr-review.md
@@ -63,13 +63,14 @@ Create a to-do list with the following items then perform all of them:
    - `gh pr checkout <PR_NUMBER> --repo $REPO`
    - If the base branch has moved substantially, run `tbd shortcut merge-upstream` first
      so fixes land on a current branch
-   - **If the PR is one layer of a stack** (`gh stack view --json`; exit 2 means it is
-     not), the checkout lands you mid-stack.
-     Two rules follow: land each fix on the layer that owns the code, never on whatever
-     layer is checked out; and after committing, run `gh stack rebase --upstack` so the
-     layers above pick up the change.
+   - **If the PR is one layer of a stack** (`gh stack view --json`; any non-zero exit,
+     whether 2 or a missing `gh stack`, means it is not), the checkout lands you
+     mid-stack. Two rules follow: land each fix on the layer that owns the code, never on
+     whatever layer is checked out; and after committing, run
+     `gh stack rebase --upstack` so the layers above pick up the change.
      CI on the upper PRs means nothing until that rebase happens.
-     Use `gh stack sync`, not `merge-upstream`, to refresh a stacked branch.
+     To refresh a stacked branch use `gh stack sync`, not `merge-upstream`, bearing in
+     mind it force-pushes (`--force-with-lease`) the whole chain.
 
 6. **Triage and address each finding, in severity order:**
 

--- a/packages/tbd/docs/shortcuts/standard/address-pr-review.md
+++ b/packages/tbd/docs/shortcuts/standard/address-pr-review.md
@@ -63,6 +63,13 @@ Create a to-do list with the following items then perform all of them:
    - `gh pr checkout <PR_NUMBER> --repo $REPO`
    - If the base branch has moved substantially, run `tbd shortcut merge-upstream` first
      so fixes land on a current branch
+   - **If the PR is one layer of a stack** (`gh stack view --json`; exit 2 means it is
+     not), the checkout lands you mid-stack.
+     Two rules follow: land each fix on the layer that owns the code, never on whatever
+     layer is checked out; and after committing, run `gh stack rebase --upstack` so the
+     layers above pick up the change.
+     CI on the upper PRs means nothing until that rebase happens.
+     Use `gh stack sync`, not `merge-upstream`, to refresh a stacked branch.
 
 6. **Triage and address each finding, in severity order:**
 

--- a/packages/tbd/docs/shortcuts/standard/create-or-update-pr-simple.md
+++ b/packages/tbd/docs/shortcuts/standard/create-or-update-pr-simple.md
@@ -18,6 +18,12 @@ Create a to-do list with the following items then perform all of them:
      BRANCH=$(git rev-parse --abbrev-ref HEAD)
      REPO=$(git remote get-url origin | sed -E 's#.*/git/##; s#.*github.com[:/]##; s#\.git$##')
      ```
+   - Resolve the trunk instead of assuming `main`, since repos differ and a wrong base
+     makes the PR unreviewable:
+     ```
+     TRUNK=$(gh repo view $REPO --json defaultBranchRef -q .defaultBranchRef.name)
+     ```
+     (`gh repo view` takes the repo as a positional argument; it has no `--repo` flag.)
    - Use `--repo $REPO` on all gh commands (required for Claude Code Cloud)
 
 2. Check branch state: if this branch has uncommitted work, commit it first via
@@ -25,10 +31,15 @@ Create a to-do list with the following items then perform all of them:
    in-progress work); if the branch is behind its base with likely conflicts, run
    `tbd shortcut merge-upstream` first.
 
-3. Check if a PR already exists for this branch:
+3. Check if a PR already exists for this branch, and whether the branch is stacked:
    - Run: `gh pr view $BRANCH --repo $REPO --json number,url 2>/dev/null`
    - If it returns JSON, a PR exists (you’ll update it).
      If it errors, you’ll create one.
+   - Check for a stack: `gh stack view --json 2>/dev/null` Always pass `--json`; bare
+     `gh stack view` opens a TUI that blocks forever.
+     Exit 0 with a stack containing `$BRANCH` means step 6 takes the stacked path.
+     Exit 2 (`not part of a stack`) or a missing `gh stack` means the normal path
+     applies.
 
 4. Review all commits on this branch since it diverged from main:
    - Run `git log main..HEAD --oneline` to see commits
@@ -44,9 +55,15 @@ Create a to-do list with the following items then perform all of them:
      (See `tbd guidelines commit-conventions` for details.)
 
 6. Create or update the PR:
-   - If creating:
-     `gh pr create --repo $REPO --head $BRANCH --base main --title "..." --body "..."`
-   - If updating: `gh pr edit $BRANCH --repo $REPO --title "..." --body "..."`
+   - **If the branch is part of a stack**, do not create the PR by hand, and never pass
+     `--base $TRUNK`. Targeting the trunk retargets the PR, shows the reviewer every
+     lower layer’s diff, and breaks the stack on GitHub.
+     Run `gh stack submit --auto`, then set the title and body with `gh pr edit`. See
+     `tbd shortcut stacked-prs`.
+   - If creating (not stacked):
+     `gh pr create --repo $REPO --head $BRANCH --base $TRUNK --title "..." --body "..."`
+   - If updating: `gh pr edit $BRANCH --repo $REPO --title "..." --body "..."` Do not
+     add `--base` here unless you actually intend to retarget the PR.
 
 7. Report the PR URL to the user and inform them you are now waiting for CI.
 

--- a/packages/tbd/docs/shortcuts/standard/create-or-update-pr-simple.md
+++ b/packages/tbd/docs/shortcuts/standard/create-or-update-pr-simple.md
@@ -24,6 +24,10 @@ Create a to-do list with the following items then perform all of them:
      TRUNK=$(gh repo view $REPO --json defaultBranchRef -q .defaultBranchRef.name)
      ```
      (`gh repo view` takes the repo as a positional argument; it has no `--repo` flag.)
+     This needs network and auth.
+     If it comes back empty, fall back to `git symbolic-ref refs/remotes/origin/HEAD`
+     rather than proceeding with an empty base, which would make step 6 create the PR
+     against nothing.
    - Use `--repo $REPO` on all gh commands (required for Claude Code Cloud)
 
 2. Check branch state: if this branch has uncommitted work, commit it first via
@@ -41,9 +45,12 @@ Create a to-do list with the following items then perform all of them:
      Exit 2 (`not part of a stack`) or a missing `gh stack` means the normal path
      applies.
 
-4. Review all commits on this branch since it diverged from main:
-   - Run `git log main..HEAD --oneline` to see commits
-   - Run `git diff main...HEAD` to see all changes
+4. Review all commits on this branch since it diverged from its base:
+   - Run `git log $TRUNK..HEAD --oneline` to see commits
+   - Run `git diff $TRUNK...HEAD` to see all changes
+   - On a stacked branch, use the layer below instead of `$TRUNK` for both.
+     Against the trunk they enumerate every lower layer, so you would describe the whole
+     stack in a PR whose diff is one layer.
 
 5. Write a PR title and description:
    - Title should be concise and describe the change (e.g., “Add user authentication”)
@@ -58,8 +65,9 @@ Create a to-do list with the following items then perform all of them:
    - **If the branch is part of a stack**, do not create the PR by hand, and never pass
      `--base $TRUNK`. Targeting the trunk retargets the PR, shows the reviewer every
      lower layer’s diff, and breaks the stack on GitHub.
-     Run `gh stack submit --auto`, then set the title and body with `gh pr edit`. See
-     `tbd shortcut stacked-prs`.
+     Run `gh stack submit --auto --open`, then set the title and body with `gh pr edit`.
+     Without `--open` the PRs are created as drafts, which `gh stack merge` refuses to
+     merge. See `tbd shortcut stacked-prs`.
    - If creating (not stacked):
      `gh pr create --repo $REPO --head $BRANCH --base $TRUNK --title "..." --body "..."`
    - If updating: `gh pr edit $BRANCH --repo $REPO --title "..." --body "..."` Do not

--- a/packages/tbd/docs/shortcuts/standard/create-or-update-pr-with-validation-plan.md
+++ b/packages/tbd/docs/shortcuts/standard/create-or-update-pr-with-validation-plan.md
@@ -18,6 +18,12 @@ Create a to-do list with the following items then perform all of them:
      BRANCH=$(git rev-parse --abbrev-ref HEAD)
      REPO=$(git remote get-url origin | sed -E 's#.*/git/##; s#.*github.com[:/]##; s#\.git$##')
      ```
+   - Resolve the trunk instead of assuming `main`, since repos differ and a wrong base
+     makes the PR unreviewable:
+     ```
+     TRUNK=$(gh repo view $REPO --json defaultBranchRef -q .defaultBranchRef.name)
+     ```
+     (`gh repo view` takes the repo as a positional argument; it has no `--repo` flag.)
    - Use `--repo $REPO` on all gh commands (required for Claude Code Cloud)
 
 2. Check branch state: if this branch has uncommitted work, commit it first via
@@ -25,10 +31,15 @@ Create a to-do list with the following items then perform all of them:
    in-progress work); if the branch is behind its base with likely conflicts, run
    `tbd shortcut merge-upstream` first.
 
-3. Check if a PR already exists for this branch:
+3. Check if a PR already exists for this branch, and whether the branch is stacked:
    - Run: `gh pr view $BRANCH --repo $REPO --json number,url 2>/dev/null`
    - If it returns JSON, a PR exists (you’ll update it).
      If it errors, you’ll create one.
+   - Check for a stack: `gh stack view --json 2>/dev/null` Always pass `--json`; bare
+     `gh stack view` opens a TUI that blocks forever.
+     Exit 0 with a stack containing `$BRANCH` means step 6 takes the stacked path.
+     Exit 2 (`not part of a stack`) or a missing `gh stack` means the normal path
+     applies.
 
 4. Review all commits on this branch since it diverged from main:
    - Run `git log main..HEAD --oneline` to see commits
@@ -62,9 +73,15 @@ Create a to-do list with the following items then perform all of them:
    Link any related beads using their IDs.
 
 6. Create or update the PR:
-   - If creating:
-     `gh pr create --repo $REPO --head $BRANCH --base main --title "..." --body "..."`
-   - If updating: `gh pr edit $BRANCH --repo $REPO --title "..." --body "..."`
+   - **If the branch is part of a stack**, do not create the PR by hand, and never pass
+     `--base $TRUNK`. Targeting the trunk retargets the PR, shows the reviewer every
+     lower layer’s diff, and breaks the stack on GitHub.
+     Run `gh stack submit --auto`, then set the title and body with `gh pr edit`. See
+     `tbd shortcut stacked-prs`.
+   - If creating (not stacked):
+     `gh pr create --repo $REPO --head $BRANCH --base $TRUNK --title "..." --body "..."`
+   - If updating: `gh pr edit $BRANCH --repo $REPO --title "..." --body "..."` Do not
+     add `--base` here unless you actually intend to retarget the PR.
 
 7. Report the PR URL to the user, summarize the validation plan, and inform them you are
    now waiting for CI.

--- a/packages/tbd/docs/shortcuts/standard/create-or-update-pr-with-validation-plan.md
+++ b/packages/tbd/docs/shortcuts/standard/create-or-update-pr-with-validation-plan.md
@@ -24,6 +24,10 @@ Create a to-do list with the following items then perform all of them:
      TRUNK=$(gh repo view $REPO --json defaultBranchRef -q .defaultBranchRef.name)
      ```
      (`gh repo view` takes the repo as a positional argument; it has no `--repo` flag.)
+     This needs network and auth.
+     If it comes back empty, fall back to `git symbolic-ref refs/remotes/origin/HEAD`
+     rather than proceeding with an empty base, which would make step 6 create the PR
+     against nothing.
    - Use `--repo $REPO` on all gh commands (required for Claude Code Cloud)
 
 2. Check branch state: if this branch has uncommitted work, commit it first via
@@ -41,9 +45,12 @@ Create a to-do list with the following items then perform all of them:
      Exit 2 (`not part of a stack`) or a missing `gh stack` means the normal path
      applies.
 
-4. Review all commits on this branch since it diverged from main:
-   - Run `git log main..HEAD --oneline` to see commits
-   - Run `git diff main...HEAD` to see all changes
+4. Review all commits on this branch since it diverged from its base:
+   - Run `git log $TRUNK..HEAD --oneline` to see commits
+   - Run `git diff $TRUNK...HEAD` to see all changes
+   - On a stacked branch, use the layer below instead of `$TRUNK` for both.
+     Against the trunk they enumerate every lower layer, so you would describe the whole
+     stack in a PR whose diff is one layer.
    - Review any related specs in docs/project/specs/active/
 
 5. Write a PR title and description with these sections.
@@ -76,8 +83,9 @@ Create a to-do list with the following items then perform all of them:
    - **If the branch is part of a stack**, do not create the PR by hand, and never pass
      `--base $TRUNK`. Targeting the trunk retargets the PR, shows the reviewer every
      lower layer’s diff, and breaks the stack on GitHub.
-     Run `gh stack submit --auto`, then set the title and body with `gh pr edit`. See
-     `tbd shortcut stacked-prs`.
+     Run `gh stack submit --auto --open`, then set the title and body with `gh pr edit`.
+     Without `--open` the PRs are created as drafts, which `gh stack merge` refuses to
+     merge. See `tbd shortcut stacked-prs`.
    - If creating (not stacked):
      `gh pr create --repo $REPO --head $BRANCH --base $TRUNK --title "..." --body "..."`
    - If updating: `gh pr edit $BRANCH --repo $REPO --title "..." --body "..."` Do not

--- a/packages/tbd/docs/shortcuts/standard/merge-upstream.md
+++ b/packages/tbd/docs/shortcuts/standard/merge-upstream.md
@@ -10,10 +10,13 @@ Run `tbd prime` for more on using tbd and current status.
 Merge upstream changes from origin/main into the current branch and leave the branch
 pushed with CI green.
 
-> **If this branch is part of a stack, stop and use `gh stack sync` instead.** A stacked
-> branch is kept current by rebasing the chain, not by merging the trunk into one layer.
-> A merge commit here rewrites the layer’s relationship to the one below it and breaks
-> the stack. Check with `gh stack view --json` (exit 2 means not stacked).
+> **If this branch is part of a stack, stop and use `gh stack sync` instead.** A merge
+> commit here breaks the stack: a stacked branch is kept current by rebasing the chain,
+> not by merging the trunk into one layer.
+> Note `gh stack sync` is the bigger hammer, rebasing and force-pushing
+> (`--force-with-lease`) every branch in the stack.
+> Check with `gh stack view --json`; any non-zero exit, whether 2 (not stacked) or a
+> missing `gh stack`, means the normal path below applies.
 > See `tbd shortcut stacked-prs`.
 
 ## Instructions

--- a/packages/tbd/docs/shortcuts/standard/merge-upstream.md
+++ b/packages/tbd/docs/shortcuts/standard/merge-upstream.md
@@ -10,6 +10,12 @@ Run `tbd prime` for more on using tbd and current status.
 Merge upstream changes from origin/main into the current branch and leave the branch
 pushed with CI green.
 
+> **If this branch is part of a stack, stop and use `gh stack sync` instead.** A stacked
+> branch is kept current by rebasing the chain, not by merging the trunk into one layer.
+> A merge commit here rewrites the layer’s relationship to the one below it and breaks
+> the stack. Check with `gh stack view --json` (exit 2 means not stacked).
+> See `tbd shortcut stacked-prs`.
+
 ## Instructions
 
 Create a to-do list with the following items then perform all of them:

--- a/packages/tbd/docs/shortcuts/standard/pr-review-workflows.md
+++ b/packages/tbd/docs/shortcuts/standard/pr-review-workflows.md
@@ -35,6 +35,23 @@ Pre-commit reviews (`tbd shortcut precommit-process`) use `review-code` directly
 issues immediately—the publish and address stages apply to reviews of pushed PRs, where
 the review and the fix are separate pieces of work.
 
+## Stacked PRs
+
+When a PR is one layer of a stack, the lifecycle above still applies, one layer at a
+time, with three adjustments:
+
+- **Review scope is the layer.** GitHub shows only that layer’s diff, since the base is
+  the branch below it.
+  Review that, and say which layer a finding belongs to; a finding about lower-layer
+  code belongs on that lower PR.
+- **Fixes land on the owning layer**, then `gh stack rebase --upstack` so the layers
+  above pick up the change.
+  Until that rebase, CI on the upper PRs is stale.
+- **Verdicts are per layer.** A blocker on a lower layer blocks everything above it,
+  because `gh stack merge` is all-or-nothing.
+
+See `tbd shortcut stacked-prs` for when stacking is worth it.
+
 ## Review Channels
 
 A published review can live in any of these places.

--- a/packages/tbd/docs/shortcuts/standard/review-code.md
+++ b/packages/tbd/docs/shortcuts/standard/review-code.md
@@ -22,6 +22,10 @@ This shortcut supports three review scopes:
 | **Branch work** | All commits ahead of target + uncommitted | `git diff <target>...HEAD` + uncommitted |
 | **GitHub PR** | Changes in a pull request | `gh pr diff <PR>` |
 
+When the PR is one layer of a stack, `gh pr diff` shows only that layer’s changes,
+because the PR’s base is the branch below it rather than the trunk.
+That narrow diff is the correct review scope, not a sign the change is incomplete.
+
 For **GitHub PR** reviews with follow-up actions (commenting, CI checks), use
 `tbd shortcut review-github-pr` instead—it wraps this shortcut and adds GitHub workflow.
 

--- a/packages/tbd/docs/shortcuts/standard/setup-github-cli.md
+++ b/packages/tbd/docs/shortcuts/standard/setup-github-cli.md
@@ -31,8 +31,13 @@ See [Proxied Remote Sessions](#proxied-remote-sessions) first.
 1. **gh exists but is broken**: `gh --version` or `gh auth status` fails with errors
    - Solution: Reinstall via ensure script (installs fresh copy to ~/.local/bin)
 
-2. **gh exists but wrong version**: Very old gh may lack required features
-   - Solution: Reinstall via ensure script
+2. **gh exists but is too old**: a distro-packaged `gh` is often several minor versions
+   behind, and versions before 2.97.0 carry known security issues (see
+   [Version Floor](#version-floor))
+   - Solution: Reinstall via ensure script.
+     It compares the installed version against the floor and installs the pinned build
+     to `~/.local/bin` when it falls short.
+     A newer `gh` is kept as is; the script never downgrades.
 
 3. **gh works but not authenticated**: `GH_TOKEN` not set or invalid
    - Solution: Set `GH_TOKEN` environment variable before starting session
@@ -45,31 +50,124 @@ See [Proxied Remote Sessions](#proxied-remote-sessions) first.
    session’s proxy, not by GitHub — the token is often perfectly valid.
    - Solution: See [Proxied Remote Sessions](#proxied-remote-sessions)
 
-## Installation
+## Fresh Machine Setup
 
-1. **Run the ensure script:**
+Run these in order on a machine that has never had tbd or `gh` on it.
+Every step is idempotent, so re-running the whole sequence is safe.
+
+1. **Install and verify gh:**
    ```bash
    bash .claude/scripts/ensure-gh-cli.sh
    ```
-   This script installs gh to `~/.local/bin` and checks authentication.
-   If a session proxy blocks the download, it retries with a scoped `NO_PROXY` bypass
-   automatically.
 
-2. **If the script doesn’t exist:** Run `tbd setup --auto` to reinstall tbd hooks, which
-   includes the gh CLI script.
+   Installs the pinned `gh` to `~/.local/bin` when `gh` is missing or below the version
+   floor, verifying a pinned SHA-256 checksum before extracting.
+   If a session proxy blocks the download, it retries once with a scoped `NO_PROXY`
+   bypass.
 
-3. **Manual installation (fallback):**
+   If the script does not exist, run `tbd setup --auto` to reinstall tbd hooks, which
+   includes it.
+
+2. **Authenticate** (skip if `gh auth status` already passes):
    ```bash
-   # macOS
-   brew install gh
+   gh auth login
+   ```
+   Or set `GH_TOKEN` before starting the session, as described under
+   [Authentication](#authentication).
+   Either is fine; see [Two Ways to Authenticate](#two-ways-to-authenticate).
 
-   # Linux (Debian/Ubuntu)
-   curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-   sudo apt update && sudo apt install gh
+3. **Install stacked-PR tooling** (optional, only if you use stacked PRs):
+   ```bash
+   bash .claude/scripts/ensure-gh-cli.sh --with-stack
    ```
 
+   Installs the `github/gh-stack` extension and its official agent skill, both pinned to
+   `v0.1.0`. This is deliberately not part of the SessionStart hook: it costs network
+   calls that sessions which never stack should not pay.
+   Failures here warn and continue, since stacked PRs are optional.
+   See `tbd shortcut stacked-prs` for when to use them.
+
+   The skill installs at **user scope**, matching the extension, which `gh` also
+   installs per machine rather than per repo.
+   Note that `gh skill` currently has no uninstall command: to remove it, delete the
+   installed directory, whose location `gh skill list` reports.
+   Override the target agent with `GH_SKILL_AGENT=codex` if you use a different one.
+
+4. **Confirm PATH** if step 1 installed a new binary:
+   ```bash
+   command -v gh    # expect ~/.local/bin/gh, not /usr/bin/gh
+   ```
+   If an older `gh` still wins, put `~/.local/bin` earlier in `PATH`.
+
+### Verification Checklist
+
+Run these after setup.
+Each line states the expected result, so the outcome is pass or fail rather than a
+judgment call:
+
+| Command | Expected |
+| --- | --- |
+| `gh --version` | `2.97.0` or higher |
+| `gh auth status` | `Logged in to github.com` |
+| `gh repo view <owner>/<repo> --json defaultBranchRef -q .defaultBranchRef.name` | the trunk name, e.g. `main` |
+| `gh extension list` | `gh stack  github/gh-stack  v0.1.0` (only after step 3) |
+| `gh skill list` | a `gh-stack` row (only after step 3) |
+| `gh stack --help` | exits 0 (only after step 3) |
+
+### Version Floor
+
+The script pins `gh` **2.97.0** and refuses anything older.
+That release fixed four advisories, two of which land directly on paths agents use:
+
+- `gh auth status` printed part of the auth token in plaintext for `ghs_*`,
+  `github_pat_*`, and `ghu_*` token formats
+  ([GHSA-cg6r-mpgc-h9mm](https://github.com/cli/cli/security/advisories/GHSA-cg6r-mpgc-h9mm)).
+  This shortcut and every PR shortcut run `gh auth status`, and agents capture its
+  output.
+- `gh api`, `gh pr diff`, and others printed externally controlled content without
+  neutralizing terminal escape sequences
+  ([GHSA-3m3g-3wcr-px46](https://github.com/cli/cli/security/advisories/GHSA-3m3g-3wcr-px46)).
+  The review shortcuts pipe `gh pr diff` and `gh api` output straight into agent
+  context.
+
+The pin stays at least 14 days old per SUPPLY-CHAIN-SECURITY.md, so it lags the newest
+release on purpose. To bump it, pick a release at least 14 days old, copy its checksums
+from
+`https://github.com/cli/cli/releases/download/v<VERSION>/gh_<VERSION>_checksums.txt`,
+and update `GH_VERSION`, `GH_MIN_VERSION`, and `checksum_for()` together.
+
+### Manual Installation (fallback)
+
+```bash
+# macOS
+brew install gh
+
+# Linux (Debian/Ubuntu)
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+sudo apt update && sudo apt install gh
+```
+
+Check the resulting version against the floor above.
+Distro packages frequently ship something older.
+
 ## Authentication
+
+### Two Ways to Authenticate
+
+`gh` is authenticated if **either** holds, and the shortcuts work the same way under
+both:
+
+- **`GH_TOKEN` is set** in the environment.
+  Preferred for agent and CI sessions, where there is no interactive login.
+- **Stored credentials** from `gh auth login`, kept in the OS keyring.
+  Usual on a developer laptop.
+
+The ensure script reports which one is in play.
+It only warns when *neither* is present; a machine authenticated through the keyring
+with no `GH_TOKEN` is fully working and is reported as such.
+
+### Setting GH_TOKEN
 
 Set `GH_TOKEN` environment variable with a GitHub personal access token **before**
 starting the session.
@@ -214,6 +312,11 @@ report the limitation — do not attempt to tunnel around network policy.
 | --- | --- |
 | `gh: command not found` | Run ensure script or add ~/.local/bin to PATH |
 | `gh --version` fails | gh is broken, reinstall via ensure script |
+| `gh --version` is below 2.97.0 | Run the ensure script; it installs the pinned build to `~/.local/bin` |
+| Ensure script ran but `gh --version` is still old | An older gh precedes `~/.local/bin` in PATH; reorder PATH |
+| `gh: unknown command "stack"` | Extension not installed: `bash .claude/scripts/ensure-gh-cli.sh --with-stack` |
+| `gh stack view` hangs and never returns | Bare `view` opens a TUI; always pass `--json` |
+| `gh auth status` passes but the hook says GH_TOKEN is unset | Normal: authenticated via the OS keyring instead of a token |
 | `gh auth status` errors and `HTTPS_PROXY` is set | Proxied session: apply the NO_PROXY recipe above before trusting the error |
 | `gh auth status` shows errors (no proxy) | GH_TOKEN not set or invalid |
 | `Bad credentials` | Token expired or lacks permissions |

--- a/packages/tbd/docs/shortcuts/standard/setup-github-cli.md
+++ b/packages/tbd/docs/shortcuts/standard/setup-github-cli.md
@@ -55,7 +55,9 @@ See [Proxied Remote Sessions](#proxied-remote-sessions) first.
 Run these in order on a machine that has never had tbd or `gh` on it.
 Every step is idempotent, so re-running the whole sequence is safe.
 
-1. **Install and verify gh:**
+1. **Install and verify gh** with the ensure script (`.claude/scripts/ensure-gh-cli.sh`,
+   or `.codex/ensure-gh-cli.sh` under Codex; the two are byte-identical, and later steps
+   call it “the ensure script”):
    ```bash
    bash .claude/scripts/ensure-gh-cli.sh
    ```
@@ -89,6 +91,10 @@ Every step is idempotent, so re-running the whole sequence is safe.
 
    The skill installs at **user scope**, matching the extension, which `gh` also
    installs per machine rather than per repo.
+   The skill is pinned by commit SHA rather than tag, because a skill is instructions
+   loaded into later sessions rather than inert data.
+   GitHub does not verify skills, so review it before relying on it:
+   `gh skill preview github/gh-stack gh-stack@a1b4a3d4d0bcde9ec3a78ab99b2d63af121857a9`.
    Note that `gh skill` currently has no uninstall command: to remove it, delete the
    installed directory, whose location `gh skill list` reports.
    Override the target agent with `GH_SKILL_AGENT=codex` if you use a different one.

--- a/packages/tbd/docs/shortcuts/standard/stacked-prs.md
+++ b/packages/tbd/docs/shortcuts/standard/stacked-prs.md
@@ -1,0 +1,124 @@
+---
+title: Stacked PRs
+description: When to split work into a stack of dependent PRs, how stacks line up with beads, and how the PR shortcuts change when a branch is part of a stack
+category: git
+author: Joshua Levy (github.com/jlevy) with LLM assistance
+---
+A **stack** is an ordered chain of branches on a trunk, where each branch has one PR
+based on the branch below it.
+A reviewer sees only that layer’s diff, so three 200-line PRs replace one 600-line PR.
+
+This shortcut covers **when to stack and how stacking interacts with tbd**. It
+deliberately does not document the `gh stack` commands.
+
+## Mechanics Live in the Official Skill
+
+GitHub ships `gh stack` (the `github/gh-stack` extension) with an official agent skill.
+That skill is the authority on driving the tool, and it is far more precise than a
+summary here could be: it spells out which subcommands hang forever under a PTY, the
+exact flags that avoid prompts, exit codes, conflict recovery, and `--json` parsing.
+
+Check that it is installed before doing stack work:
+
+```bash
+gh extension list | grep 'gh stack'   # expect: gh stack  github/gh-stack  v0.1.0
+gh skill list | grep gh-stack         # expect: gh-stack
+```
+
+If either is missing, install both pinned:
+
+```bash
+bash .claude/scripts/ensure-gh-cli.sh --with-stack
+```
+
+If the skill is unavailable and you must proceed anyway, the four rules that matter
+most, because breaking them hangs an agent session indefinitely:
+
+- `gh stack view --json`, never bare `gh stack view` (bare opens a blocking TUI).
+- `gh stack submit --auto`, never bare `submit` (bare prompts for every PR title).
+- `gh stack merge <target> --yes`. Plain `gh pr merge` cannot merge a stack.
+- Pass branch names to `init`, `add`, and `checkout`. Bare forms prompt.
+
+## When to Stack
+
+Stacking is **opt-in**. It is one workflow among several, and a single well-scoped PR is
+the right default for most changes.
+Do not restructure someone’s work into a stack because stacks are available.
+
+**If the user asks for a stacked PR, produce an actual stack.** When they say “stacked
+PR”, “stack this”, “layer these”, or “dependent PRs”, the deliverable is a real stack:
+branches chained bottom to top, each PR based on the branch below, linked as a stack on
+GitHub. Creating one flat PR instead is a silent failure to deliver what was asked.
+Verify with `gh stack view --json` and confirm each PR’s base is the branch below it,
+not the trunk.
+
+**Offer a stack when the change plainly decomposes.** Suggest it once, in a sentence,
+and accept the answer:
+
+- A refactor or extraction that a feature then builds on.
+- A schema, migration, or type change beneath the code that consumes it.
+- A dependency bump or config change that unblocks the real work.
+- Work already crossing roughly 400 lines or several unrelated concerns.
+
+**Do not offer a stack** for a single-concern change, a small fix, work the user framed
+as one PR, or anything urgent enough that serialized review would hurt.
+Once the user declines, drop it and do not raise it again that session.
+
+## Layer Discipline
+
+When a stack is warranted, the split has to earn the extra process:
+
+- **One concern per layer.** If you cannot state a layer’s purpose in a sentence, the
+  split is wrong.
+- **Foundations at the bottom.** Each layer depends only on layers below it.
+- **Every layer stands alone.** It should build, pass tests, and be independently
+  revertible. A layer that only makes sense with the one above belongs merged into it.
+- **Order by dependency, not by chronology.** The order you wrote the code in is not
+  necessarily the order it should be reviewed in.
+- **Create the stack before writing the code** where you can.
+  Splitting a finished branch afterwards is materially harder than starting with the
+  layers.
+- **Edit the layer that owns the code.** Never commit a lower layer’s fix on the top
+  branch. Check out that layer, commit, rebase the layers above, then return.
+
+Prefer fewer, larger layers over many tiny ones.
+Each layer costs a PR, a CI run, and a review cycle.
+
+## Stacks and Beads
+
+A stack and a bead tree describe the same decomposition, so keep them aligned:
+
+- One parent bead for the whole change, one child bead per layer.
+- Order the children with `--depends-on` to mirror the stack order, bottom first.
+- Record the branch name and PR number on each child bead as its layer lands.
+- Close a child when its layer merges, not when the whole stack merges.
+
+This keeps the work legible if the stack is handed to another agent mid-flight, which is
+the usual reason a stack outlives one session.
+
+## How the Other Shortcuts Change
+
+| Shortcut | On a stacked branch |
+| --- | --- |
+| `create-or-update-pr-simple` / `-with-validation-plan` | Do **not** pass `--base main`. Use `gh stack submit --auto`, or set the base to the branch below. Passing the trunk retargets the PR and flattens the stack. |
+| `code-review-and-commit` | Commit to the layer that owns the change, then rebase the layers above. |
+| `review-github-pr` | Review only that layer’s diff, which is what GitHub already shows. Name the layer in each finding. |
+| `address-pr-review` | Fix on the owning layer, then `gh stack rebase --upstack` before trusting CI on the upper PRs. |
+| `merge-upstream` | Do not merge the trunk into a stacked branch. Use `gh stack sync`, which rebases the chain. |
+
+## Landing a Stack
+
+Merge bottom to top, and let the tooling do it:
+
+```bash
+gh stack merge <pr-number> --yes    # that PR and every unmerged PR below it
+gh stack sync --prune               # reconcile local state, drop merged branches
+```
+
+The merge is all-or-nothing: if any PR in the set cannot merge, none do.
+After a squash merge on the trunk, `gh stack sync` detects it and rebases the remaining
+layers; do not rebuild the stack by hand.
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->

--- a/packages/tbd/docs/shortcuts/standard/stacked-prs.md
+++ b/packages/tbd/docs/shortcuts/standard/stacked-prs.md
@@ -25,7 +25,8 @@ gh extension list | grep 'gh stack'   # expect: gh stack  github/gh-stack  v0.1.
 gh skill list | grep gh-stack         # expect: gh-stack
 ```
 
-If either is missing, install both pinned:
+If either is missing, install both pinned via the ensure script
+(`.claude/scripts/ensure-gh-cli.sh`, or `.codex/ensure-gh-cli.sh` under Codex):
 
 ```bash
 bash .claude/scripts/ensure-gh-cli.sh --with-stack
@@ -35,8 +36,10 @@ If the skill is unavailable and you must proceed anyway, the four rules that mat
 most, because breaking them hangs an agent session indefinitely:
 
 - `gh stack view --json`, never bare `gh stack view` (bare opens a blocking TUI).
-- `gh stack submit --auto`, never bare `submit` (bare prompts for every PR title).
-- `gh stack merge <target> --yes`. Plain `gh pr merge` cannot merge a stack.
+- `gh stack submit --auto --open`, never bare `submit` (bare prompts for every PR
+  title). `--auto` on its own opens the PRs as drafts, which `gh stack merge` refuses.
+- `gh stack merge <target> --yes`. Plain `gh pr merge` cannot merge a stack, and a bare
+  number is read as a stack number before a PR number.
 - Pass branch names to `init`, `add`, and `checkout`. Bare forms prompt.
 
 ## When to Stack
@@ -58,7 +61,8 @@ and accept the answer:
 - A refactor or extraction that a feature then builds on.
 - A schema, migration, or type change beneath the code that consumes it.
 - A dependency bump or config change that unblocks the real work.
-- Work already crossing roughly 400 lines or several unrelated concerns.
+- Work spanning several unrelated concerns, which a large diff often but not always
+  indicates.
 
 **Do not offer a stack** for a single-concern change, a small fix, work the user framed
 as one PR, or anything urgent enough that serialized review would hurt.
@@ -73,8 +77,7 @@ When a stack is warranted, the split has to earn the extra process:
 - **Foundations at the bottom.** Each layer depends only on layers below it.
 - **Every layer stands alone.** It should build, pass tests, and be independently
   revertible. A layer that only makes sense with the one above belongs merged into it.
-- **Order by dependency, not by chronology.** The order you wrote the code in is not
-  necessarily the order it should be reviewed in.
+- **Order by dependency, not by chronology.**
 - **Create the stack before writing the code** where you can.
   Splitting a finished branch afterwards is materially harder than starting with the
   layers.
@@ -93,18 +96,15 @@ A stack and a bead tree describe the same decomposition, so keep them aligned:
 - Record the branch name and PR number on each child bead as its layer lands.
 - Close a child when its layer merges, not when the whole stack merges.
 
-This keeps the work legible if the stack is handed to another agent mid-flight, which is
-the usual reason a stack outlives one session.
-
 ## How the Other Shortcuts Change
 
 | Shortcut | On a stacked branch |
 | --- | --- |
-| `create-or-update-pr-simple` / `-with-validation-plan` | Do **not** pass `--base main`. Use `gh stack submit --auto`, or set the base to the branch below. Passing the trunk retargets the PR and flattens the stack. |
-| `code-review-and-commit` | Commit to the layer that owns the change, then rebase the layers above. |
+| `create-or-update-pr-simple` / `-with-validation-plan` | Do **not** target the trunk. Use `gh stack submit --auto --open`, or set the base to the branch below. Targeting the trunk retargets the PR and flattens the stack. |
+| `code-review-and-commit` | Commit to the owning layer (see Layer Discipline), then rebase the layers above. |
 | `review-github-pr` | Review only that layer’s diff, which is what GitHub already shows. Name the layer in each finding. |
 | `address-pr-review` | Fix on the owning layer, then `gh stack rebase --upstack` before trusting CI on the upper PRs. |
-| `merge-upstream` | Do not merge the trunk into a stacked branch. Use `gh stack sync`, which rebases the chain. |
+| `merge-upstream` | Do not merge the trunk into a stacked branch. Use `gh stack sync`, which rebases and force-pushes (`--force-with-lease`) the whole chain. |
 
 ## Landing a Stack
 
@@ -114,6 +114,10 @@ Merge bottom to top, and let the tooling do it:
 gh stack merge <pr-number> --yes    # that PR and every unmerged PR below it
 gh stack sync --prune               # reconcile local state, drop merged branches
 ```
+
+A bare number is resolved as a **stack** number first and only then as a PR number, so
+on a repo where those ranges still overlap, confirm with `gh stack view --json` before
+merging.
 
 The merge is all-or-nothing: if any PR in the set cannot merge, none do.
 After a squash merge on the trunk, `gh stack sync` detects it and rebases the remaining

--- a/packages/tbd/tests/ensure-gh-cli-script.test.ts
+++ b/packages/tbd/tests/ensure-gh-cli-script.test.ts
@@ -1,0 +1,85 @@
+import { spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const SCRIPT = join(import.meta.dirname, '..', 'docs', 'install', 'ensure-gh-cli.sh');
+
+/**
+ * Extract a single bash function from the shipped script.
+ *
+ * The script cannot be sourced directly: it runs an install on load. Pulling the
+ * function out keeps the assertions pointed at the real shipped text rather than a
+ * copy that can drift.
+ */
+async function extractFunction(name: string): Promise<string> {
+  const source = await readFile(SCRIPT, 'utf8');
+  const match = new RegExp(`^${name}\\(\\) \\{$.*?^\\}$`, 'ms').exec(source);
+  if (!match) {throw new Error(`${name}() not found in ${SCRIPT}`);}
+  return match[0];
+}
+
+describe('ensure-gh-cli.sh', () => {
+  describe('version_ge', () => {
+    /** Runs `version_ge have want` and reports whether it returned success. */
+    async function versionGe(have: string, want: string): Promise<boolean> {
+      const fn = await extractFunction('version_ge');
+      const result = spawnSync('bash', ['-c', `${fn}\nversion_ge "$1" "$2"`, '_', have, want], {
+        encoding: 'utf8',
+      });
+      if (result.status !== 0 && result.status !== 1) {
+        throw new Error(`unexpected exit ${result.status}: ${result.stderr}`);
+      }
+      return result.status === 0;
+    }
+
+    // The floor decides whether an existing gh is replaced. A false "new enough" leaves
+    // a vulnerable gh in place; a false "too old" downgrades a good one.
+    it.each([
+      ['2.97.0', '2.97.0', true, 'equal meets the floor'],
+      ['2.98.0', '2.97.0', true, 'newer is kept, never downgraded'],
+      ['2.92.0', '2.97.0', false, 'the previous pin is below the floor'],
+      ['2.9.0', '2.97.0', false, 'numeric compare, not lexicographic (9 < 97)'],
+      ['2.100.0', '2.97.0', true, 'numeric compare, not lexicographic (100 > 97)'],
+      ['2.08.0', '2.97.0', false, 'leading zero is not parsed as octal'],
+      ['3.0.0', '2.97.0', true, 'major bump'],
+      ['1.99.9', '2.97.0', false, 'lower major loses despite higher minor'],
+      ['2.97', '2.97.0', true, 'missing patch is treated as .0'],
+      ['2.97.1', '2.97.0', true, 'higher patch'],
+      ['2.96.9', '2.97.0', false, 'just below the floor'],
+      ['2.97.0-rc1', '2.97.0', true, 'prerelease suffix is stripped before comparing'],
+    ])('%s >= %s is %s (%s)', async (have, want, expected) => {
+      expect(await versionGe(have, want)).toBe(expected);
+    });
+  });
+
+  it('pins the gh version, the floor, and a checksum for every supported platform', async () => {
+    const source = await readFile(SCRIPT, 'utf8');
+    const version = (/^GH_VERSION="([^"]+)"$/m.exec(source))?.[1];
+    const floor = (/^GH_MIN_VERSION="([^"]+)"$/m.exec(source))?.[1];
+    expect(version).toBeTruthy();
+    // A floor above the pinned build would reinstall on every run, forever.
+    expect(floor).toBe(version);
+    for (const platform of [
+      'linux_amd64.tar.gz',
+      'linux_arm64.tar.gz',
+      'macOS_amd64.zip',
+      'macOS_arm64.zip',
+    ]) {
+      expect(source).toMatch(
+        new RegExp(`${platform.replace(/\./g, '\\.')}\\)\\s*echo "[0-9a-f]{64}"`),
+      );
+    }
+  });
+
+  it('installs the gh-stack skill by name and verifies the result', async () => {
+    const source = await readFile(SCRIPT, 'utf8');
+    // `gh skill install <repo>` with no skill name installs nothing and still exits 0,
+    // so both the selector and a result check are load-bearing.
+    expect(source).toMatch(/gh skill install "\$GH_STACK_REPO" gh-stack/);
+    expect(source).toMatch(/gh_stack_skill_present/);
+    // The skill is instructions loaded into later sessions, so it is pinned by SHA.
+    expect(source).toMatch(/^GH_STACK_SKILL_SHA="[0-9a-f]{40}"$/m);
+  });
+});

--- a/packages/tbd/tests/ensure-gh-cli-script.test.ts
+++ b/packages/tbd/tests/ensure-gh-cli-script.test.ts
@@ -16,7 +16,9 @@ const SCRIPT = join(import.meta.dirname, '..', 'docs', 'install', 'ensure-gh-cli
 async function extractFunction(name: string): Promise<string> {
   const source = await readFile(SCRIPT, 'utf8');
   const match = new RegExp(`^${name}\\(\\) \\{$.*?^\\}$`, 'ms').exec(source);
-  if (!match) {throw new Error(`${name}() not found in ${SCRIPT}`);}
+  if (!match) {
+    throw new Error(`${name}() not found in ${SCRIPT}`);
+  }
   return match[0];
 }
 
@@ -56,8 +58,8 @@ describe('ensure-gh-cli.sh', () => {
 
   it('pins the gh version, the floor, and a checksum for every supported platform', async () => {
     const source = await readFile(SCRIPT, 'utf8');
-    const version = (/^GH_VERSION="([^"]+)"$/m.exec(source))?.[1];
-    const floor = (/^GH_MIN_VERSION="([^"]+)"$/m.exec(source))?.[1];
+    const version = /^GH_VERSION="([^"]+)"$/m.exec(source)?.[1];
+    const floor = /^GH_MIN_VERSION="([^"]+)"$/m.exec(source)?.[1];
     expect(version).toBeTruthy();
     // A floor above the pinned build would reinstall on every run, forever.
     expect(floor).toBe(version);

--- a/tests/qa/gh-cli-and-stacked-prs.qa.md
+++ b/tests/qa/gh-cli-and-stacked-prs.qa.md
@@ -143,6 +143,15 @@ The script must never downgrade.
 | `gh stack --help` | exits 0 |
 
 3. Confirm the pin held: the extension row must read `v0.1.0`, not a later tag.
+   For the skill, confirm it is actually present rather than trusting the install
+   output:
+   ```bash
+   gh skill list --agent claude-code --json skillName -q '.[].skillName' | grep -x gh-stack
+   ```
+   **This check matters most in the whole playbook.** `gh skill install` exits 0 without
+   installing anything when it is given a repository but no skill name, so “it printed
+   success” is not evidence.
+   A review caught exactly that bug before this playbook was first run.
 4. Simulate failure by running `--with-stack` with no network.
    **Expected**: a warning, and exit 0. It must not block the session.
 
@@ -206,12 +215,9 @@ longer linked on GitHub.
    ```
    **Expected**: the second `--with-stack` run reports both the extension and the skill
    as already installed, and reinstalls neither.
-2. Confirm the three copies of the script are still byte-identical:
-   ```bash
-   diff packages/tbd/docs/install/ensure-gh-cli.sh .claude/scripts/ensure-gh-cli.sh
-   diff packages/tbd/docs/install/ensure-gh-cli.sh .codex/ensure-gh-cli.sh
-   ```
-   **Expected**: no output from either.
+   Byte-identity of the three script copies is already asserted by `setup-flows.test.ts`
+   (`installed script matches bundled ensure-gh-cli.sh` and the upgrade-path case), so
+   it needs no manual step here.
 
 ## Reporting
 

--- a/tests/qa/gh-cli-and-stacked-prs.qa.md
+++ b/tests/qa/gh-cli-and-stacked-prs.qa.md
@@ -1,0 +1,225 @@
+---
+title: QA Playbook
+description: Fresh-machine validation of gh CLI provisioning (version floor, pinned install) and stacked-PR support (gh-stack extension, official skill, PR shortcut behavior)
+author: Joshua Levy (github.com/jlevy) with LLM assistance
+---
+# QA Playbook: gh CLI Provisioning and Stacked PRs
+
+Validates the work in epic `tbd-ewsw` on a machine that is not the one it was written
+on.
+
+**Purpose**: prove that (a) `ensure-gh-cli.sh` enforces a version floor instead of
+accepting any `gh` it finds, (b) it never downgrades a newer `gh`, (c) the pinned
+gh-stack extension and its official agent skill install cleanly, (d) a real two-layer
+stack can be created and submitted, and (e) the PR shortcuts no longer flatten a stack
+by targeting the trunk.
+
+**Estimated time**: 45 to 60 minutes.
+
+**Why manual**: this exercises real network installs, a real GitHub repo, and real PR
+state. None of it is meaningfully coverable in unit tests.
+
+> **Instructions to the validating agent.** Report what actually happened, including
+> anything that contradicts this document.
+> A step that fails is a useful result, not a problem to work around: record the actual
+> output and continue.
+> Do not edit this playbook to match observed behavior.
+> If a step is skipped or blocked, say so explicitly rather than leaving it blank.
+
+* * *
+
+## Current Status (last update: not yet run)
+
+| Phase | Status | Notes |
+| --- | --- | --- |
+| Phase 0: Environment prep | ⏳ Pending |  |
+| Phase 1: Old gh is upgraded | ⏳ Pending |  |
+| Phase 2: Missing gh is installed | ⏳ Pending |  |
+| Phase 3: Newer gh is left alone | ⏳ Pending |  |
+| Phase 4: Stack tooling provisioning | ⏳ Pending |  |
+| Phase 5: Real two-layer stack | ⏳ Pending |  |
+| Phase 6: PR shortcut does not flatten a stack | ⏳ Pending |  |
+| Phase 7: Idempotency | ⏳ Pending |  |
+
+**Status Legend**: ✅ Passed | ❌ Failed | ⏳ Pending | ⏸️ Blocked
+
+* * *
+
+## Phase 0: Environment Prep
+
+Linux, x86_64 or arm64, with network access to GitHub.
+
+1. Confirm a clean starting point and record it:
+   ```bash
+   command -v gh || echo "no gh"
+   gh --version 2>/dev/null | head -1
+   uname -s -m
+   ```
+2. Authenticate, since later phases create real PRs.
+   Either export `GH_TOKEN`, or run `gh auth login` once `gh` exists.
+3. Clone the repo under test and check out the branch carrying this playbook.
+4. Pick a scratch GitHub repo you may freely create and close PRs in.
+   Do **not** use a production repo.
+
+**Record**: starting `gh` version (or absent), OS, arch, scratch repo name.
+
+## Phase 1: An Old gh Is Upgraded (the important case)
+
+This is the regression that motivated the work.
+Before the fix, any existing `gh` was accepted forever, so a distro package silently
+defeated the pin.
+
+1. Install an old `gh` deliberately, ahead of `~/.local/bin` in PATH:
+   ```bash
+   sudo apt-get install -y gh    # or any build older than 2.97.0
+   command -v gh && gh --version | head -1
+   ```
+   If apt provides 2.97.0 or newer, install an older release manually from
+   `https://github.com/cli/cli/releases`; the phase needs a genuinely old binary.
+2. Run the ensure script:
+   ```bash
+   bash .claude/scripts/ensure-gh-cli.sh
+   ```
+
+**Expected**:
+- Output names the found version and states it is below the required 2.97.0.
+- The pinned 2.97.0 is downloaded, its checksum verified, and it is installed to
+  `~/.local/bin/gh`.
+- If the old `gh` still precedes `~/.local/bin` in PATH, a PATH warning is printed
+  naming both paths.
+
+3. Confirm the effective version:
+   ```bash
+   hash -r; command -v gh; gh --version | head -1
+   ```
+   Expect 2.97.0 or higher.
+   If an older one still wins, the PATH warning should have said so; record whether it
+   did.
+
+**Fails if**: the script reports the old `gh` as fine and installs nothing.
+
+## Phase 2: A Missing gh Is Installed
+
+1. Remove `gh` from PATH entirely (uninstall the distro package and move
+   `~/.local/bin/gh` aside).
+2. Run `bash .claude/scripts/ensure-gh-cli.sh`.
+
+**Expected**: reports `CLI not found`, installs pinned 2.97.0, verifies the checksum,
+and exits 0. A checksum mismatch must abort with a non-zero exit and install nothing.
+
+## Phase 3: A Newer gh Is Left Alone
+
+The script must never downgrade.
+
+1. Install a `gh` newer than the pin, for example 2.98.0, into `~/.local/bin`.
+2. Run `bash .claude/scripts/ensure-gh-cli.sh`.
+
+**Expected**: reports the found version and exits without downloading anything.
+`gh --version` is unchanged afterward.
+
+**Fails if**: the newer `gh` is replaced with 2.97.0.
+
+## Phase 4: Stack Tooling Provisioning
+
+1. Confirm the default run installs no stack tooling:
+   ```bash
+   bash .claude/scripts/ensure-gh-cli.sh
+   gh extension list        # expect NO gh-stack row
+   ```
+   Stack tooling is opt-in; a default session must not pay for it.
+2. Opt in:
+   ```bash
+   bash .claude/scripts/ensure-gh-cli.sh --with-stack
+   ```
+
+**Expected**, matching the checklist in `setup-github-cli.md`:
+
+| Command | Expected |
+| --- | --- |
+| `gh --version` | 2.97.0 or higher |
+| `gh auth status` | `Logged in to github.com` |
+| `gh extension list` | `gh stack  github/gh-stack  v0.1.0` |
+| `gh skill list` | a `gh-stack` row |
+| `gh stack --help` | exits 0 |
+
+3. Confirm the pin held: the extension row must read `v0.1.0`, not a later tag.
+4. Simulate failure by running `--with-stack` with no network.
+   **Expected**: a warning, and exit 0. It must not block the session.
+
+## Phase 5: A Real Two-Layer Stack
+
+In the scratch repo:
+
+1. Create the stack and two commits:
+   ```bash
+   gh stack init layer-one
+   # edit a file, commit
+   gh stack add layer-two
+   # edit a different file, commit
+   gh stack submit --auto
+   ```
+2. Inspect:
+   ```bash
+   gh stack view --json
+   ```
+
+**Expected**:
+- Two PRs exist.
+- `layer-one` is based on the trunk.
+- **`layer-two` is based on `layer-one`, not on the trunk.** This is the core assertion.
+- GitHub shows the two PRs linked as a stack.
+- `gh pr diff <layer-two PR>` shows only layer two’s changes.
+
+3. Confirm the documented agent rules hold:
+   - `gh stack view --json` returns promptly and exits 0.
+   - On a non-stacked branch, `gh stack view --json` exits 2 with `not part of a stack`
+     rather than hanging.
+
+## Phase 6: The PR Shortcut Does Not Flatten a Stack
+
+This is the guidance regression fixed in this change.
+
+1. Check out `layer-two` from Phase 5.
+2. Follow `tbd shortcut create-or-update-pr-simple` exactly as written, running its
+   commands verbatim.
+
+**Expected**:
+- Step 1’s `TRUNK=$(gh repo view $REPO --json defaultBranchRef ...)` returns the trunk
+  name and exits 0.
+- Step 3 detects that the branch is part of a stack.
+- Step 6 takes the stacked path: it does **not** run `gh pr create ... --base <trunk>`.
+- After the shortcut completes, `gh stack view --json` still shows `layer-two` based on
+  `layer-one`.
+
+**Fails if**: the PR for `layer-two` ends up based on the trunk, or the stack is no
+longer linked on GitHub.
+
+3. Repeat on an ordinary non-stacked branch and confirm the simple path is unchanged and
+   no more laborious than before.
+
+## Phase 7: Idempotency
+
+1. Run each of these twice in a row and confirm the second run is a clean no-op:
+   ```bash
+   bash .claude/scripts/ensure-gh-cli.sh
+   bash .claude/scripts/ensure-gh-cli.sh --with-stack
+   ```
+   **Expected**: the second `--with-stack` run reports both the extension and the skill
+   as already installed, and reinstalls neither.
+2. Confirm the three copies of the script are still byte-identical:
+   ```bash
+   diff packages/tbd/docs/install/ensure-gh-cli.sh .claude/scripts/ensure-gh-cli.sh
+   diff packages/tbd/docs/install/ensure-gh-cli.sh .codex/ensure-gh-cli.sh
+   ```
+   **Expected**: no output from either.
+
+## Reporting
+
+Update the status table above, then record for each phase: the command run, actual
+output, and pass or fail.
+File a bead for each failure, linked to epic `tbd-ewsw`, and note anything this playbook
+told you to expect that turned out not to be true.
+
+<!-- This document follows common-doc-guidelines.md.
+See github.com/jlevy/practical-prose and review guidelines before editing.
+-->


### PR DESCRIPTION
Review of how we use `gh` locally and of all `gh` guidance in tbd, plus the fixes that review turned up.

## What the review found

**Local state:** `gh` 2.98.0, authenticated via keyring, with `gh stack` v0.1.0 already installed by hand. tbd knew about none of it, so the local machine had drifted well ahead of what tbd provisions.

**Three defects in the install path:**

1. **The pin (2.92.0) missed four security advisories** fixed in 2.97.0. Two land on paths agents use constantly:
   - `gh auth status` printed part of the auth token in plaintext for `ghs_*`, `github_pat_*`, and `ghu_*` formats ([GHSA-cg6r-mpgc-h9mm](https://github.com/cli/cli/security/advisories/GHSA-cg6r-mpgc-h9mm)). The ensure script and every PR shortcut run this command, and agents capture its output.
   - `gh api` and `gh pr diff` printed externally controlled content without neutralizing terminal escape sequences ([GHSA-3m3g-3wcr-px46](https://github.com/cli/cli/security/advisories/GHSA-3m3g-3wcr-px46)). Our review shortcuts pipe both straight into agent context.
2. **`ensure-gh-cli.sh` never checked the version.** It gated on `command -v gh` alone, so any `gh` was accepted forever and a distro package silently defeated the pin. `setup-github-cli.md` already claimed the script reinstalls on a wrong version; it did not. Code and doc now agree.
3. **No extension or skill provisioning,** so `gh stack` was absent on every fresh machine.

**One guidance bug, the most severe:** all four PR shortcuts hardcoded `--base main`. On a stacked branch that retargets the PR at the trunk, shows the reviewer every lower layer's diff, and breaks the stack on GitHub. An agent following our own shortcut silently undid the user's stack.

## Why 2.97.0 and not 2.98.0

2.98.0 was published 2026-08-20, making it 11 days old, which fails the 14-day cool-off in `SUPPLY-CHAIN-SECURITY.md`. 2.97.0 (2026-07-31, 31 days) carries all four fixes and the mature `gh skill` commands. The script never downgrades, so machines already on 2.98.0 keep it.

## Adopting GitHub's own skill rather than writing ours

`github/gh-stack` ships an official agent skill. Pinned at v0.1.0 it is 892 lines of operational detail we would otherwise have to reverse-engineer: which subcommands open a blocking TUI under a PTY, the exact flags that avoid prompts, exit codes, conflict recovery, `--json` parsing.

So the split is: **the official skill owns the mechanics, tbd owns the policy.** The new `stacked-prs` shortcut covers only when stacking is worth it, layer discipline, how stacks map to beads, and how the other shortcuts change. It does not document `gh stack` commands.

Both the extension and the skill are pinned to `v0.1.0` (published 2026-07-29, 33 days old, clears the cool-off).

## Stacking stays opt-in

Per review feedback, this does not push anyone toward stacked PRs:

- Provisioning is behind an explicit `--with-stack` flag, deliberately **not** in the SessionStart hook, so sessions that never stack pay no network cost. Failures warn and exit 0 rather than blocking a session.
- The guidance says to honor a stack when the user asks for one, offer it once when a change plainly decomposes, and drop it when declined.

## Verification done here

- Version comparison unit-tested across 12 cases: lexicographic traps (2.9.0 < 2.97.0), octal-looking segments (2.08.0), prerelease suffixes, and the no-downgrade case.
- Default script path run end to end on macOS: correctly keeps 2.98.0 and now reports auth honestly. It previously printed `GH_TOKEN not set - some operations may require authentication` on a fully working keyring-authenticated machine.
- Pinned skill fetch verified into a scratch directory (v0.1.0 resolved to `a1b4a3d4`).
- `gh repo view` and `gh stack view --json` verified against the live CLI. This caught a bug in my own first draft: `gh repo view` takes the repo positionally and has no `--repo` flag.
- Full repo gate green: 163 files, 2449 tests.

**Not verified locally:** the user-scope skill install branch, since it changes the machine globally and `gh skill` has no uninstall command. Phase 4 of the QA playbook covers it.

## How to validate this PR

`tests/qa/gh-cli-and-stacked-prs.qa.md` is written for a fresh Linux instance and is the acceptance test. Phases 1 and 6 matter most:

- **Phase 1** starts from a deliberately **old** `gh`, the case the current script silently fails.
- **Phase 6** runs `create-or-update-pr-simple` against a stacked branch and asserts the PR is not retargeted at the trunk.

The playbook asks the validating agent to report what actually happened, including anything contradicting the doc, rather than confirming it.

Beads: `tbd-ewsw` (epic) with children `tbd-hvcr`, `tbd-um28`, `tbd-70a2`, `tbd-njez`, `tbd-d2f6`, `tbd-gc0p`, `tbd-oudg`, `tbd-j4wy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
