### PR TITLE
fix: Patch js-yaml security overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "pnpm": {
     "overrides": {
-      "js-yaml@3": "3.15.1",
-      "js-yaml@4": "4.3.1"
+      "js-yaml@3": "3.15.2",
+      "js-yaml@4": "4.3.2"
     },
     "onlyBuiltDependencies": [
       "esbuild",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  js-yaml@3: 3.15.1
-  js-yaml@4: 4.3.1
+  js-yaml@3: 3.15.2
+  js-yaml@4: 4.3.2
 
 importers:
 
@@ -1250,12 +1250,12 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
-  js-yaml@3.15.1:
-    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
+  js-yaml@3.15.2:
+    resolution: {integrity: sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==}
     hasBin: true
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -2103,7 +2103,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2876,7 +2876,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.15.1
+      js-yaml: 3.15.2
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -2940,12 +2940,12 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
-  js-yaml@3.15.1:
+  js-yaml@3.15.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
A newly published high-severity advisory, GHSA-2883-xcg3-v3hh / CVE-2026-84375, makes the production audit fail for every PR through `gray-matter`'s `js-yaml` dependency. This updates the existing exact overrides from 3.15.1/4.3.1 to the patched 3.15.2/4.3.2 releases and updates only their lockfile entries.

## Supply-chain exception

Both releases were approximately 13.2 days old when reviewed, just inside the repository's 14-day floor. This exception is approved after review and keeps both packages exactly pinned.

- npm registry signatures verify with the same signing key used for the prior versions, and the downloaded SHA-1/SHA-512 values match registry metadata.
- Publisher, maintainers, dependencies, package file lists, binaries, and scripts are unchanged. Neither package has an install lifecycle script.
- The 3.15.2 package matches its Git tag byte-for-byte. All source shipped in 4.3.2 matches its tag; the remaining files are generated distributions whose source maps embed the same tagged source.
- The upstream security PR was merged by a maintainer with a GitHub-verified merge commit. The release/backport commits are unsigned and no Sigstore attestations are published; the package/source correspondence and npm signatures mitigate that residual risk.
- Exploit-shaped merge input accepted by both old versions is rejected by both patched versions. Ordinary YAML merge behavior is unchanged. The intended compatibility change is a hard limit of 100 merge-sequence sources even when the total-merge option is unlimited.

Reviewed-by: Joshua Levy (github.com/jlevy)

## Validation

- `pnpm audit --prod` — no known vulnerabilities
- `npm audit signatures` — registry signatures verified in isolated 3.x and 4.x installs
- focused YAML/frontmatter suite — 111 tests passed
- pre-push quality gate — formatting, lint, typecheck, action pins, build, package-age check, and all 2,480 tests passed
- installed package contents compared with the reviewed registry tarballs

`tbd-jntc` tracks the discovered gap that `check-package-age.mjs` does not yet inspect `pnpm.overrides`.

Refs: tbd-r82u
